### PR TITLE
feat: add winston logger and json logging on prod

### DIFF
--- a/apps/official-journal-api/src/app/journal.controller.spec.ts
+++ b/apps/official-journal-api/src/app/journal.controller.spec.ts
@@ -21,7 +21,7 @@ describe('JournalController', () => {
           provide: LOGGER_PROVIDER,
           useValue: {
             debug: jest.fn(),
-            log: jest.fn(),
+            info: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
           },

--- a/apps/official-journal-api/src/app/journal.controller.ts
+++ b/apps/official-journal-api/src/app/journal.controller.ts
@@ -161,7 +161,7 @@ export class JournalController {
     description: 'Explicit error from service to test logging.',
   })
   error(): void {
-    this.logger.info('Testing to log national id 010101-0101 0101010101')
+    this.logger.info('Testing to log national id 221101-0101 1212990101')
 
     this.logger.debug(
       'about to call the error method (this is a debug message)',

--- a/apps/official-journal-api/src/app/journal.controller.ts
+++ b/apps/official-journal-api/src/app/journal.controller.ts
@@ -1,4 +1,4 @@
-import { CustomLogger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 import {
   Body,
   Controller,
@@ -34,7 +34,7 @@ const LOGGING_CATEGORY = 'JournalController'
 export class JournalController {
   constructor(
     @Inject(IJournalService) private readonly journalService: IJournalService,
-    @Inject(LOGGER_PROVIDER) private readonly logger: CustomLogger,
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
   ) {}
 
   @Get('advert')
@@ -153,6 +153,8 @@ export class JournalController {
     description: 'Explicit error from service to test logging.',
   })
   error(): void {
+    this.logger.info('Testing to log national id 010101-0101 0101010101')
+
     this.logger.debug(
       'about to call the error method (this is a debug message)',
       { category: LOGGING_CATEGORY },

--- a/apps/official-journal-api/src/app/journal.controller.ts
+++ b/apps/official-journal-api/src/app/journal.controller.ts
@@ -56,7 +56,7 @@ export class JournalController {
   async advert(@Query('id') id: string): Promise<JournalAdvert | null> {
     const advert = await this.journalService.getAdvert(id)
     if (!advert) {
-      this.logger.log('advert not found', {
+      this.logger.info('advert not found', {
         category: LOGGING_CATEGORY,
         metadata: { id },
       })

--- a/apps/official-journal-api/src/app/journal.service.mock.ts
+++ b/apps/official-journal-api/src/app/journal.service.mock.ts
@@ -1,5 +1,5 @@
-import { LOGGER_PROVIDER } from '@dmr.is/logging'
-import { Inject, Injectable, LoggerService } from '@nestjs/common'
+import { LOGGER_PROVIDER, Logger } from '@dmr.is/logging'
+import { Inject, Injectable } from '@nestjs/common'
 import { JournalAdvert } from '../dto/adverts/journal-advert.dto'
 import {
   ADVERT_B_1278_2023,
@@ -60,8 +60,8 @@ function generatePaging(
 
 @Injectable()
 export class MockJournalService implements IJournalService {
-  constructor(@Inject(LOGGER_PROVIDER) private readonly logger: LoggerService) {
-    this.logger.log('Using MockJournalService')
+  constructor(@Inject(LOGGER_PROVIDER) private readonly logger: Logger) {
+    this.logger.info('Using MockJournalService')
   }
 
   getAdvert(id: string): Promise<JournalAdvert | null> {

--- a/apps/official-journal-api/src/app/journal.service.mock.ts
+++ b/apps/official-journal-api/src/app/journal.service.mock.ts
@@ -1,9 +1,5 @@
 import { LOGGER_PROVIDER, Logger } from '@dmr.is/logging'
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-} from '@nestjs/common'
+import { BadRequestException, Inject, Injectable } from '@nestjs/common'
 import { JournalAdvert } from '../dto/adverts/journal-advert.dto'
 import {
   ADVERT_B_1278_2023,
@@ -73,7 +69,7 @@ export class MockJournalService implements IJournalService {
   }
 
   getAdvert(id: string): Promise<JournalAdvert | null> {
-    this.logger.log('getAdvert', {
+    this.logger.info('getAdvert', {
       category: LOGGING_CATEGORY,
       metadata: { id },
     })
@@ -85,7 +81,7 @@ export class MockJournalService implements IJournalService {
   getAdverts(
     params?: JournalGetAdvertsQueryParams,
   ): Promise<JournalAdvertsResponse> {
-    this.logger.log('getAdverts', {
+    this.logger.info('getAdverts', {
       category: LOGGING_CATEGORY,
       metadata: { params },
     })
@@ -209,7 +205,7 @@ export class MockJournalService implements IJournalService {
       throw new BadRequestException('Type not found') // We need to return the field and reason
     }
 
-    this.logger.log('submitApplication', {
+    this.logger.info('submitApplication', {
       category: LOGGING_CATEGORY,
       metadata: { body },
     })

--- a/apps/official-journal-api/src/app/journal.service.spec.ts
+++ b/apps/official-journal-api/src/app/journal.service.spec.ts
@@ -17,7 +17,7 @@ describe('JournalService', () => {
         {
           provide: LOGGER_PROVIDER,
           useValue: {
-            log: jest.fn(),
+            info: jest.fn(),
             warn: jest.fn(),
             error: jest.fn(),
           },

--- a/apps/official-journal-api/src/app/journal.service.ts
+++ b/apps/official-journal-api/src/app/journal.service.ts
@@ -1,4 +1,4 @@
-import { CustomLogger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 import { Inject, Injectable } from '@nestjs/common'
 import { JournalAdvert } from '../dto/adverts/journal-advert.dto'
 import { IJournalService } from './journal.service.interface'
@@ -17,8 +17,8 @@ const LOGGING_CATEGORY = 'JournalService'
 
 @Injectable()
 export class JournalService implements IJournalService {
-  constructor(@Inject(LOGGER_PROVIDER) private readonly logger: CustomLogger) {
-    this.logger.log('JournalService')
+  constructor(@Inject(LOGGER_PROVIDER) private readonly logger: Logger) {
+    this.logger.info('JournalService')
   }
 
   getAdverts(

--- a/apps/official-journal-api/src/app/journal.service.ts
+++ b/apps/official-journal-api/src/app/journal.service.ts
@@ -24,28 +24,28 @@ export class JournalService implements IJournalService {
   getAdverts(
     params: JournalGetAdvertsQueryParams | undefined,
   ): Promise<JournalAdvertsResponse> {
-    console.log(params)
+    this.logger.info(params)
     throw new Error('Method not implemented.')
   }
 
   getDepartments(
     params?: JournalGetDepartmentsQueryParams | undefined,
   ): Promise<JournalAdvertDepartmentsResponse> {
-    this.logger.log('getDepartments', { params })
+    this.logger.info('getDepartments', { params })
     throw new Error('Method not implemented.')
   }
 
   getTypes(
     params?: JournalGetTypesQueryParams | undefined,
   ): Promise<JournalAdvertTypesResponse> {
-    this.logger.log('getTypes', { params })
+    this.logger.info('getTypes', { params })
     throw new Error('Method not implemented.')
   }
 
   getCategories(
     params?: JournalGetCategoriesQueryParams | undefined,
   ): Promise<JournalAdvertCategoriesResponse> {
-    this.logger.log('getCategories', { params })
+    this.logger.info('getCategories', { params })
     throw new Error('Method not implemented.')
   }
 
@@ -56,7 +56,7 @@ export class JournalService implements IJournalService {
   submitApplication(
     body: JournalPostApplicationBody,
   ): Promise<JournalPostApplicationResponse> {
-    this.logger.log('submitApplication', { body })
+    this.logger.info('submitApplication', { body })
     throw new Error('Method not implemented.')
   }
 

--- a/apps/official-journal-api/src/main.ts
+++ b/apps/official-journal-api/src/main.ts
@@ -11,12 +11,15 @@ import { JournalModule } from './app/journal.module'
 import { openApi } from './openApi'
 import { logger } from '@dmr.is/logging'
 import { apmInit } from '@dmr.is/apm'
+import { WinstonModule } from 'nest-winston'
 
 async function bootstrap() {
   const globalPrefix = 'api'
   const swaggerPath = 'swagger'
 
-  const app = await NestFactory.create(JournalModule)
+  const app = await NestFactory.create(JournalModule, {
+    logger: WinstonModule.createLogger({ instance: logger })
+  })
 
   // TODO make this behave with nest
   // app.useLogger(logger)

--- a/apps/official-journal-api/src/main.ts
+++ b/apps/official-journal-api/src/main.ts
@@ -3,18 +3,22 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger, ValidationPipe, VersioningType } from '@nestjs/common'
+import { ValidationPipe, VersioningType } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 
 import { SwaggerModule } from '@nestjs/swagger'
 import { JournalModule } from './app/journal.module'
 import { openApi } from './openApi'
+import { logger } from '@dmr.is/logging'
 
 async function bootstrap() {
   const globalPrefix = 'api'
   const swaggerPath = 'swagger'
 
   const app = await NestFactory.create(JournalModule)
+
+  // TODO make this behave with nest
+  // app.useLogger(logger)
 
   app.useGlobalPipes(new ValidationPipe({ transform: true }))
   app.setGlobalPrefix(globalPrefix)
@@ -28,7 +32,7 @@ async function bootstrap() {
 
   const port = process.env.PORT || 3000
   await app.listen(port)
-  Logger.log(
+  logger.info(
     `🚀 Application is running on: http://localhost:${port}/${globalPrefix}`,
   )
 }

--- a/libs/logging/README.md
+++ b/libs/logging/README.md
@@ -1,3 +1,11 @@
-# logging
+# Logging
 
-Basic logger, needs extending to be useful.
+Copied from [island.is logger](https://github.com/island-is/island.is/tree/main/libs/logging).
+
+See usage in e.g. `official-journal-api`.
+
+Run tests with:
+
+```bash
+yarn test logging
+```

--- a/libs/logging/src/index.ts
+++ b/libs/logging/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/logging'
 export * from './lib/nest/logging.module'
+export type { Logger } from './lib/nest/logging.module'

--- a/libs/logging/src/lib/formatters.spec.ts
+++ b/libs/logging/src/lib/formatters.spec.ts
@@ -1,0 +1,25 @@
+import { MESSAGE } from 'triple-beam'
+import { TransformableInfo } from 'logform'
+
+import { maskNationalIdFormatter } from './formatters'
+
+describe('maskNationalIdFormatter', () => {
+  const messageSymbol = MESSAGE as unknown as string
+
+  it('should mask national ids', () => {
+    // Arrange
+    const transformer = maskNationalIdFormatter()
+
+    // Act
+    const result = transformer.transform({
+      level: 'INFO',
+      message: 'Ignored',
+      [messageSymbol]: 'Test 0101307789, 010130-7789',
+    })
+
+    // Assert
+    expect((result as TransformableInfo)[messageSymbol]).toMatchInlineSnapshot(
+      `"Test **REMOVE_PII: 0101307789**, **REMOVE_PII: 010130-7789**"`,
+    )
+  })
+})

--- a/libs/logging/src/lib/formatters.ts
+++ b/libs/logging/src/lib/formatters.ts
@@ -1,0 +1,11 @@
+import { MESSAGE } from 'triple-beam'
+import { format } from 'winston'
+
+import { maskNationalId } from './maskNationalId'
+
+const messageSymbol = MESSAGE as unknown as string
+
+export const maskNationalIdFormatter = format((info) => {
+  info[messageSymbol] = maskNationalId(info[messageSymbol])
+  return info
+})

--- a/libs/logging/src/lib/logging.spec.ts
+++ b/libs/logging/src/lib/logging.spec.ts
@@ -1,12 +1,37 @@
 describe('logging', () => {
-  const ENV = process.env
+  describe('log level', () => {
+    const ENV = process.env
 
-  afterEach(() => {
-    jest.resetModules()
-    process.env = { ...ENV }
-  })
+    afterEach(() => {
+      jest.resetModules()
+      process.env = { ...ENV }
+    })
 
-  it('should have tests', async () => {
-    expect(true).toBeTruthy()
+    it('should use level debug as default', async () => {
+      const logLevel = 'debug'
+
+      const { logger } = await import('./logging')
+
+      expect(logger.level).toEqual(logLevel)
+    })
+
+    it('should use LOG_LEVEL env variable if is defined and in production', async () => {
+      const logLevel = 'warn'
+      process.env.NODE_ENV = 'production'
+      process.env.LOG_LEVEL = logLevel
+
+      const { logger } = await import('./logging')
+
+      expect(logger.level).toEqual(logLevel)
+    })
+
+    it('should use info level if in production and LOG_LEVEL is undefined', async () => {
+      const logLevel = 'info'
+      process.env.NODE_ENV = 'production'
+
+      const { logger } = await import('./logging')
+
+      expect(logger.level).toEqual(logLevel)
+    })
   })
 })

--- a/libs/logging/src/lib/logging.ts
+++ b/libs/logging/src/lib/logging.ts
@@ -1,9 +1,4 @@
-import winston, {
-  createLogger,
-  format,
-  LoggerOptions,
-  transports,
-} from 'winston'
+import { createLogger, format, LoggerOptions, transports } from 'winston'
 import { utilities } from 'nest-winston'
 
 import { maskNationalIdFormatter } from './formatters'

--- a/libs/logging/src/lib/logging.ts
+++ b/libs/logging/src/lib/logging.ts
@@ -1,5 +1,41 @@
-import { ConsoleLogger } from '@nestjs/common'
+import winston, {
+  createLogger,
+  format,
+  LoggerOptions,
+  transports,
+} from 'winston'
+import { utilities } from 'nest-winston'
 
-export class CustomLogger extends ConsoleLogger {}
+import { maskNationalIdFormatter } from './formatters'
 
-export const logger = new CustomLogger()
+// Default log settings for debug mode
+let logLevel = 'debug'
+let logFormat = format.combine(
+  format.errors({ stack: true }),
+  format.timestamp(),
+  utilities.format.nestLike('App'),
+  maskNationalIdFormatter(),
+)
+
+// Production overrides
+if (process.env.NODE_ENV === 'production') {
+  logLevel = process.env.LOG_LEVEL || 'info'
+  logFormat = format.combine(
+    format.errors({ stack: true }),
+    format.timestamp(),
+    format.json(),
+    maskNationalIdFormatter(),
+  )
+}
+
+const logTransports = [new transports.Console()]
+
+export const logger = createLogger({
+  level: logLevel,
+  format: logFormat,
+  transports: logTransports,
+  handleExceptions: true,
+  exitOnError: true,
+  exceptionHandlers: logTransports,
+  rejectionHandlers: logTransports,
+} as LoggerOptions)

--- a/libs/logging/src/lib/maskNationalId.spec.ts
+++ b/libs/logging/src/lib/maskNationalId.spec.ts
@@ -1,0 +1,46 @@
+import { maskNationalId } from './maskNationalId'
+
+describe('maskNationalId', () => {
+  const ENV = process.env
+
+  afterEach(() => {
+    jest.resetModules()
+    process.env = { ...ENV }
+  })
+  it('should mask national ids from text', () => {
+    // Arrange
+    const text = 'Test 0101307789, 010130-7789'
+
+    // Act
+    const result = maskNationalId(text)
+
+    // Assert
+    expect(result).toBe(
+      'Test **REMOVE_PII: 0101307789**, **REMOVE_PII: 010130-7789**',
+    )
+  })
+
+  it('should mask not mask 10 digit number from text', () => {
+    // Arrange
+    const text = 'Test 1234561234, 123456-1234'
+
+    // Act
+    const result = maskNationalId(text)
+
+    // Assert
+    expect(result).toBe(text)
+  })
+
+  it('should not display nationalId in production', async () => {
+    // Arrange
+    process.env.NODE_ENV = 'production'
+    const text = 'https://island.is/api/0101307789/010130-7789/info'
+
+    // Act
+    const { maskNationalId } = await import('./maskNationalId')
+    const result = maskNationalId(text)
+
+    // Assert
+    expect(result).toBe('https://island.is/api/--MASKED--/--MASKED--/info')
+  })
+})

--- a/libs/logging/src/lib/maskNationalId.ts
+++ b/libs/logging/src/lib/maskNationalId.ts
@@ -1,7 +1,7 @@
 // borrowed from here https://github.com/HermannBjorgvin/Kennitala/blob/1.2.6/kennitala.js#L150
 function isPerson(kt: string) {
   const d = Number.parseInt(kt.substring(0, 2), 10)
-  const m = Number.parseInt(kt.substring(2, 2), 10)
+  const m = Number.parseInt(kt.substring(2, 4), 10)
 
   return d > 0 && d <= 31 && m > 0 && m <= 12
 }

--- a/libs/logging/src/lib/maskNationalId.ts
+++ b/libs/logging/src/lib/maskNationalId.ts
@@ -1,0 +1,20 @@
+// borrowed from here https://github.com/HermannBjorgvin/Kennitala/blob/1.2.6/kennitala.js#L150
+function isPerson(kt: string) {
+  const d = Number.parseInt(kt.substring(0, 2), 10)
+  const m = Number.parseInt(kt.substring(2, 2), 10)
+
+  return d > 0 && d <= 31 && m > 0 && m <= 12
+}
+const nationalIdRegexp = /\b\d{6}-?\d{4}\b/g
+const isProd = process.env.NODE_ENV === 'production'
+const replaceString = isProd ? '--MASKED--' : '**REMOVE_PII: $&**'
+
+export const maskNationalId = (text: string) => {
+  const matches = text.match(nationalIdRegexp) || []
+  matches.forEach((match) => {
+    if (isPerson(match)) {
+      text = text.replace(match, replaceString)
+    }
+  })
+  return text
+}

--- a/libs/logging/src/lib/nest/logging.module.ts
+++ b/libs/logging/src/lib/nest/logging.module.ts
@@ -1,11 +1,18 @@
-import { Module } from '@nestjs/common'
+import { Global, LoggerService, Module } from '@nestjs/common'
+export type { Logger } from 'winston'
+import { WinstonLogger } from 'nest-winston'
 
 import { logger } from '../logging'
 
 export const LOGGER_PROVIDER = 'Logger'
 
+@Global()
 @Module({
   providers: [{ provide: LOGGER_PROVIDER, useValue: logger }],
   exports: [{ provide: LOGGER_PROVIDER, useValue: logger }],
 })
-export class LoggingModule {}
+export class LoggingModule {
+  static createLogger(): LoggerService {
+    return new WinstonLogger(logger)
+  }
+}

--- a/libs/logging/tsconfig.json
+++ b/libs/logging/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../tsconfig.json",
   "include": [],
   "files": [],
-  "references": []
+  "references": [],
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "class-validator": "^0.14.1",
     "kennitala": "^2.0.0-beta.3",
     "license-checker": "^25.0.1",
+    "nest-winston": "^1.9.4",
     "next": "14.0.4",
     "pg": "^8.11.3",
     "react": "18.2.0",
@@ -77,6 +78,7 @@
     "sequelize": "^6.35.2",
     "sequelize-replace-enum-postgres": "^1.6.0",
     "sequelize-typescript": "^2.1.6",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "winston": "^3.11.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,12 +1633,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
   languageName: node
   linkType: hard
 
@@ -3939,6 +3957,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
 "@types/validator@npm:^13.11.8":
   version: 13.11.8
   resolution: "@types/validator@npm:13.11.8"
@@ -5586,7 +5611,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -5611,10 +5636,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: "npm:^1.0.0"
+    simple-swizzle: "npm:^0.2.2"
+  checksum: b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
   languageName: node
   linkType: hard
 
@@ -5629,6 +5674,16 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
   languageName: node
   linkType: hard
 
@@ -6489,6 +6544,7 @@ __metadata:
     jest-environment-node: "npm:^29.4.1"
     kennitala: "npm:^2.0.0-beta.3"
     license-checker: "npm:^25.0.1"
+    nest-winston: "npm:^1.9.4"
     next: "npm:14.0.4"
     nx: "npm:v17.2.5"
     pg: "npm:^8.11.3"
@@ -6508,6 +6564,7 @@ __metadata:
     tslib: "npm:^2.3.0"
     typescript: "npm:^5.3.3"
     url-loader: "npm:^4.1.1"
+    winston: "npm:^3.11.0"
   languageName: unknown
   linkType: soft
 
@@ -6708,6 +6765,13 @@ __metadata:
   version: 3.0.0
   resolution: "emojis-list@npm:3.0.0"
   checksum: 7dc4394b7b910444910ad64b812392159a21e1a7ecc637c775a440227dcb4f80eff7fe61f4453a7d7603fa23d23d30cc93fe9e4b5ed985b88d6441cd4a35117b
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -7589,7 +7653,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-safe-stringify@npm:2.1.1":
+"fast-safe-stringify@npm:2.1.1, fast-safe-stringify@npm:^2.1.1":
   version: 2.1.1
   resolution: "fast-safe-stringify@npm:2.1.1"
   checksum: d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
@@ -7620,6 +7684,13 @@ __metadata:
   dependencies:
     bser: "npm:2.1.1"
   checksum: feae89ac148adb8f6ae8ccd87632e62b13563e6fb114cacb5265c51f585b17e2e268084519fb2edd133872f1d47a18e6bfd7e5e08625c0d41b93149694187581
+  languageName: node
+  linkType: hard
+
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
   languageName: node
   linkType: hard
 
@@ -7750,6 +7821,13 @@ __metadata:
   version: 3.2.9
   resolution: "flatted@npm:3.2.9"
   checksum: 5c91c5a0a21bbc0b07b272231e5b4efe6b822bcb4ad317caf6bb06984be4042a9e9045026307da0fdb4583f1f545e317a67ef1231a59e71f7fced3cc429cfc53
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -8701,6 +8779,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "is-arrayish@npm:0.3.2"
+  checksum: f59b43dc1d129edb6f0e282595e56477f98c40278a2acdc8b0a5c57097c9eff8fe55470493df5775478cf32a4dc8eaf6d3a749f07ceee5bc263a78b2434f6a54
   languageName: node
   linkType: hard
 
@@ -9877,6 +9962,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
 "language-subtag-registry@npm:^0.3.20, language-subtag-registry@npm:~0.3.2":
   version: 0.3.22
   resolution: "language-subtag-registry@npm:0.3.22"
@@ -10125,6 +10217,20 @@ __metadata:
     chalk: "npm:^4.1.0"
     is-unicode-supported: "npm:^0.1.0"
   checksum: 67f445a9ffa76db1989d0fa98586e5bc2fd5247260dafb8ad93d9f0ccd5896d53fb830b0e54dade5ad838b9de2006c826831a3c528913093af20dff8bd24aca6
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.3.2, logform@npm:^2.4.0":
+  version: 2.6.0
+  resolution: "logform@npm:2.6.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 6e02f8617a03155b2fce451bacf777a2c01da16d32c4c745b3ec85be6c3f2602f2a4953a8bd096441cb4c42c447b52318541d6b6bc335dce903cb9ad77a1749f
   languageName: node
   linkType: hard
 
@@ -10668,6 +10774,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nest-winston@npm:^1.9.4":
+  version: 1.9.4
+  resolution: "nest-winston@npm:1.9.4"
+  dependencies:
+    fast-safe-stringify: "npm:^2.1.1"
+  peerDependencies:
+    "@nestjs/common": ^5.0.0 || ^6.6.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+    winston: ^3.0.0
+  checksum: 95930ce71481152b7d2980c57b0124fb8ea5a43cdb24f2f7f51ea84f7fa9a6f44fe0f2229f92371d353c66213590080180204542fe90130b1f0d01ae11a96583
+  languageName: node
+  linkType: hard
+
 "next-tick@npm:1, next-tick@npm:^1.1.0":
   version: 1.1.0
   resolution: "next-tick@npm:1.1.0"
@@ -11114,6 +11232,15 @@ __metadata:
   dependencies:
     wrappy: "npm:1"
   checksum: 5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
   languageName: node
   linkType: hard
 
@@ -12395,7 +12522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+"readable-stream@npm:^3.0.6, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -12748,6 +12875,13 @@ __metadata:
     get-intrinsic: "npm:^1.1.3"
     is-regex: "npm:^1.1.4"
   checksum: 14a81a7e683f97b2d6e9c8be61fddcf8ed7a02f4e64a825515f96bb1738eb007145359313741d2704d28b55b703a0f6300c749dde7c1dbc13952a2b85048ede2
+  languageName: node
+  linkType: hard
+
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.4.3
+  resolution: "safe-stable-stringify@npm:2.4.3"
+  checksum: 81dede06b8f2ae794efd868b1e281e3c9000e57b39801c6c162267eb9efda17bd7a9eafa7379e1f1cacd528d4ced7c80d7460ad26f62ada7c9e01dec61b2e768
   languageName: node
   linkType: hard
 
@@ -13168,6 +13302,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.2
+  resolution: "simple-swizzle@npm:0.2.2"
+  dependencies:
+    is-arrayish: "npm:^0.3.1"
+  checksum: df5e4662a8c750bdba69af4e8263c5d96fe4cd0f9fe4bdfa3cbdeb45d2e869dff640beaaeb1ef0e99db4d8d2ec92f85508c269f50c972174851bc1ae5bd64308
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -13419,6 +13562,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: b091f2ae92474183c7ac5ed3f9811457e1df23df7a7e70c9476eaa9a0c4a0c8fc190fb45acefbf023ca9ee864dd6754237a697dc52a0fb182afe65d8e77443d8
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
   languageName: node
   linkType: hard
 
@@ -13845,6 +13995,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
 "text-table@npm:^0.2.0":
   version: 0.2.0
   resolution: "text-table@npm:0.2.0"
@@ -13954,6 +14111,13 @@ __metadata:
   version: 1.1.0
   resolution: "treeify@npm:1.1.0"
   checksum: 2f0dea9e89328b8a42296a3963d341ab19897a05b723d6b0bced6b28701a340d2a7b03241aef807844198e46009aaf3755139274eb082cfce6fdc1935cbd69dd
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
   languageName: node
   linkType: hard
 
@@ -14897,6 +15061,36 @@ __metadata:
   version: 2.0.1
   resolution: "wildcard@npm:2.0.1"
   checksum: 08f70cd97dd9a20aea280847a1fe8148e17cae7d231640e41eb26d2388697cbe65b67fd9e68715251c39b080c5ae4f76d71a9a69fa101d897273efdfb1b58bf7
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.5.0":
+  version: 4.7.0
+  resolution: "winston-transport@npm:4.7.0"
+  dependencies:
+    logform: "npm:^2.3.2"
+    readable-stream: "npm:^3.6.0"
+    triple-beam: "npm:^1.3.0"
+  checksum: cd16f3d0ab56697f93c4899e0eb5f89690f291bb6cf309194819789326a7c7ed943ef00f0b2fab513b114d371314368bde1a7ae6252ad1516181a79f90199cd2
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.11.0":
+  version: 3.11.0
+  resolution: "winston@npm:3.11.0"
+  dependencies:
+    "@colors/colors": "npm:^1.6.0"
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.2.3"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.4.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.5.0"
+  checksum: 7e1f8919cbdc62cfe46e6204d79a83e1364696ef61111483f3ecf204988922383fe74192c5bc9f89df9b47caf24c2d34f5420ef6f3b693f8d1286b46432e97be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This only plugs winston into the app, not into nest itself

<details><summary>Example dev output from start and call to /error</summary>

```
❯ yarn start official-journal-api

> nx run official-journal-api:serve:development

chunk (runtime: main) main.js (main) 78.4 KiB [entry] [rendered]
webpack compiled successfully (7d6380f82382548c)
Debugger listening on ws://localhost:9229/f5bb5905-6fba-4147-9c0b-a94210a347b4
Debugger listening on ws://localhost:9229/f5bb5905-6fba-4147-9c0b-a94210a347b4
For help, see: https://nodejs.org/en/docs/inspector

[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [NestFactory] Starting Nest application...
[App] Info      2/12/2024, 10:48:38 AM Using MockJournalService
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [InstanceLoader] LoggingModule dependencies initialized +6ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [InstanceLoader] JournalModule dependencies initialized +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RoutesResolver] JournalController {/api} (version: 1): +36ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/advert, GET} (version: 1) route +1ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/adverts, GET} (version: 1) route +1ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/departments, GET} (version: 1) route +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/types, GET} (version: 1) route +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/categories, GET} (version: 1) route +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/application, POST} (version: 1) route +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/error, GET} (version: 1) route +0ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [RouterExplorer] Mapped {/api/health, GET} (version: 1) route +1ms
[Nest] 12683  - 02/12/2024, 10:48:38 AM     LOG [NestApplication] Nest application successfully started +0ms
[App] Info      2/12/2024, 10:48:38 AM 🚀 Application is running on: http://localhost:3000/api
[App] Info      2/12/2024, 10:49:26 AM Testing to log national id 010101-0101 0101010101
[App] Debug     2/12/2024, 10:49:26 AM about to call the error method (this is a debug message) - {"category":"JournalController"}
[App] Warn      2/12/2024, 10:49:26 AM about to call the error method (this is a warn message) - {"category":"JournalController"}
[App] Warn      2/12/2024, 10:49:26 AM about to throw error from service - {"category":"MockJournalService"}
[App] Error     2/12/2024, 10:49:26 AM caught error from service, spreading error message - {"error":{},"category":"JournalController"}
[App] Warn      2/12/2024, 10:49:26 AM calling error method without try/catch - {"category":"JournalController"}
[App] Warn      2/12/2024, 10:49:26 AM about to throw error from service - {"category":"MockJournalService"}
[Nest] 12683  - 02/12/2024, 10:49:26 AM   ERROR [ExceptionsHandler] error from service

Error: error from service
    at MockJournalService.error (/Users/oli/Code/dmr/dmr.is/apps/official-journal-api/dist/main.js:1687:15)
    at JournalController.error (/Users/oli/Code/dmr/dmr.is/apps/official-journal-api/dist/main.js:265:29)
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-execution-context.js:38:29
    at InterceptorsConsumer.intercept (/Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/interceptors/interceptors-consumer.js:12:20)
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-execution-context.js:46:60
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-proxy.js:9:23
    at /Users/oli/Code/dmr/dmr.is/node_modules/dd-trace/packages/datadog-instrumentations/src/router.js:50:25
    at /Users/oli/Code/dmr/dmr.is/node_modules/dd-trace/packages/datadog-shimmer/src/shimmer.js:26:21
    at Layer.handle [as handle_request] (/Users/oli/Code/dmr/dmr.is/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/oli/Code/dmr/dmr.is/node_modules/express/lib/router/route.js:144:13)
```

</details> 

this is _fine_ in dev but shows the problem (`[App]` vs `[Nest]` lines).

In prod this is an issue with uncaught errors:

<details><summary>Example prod output from start and call to /error</summary>

```
❯ NODE_ENV=production yarn start official-journal-api

> nx run official-journal-api:serve:development

chunk (runtime: main) main.js (main) 78.4 KiB [entry] [rendered]
webpack compiled successfully (7d6380f82382548c)
Debugger listening on ws://localhost:9229/156be2ce-462b-4633-a71f-bf1b732ccf6a
Debugger listening on ws://localhost:9229/156be2ce-462b-4633-a71f-bf1b732ccf6a
For help, see: https://nodejs.org/en/docs/inspector

[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [NestFactory] Starting Nest application...
{"level":"info","message":"Using MockJournalService","timestamp":"2024-02-12T10:53:01.741Z"}
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [InstanceLoader] LoggingModule dependencies initialized +6ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [InstanceLoader] JournalModule dependencies initialized +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RoutesResolver] JournalController {/api} (version: 1): +35ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/advert, GET} (version: 1) route +1ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/adverts, GET} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/departments, GET} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/types, GET} (version: 1) route +1ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/categories, GET} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/application, POST} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/error, GET} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [RouterExplorer] Mapped {/api/health, GET} (version: 1) route +0ms
[Nest] 12847  - 02/12/2024, 10:53:01 AM     LOG [NestApplication] Nest application successfully started +1ms
{"level":"info","message":"🚀 Application is running on: http://localhost:3000/api","timestamp":"2024-02-12T10:53:01.782Z"}
{"level":"info","message":"Testing to log national id 010101-0101 0101010101","timestamp":"2024-02-12T10:53:08.662Z"}
{"category":"JournalController","level":"warn","message":"about to call the error method (this is a warn message)","timestamp":"2024-02-12T10:53:08.663Z"}
{"category":"MockJournalService","level":"warn","message":"about to throw error from service","timestamp":"2024-02-12T10:53:08.663Z"}
{"category":"JournalController","error":{},"level":"error","message":"caught error from service, spreading error message","timestamp":"2024-02-12T10:53:08.663Z"}
{"category":"JournalController","level":"warn","message":"calling error method without try/catch","timestamp":"2024-02-12T10:53:08.663Z"}
{"category":"MockJournalService","level":"warn","message":"about to throw error from service","timestamp":"2024-02-12T10:53:08.663Z"}
[Nest] 12847  - 02/12/2024, 10:53:08 AM   ERROR [ExceptionsHandler] error from service

Error: error from service
    at MockJournalService.error (/Users/oli/Code/dmr/dmr.is/apps/official-journal-api/dist/main.js:1687:15)
    at JournalController.error (/Users/oli/Code/dmr/dmr.is/apps/official-journal-api/dist/main.js:265:29)
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-execution-context.js:38:29
    at InterceptorsConsumer.intercept (/Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/interceptors/interceptors-consumer.js:12:20)
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-execution-context.js:46:60
    at /Users/oli/Code/dmr/dmr.is/node_modules/@nestjs/core/router/router-proxy.js:9:23
    at /Users/oli/Code/dmr/dmr.is/node_modules/dd-trace/packages/datadog-instrumentations/src/router.js:50:25
    at /Users/oli/Code/dmr/dmr.is/node_modules/dd-trace/packages/datadog-shimmer/src/shimmer.js:26:21
    at Layer.handle [as handle_request] (/Users/oli/Code/dmr/dmr.is/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/oli/Code/dmr/dmr.is/node_modules/express/lib/router/route.js:144:13)
```

</details> 

but there the uncaught exception goes to the nest handler which does not use json.

This probably needs some [`monkeyPatch`-ing like in DI repo](https://github.com/island-is/island.is/blob/5d6017e94d58f55998b37ebf605fad49454dbb69/libs/logging/src/lib/monkeyPatch.ts#L32) but I couldn't get it to work (in a limited time). Probably fine to merge this and then tackle.
