### PR TITLE
fix: show affected files from submodule checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # dmr.is
 
 Monorepo DMR
-# Dependencies
+
+## Dependencies
 
 TODO
+
 ## Git submodules
 
 Submodules are configured with [.envrc.git](./.envrc.git) by adding [post-checkout](https://git-scm.com/docs/githooks#_post_checkout) and [post-merge](https://git-scm.com/docs/githooks#_post_merge) hooks to the repository. This means that after cloning the repository, the submodules are automatically initialized and updated.
@@ -15,6 +17,23 @@ The `.envrc` script will create/override the following files:
 .git/hooks/post-merge
 ```
 
-To pin a submodule to a specific commit or the paths that should be checked out, update the [submodules/config.json](./submodules/config.json) file.
+To pin a submodule to a specific commit or the paths that should be checked out, update the `sha` property in the [submodules/config.json](./submodules/config.json) file.
 
+To play around with the automation script you can modify the the config file and run the script manually:
 
+```bash
+
+{
+  "submodules": [
+    {
+      "name": "island.is",
+      "sha": "HEAD~5", # some commit sha
+      "sparseCheckoutPaths": [
+        "libs/shared"
+      ]
+    }
+  ]
+}
+
+./.gitscripts/checkout-submodules.sh
+```


### PR DESCRIPTION
Affected files are now included when submodules are checked out.

```
🚀 Commits in island.is from 4001e6b to origin/main affecting paths:

    04ff3fa9db - feat(delegation-api): webhooks for delegation index (#14113) <Herdis Maria> (21 hours ago)
    libs/shared/types/src/lib/delegation.ts

    df467305c2 - fix(ojoi-application): Fixing bugs from testing (#14054) <Jón Bjarni Ólafsson> (2 days ago)
    libs/shared/form-fields/src/lib/CheckboxController/CheckboxController.tsx
    libs/shared/form-fields/src/lib/DatePickerController/DatePickerController.tsx
```   