### PR TITLE
feat(api): Test swagger doc and codegen

### DIFF
--- a/apps/official-journal-api/src/app/app.spec.ts
+++ b/apps/official-journal-api/src/app/app.spec.ts
@@ -1,0 +1,60 @@
+import { Test } from '@nestjs/testing'
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger'
+import * as fs from 'fs'
+import { NestApplication } from '@nestjs/core'
+import { exec } from 'child_process'
+import { AppModule } from './app.module'
+
+const TMP_DIR = 'tmp/swagger'
+
+const genereteFromSchema = () => {
+  return new Promise((resolve, reject) => {
+    exec(
+      `yarn openapi-generator -o ${TMP_DIR}/gen/fetch -i ${TMP_DIR}/swagger.json`,
+      (err, stdout) => {
+        if (err) {
+          reject(err)
+        }
+        resolve(stdout)
+      },
+    )
+  })
+}
+
+describe('Swagger documentation', () => {
+  let app: NestApplication
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile()
+
+    app = module.createNestApplication()
+  })
+
+  afterAll(async () => {
+    await app.close()
+
+    // Clean up
+    fs.rmSync(TMP_DIR, { recursive: true, force: true })
+  })
+
+  it('should generate swagger spec', async () => {
+    const config = new DocumentBuilder()
+      .setTitle('Official Journal API')
+      .setVersion('1.0')
+      .build()
+
+    const document = SwaggerModule.createDocument(app, config)
+
+    if (!fs.existsSync(TMP_DIR)) {
+      fs.mkdirSync(TMP_DIR, { recursive: true })
+    }
+    fs.writeFileSync(`${TMP_DIR}/swagger.json`, JSON.stringify(document))
+
+    // run the openapi generator
+    await genereteFromSchema()
+
+    expect(fs.existsSync(`${TMP_DIR}/swagger.json`)).toBeTruthy()
+  })
+})

--- a/apps/official-journal-api/src/app/case/case.controller.spec.ts
+++ b/apps/official-journal-api/src/app/case/case.controller.spec.ts
@@ -51,12 +51,12 @@ describe('CaseController', () => {
     })
 
     it('should return case with caseNumber 01905', async () => {
-      const result = await caseController.cases(undefined, undefined, '01905')
+      const result = await caseController.cases({ caseNumber: '01905' })
       expect(result.cases.length).toEqual(1)
     })
 
     it('should return no results', async () => {
-      const result = await caseController.cases(undefined, undefined, '00000')
+      const result = await caseController.cases({ caseNumber: 'not-found' })
       expect(result.cases.length).toEqual(0)
     })
   })

--- a/apps/official-journal-api/src/app/case/case.controller.ts
+++ b/apps/official-journal-api/src/app/case/case.controller.ts
@@ -33,30 +33,7 @@ export class CaseController {
     type: CasesReponse,
     description: 'All cases.',
   })
-  @ApiQuery({
-    name: 'params',
-    type: CasesQuery,
-    required: false,
-  })
-  async cases(
-    @Query('search') search?: string,
-    @Query('page') page?: number,
-    @Query('caseNumber') caseNumber?: string,
-    @Query('status') status?: string,
-    @Query('employeeId') employeeId?: string,
-    @Query('dateFrom') dateFrom?: string,
-    @Query('dateTo') dateTo?: string,
-    @Query('fastTrack') fastTrack?: boolean,
-  ): Promise<CasesReponse> {
-    return this.caseService.getCases({
-      search,
-      page: page ? page : undefined, // prevent NaN
-      caseNumber,
-      status,
-      employeeId,
-      dateFrom,
-      dateTo,
-      fastTrack,
-    })
+  async cases(@Query() params?: CasesQuery): Promise<CasesReponse> {
+    return this.caseService.getCases(params)
   }
 }

--- a/apps/official-journal-api/src/app/case/case.service.mock.ts
+++ b/apps/official-journal-api/src/app/case/case.service.mock.ts
@@ -1,12 +1,20 @@
-import { InternalServerErrorException, NotFoundException } from '@nestjs/common'
+import {
+  Inject,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common'
 import { Case } from '../../dto/case/case.dto'
 import { ALL_MOCK_CASES } from '../../mock/case.mock'
 import { ICaseService } from './case.service.interface'
 import { CasesReponse } from '../../dto/case/cases-response'
 import { CasesQuery } from '../../dto/case/cases-query.dto'
 import { generatePaging } from '../../utils'
+import { LOGGER_PROVIDER, Logger } from '@dmr.is/logging'
 
 export class CaseServiceMock implements ICaseService {
+  constructor(@Inject(LOGGER_PROVIDER) private readonly logger: Logger) {
+    this.logger.info('Using CaseServiceMock')
+  }
   getCase(id: string): Promise<Case | null> {
     const found = ALL_MOCK_CASES.find((c) => c.id === id)
 


### PR DESCRIPTION
Created a test that creates swagger schema from the app module and runs code generator on said schema.
Could be useful to skip this tests on github.