### PR TITLE
fix(s3): Removed default values for credientials in s3 client initalization

### DIFF
--- a/libs/shared/modules/src/s3/s3.service.ts
+++ b/libs/shared/modules/src/s3/s3.service.ts
@@ -41,11 +41,6 @@ import { IS3Service } from './s3.service.interface'
 export class S3Service implements IS3Service {
   private readonly client = new S3Client({
     region: process.env.AWS_REGION ?? 'eu-west-1',
-    credentials: {
-      accessKeyId: process.env.AWS_ACCESS_KEY_ID ?? '',
-      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
-      sessionToken: process.env.AWS_SESSION_TOKEN ?? '',
-    },
   })
   constructor(
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,


### PR DESCRIPTION
Minor bugfix where empty string is passed instead of nothing to init process of s3 client.