### PR TITLE
fix(api): Change validation on post application attachment 

### DIFF
--- a/libs/shared/dto/src/lib/attachments/post-application-attachment.body.ts
+++ b/libs/shared/dto/src/lib/attachments/post-application-attachment.body.ts
@@ -35,7 +35,7 @@ export class PostApplicationAttachmentBody {
     type: String,
     required: true,
   })
-  @IsUrl()
+  @IsString()
   fileLocation!: string
 
   @ApiProperty({


### PR DESCRIPTION
- Changed to string validation since we do only store the pathname not the whole url