### PR TITLE
fix(s3): Updated deleteAttachment to take query stirng instead of body

### DIFF
--- a/apps/official-journal-application-api/src/app/application/application.controller.ts
+++ b/apps/official-journal-application-api/src/app/application/application.controller.ts
@@ -16,14 +16,17 @@ import { ResultWrapper } from '@dmr.is/types'
 import { FilesInterceptor } from '@nestjs/platform-express'
 import 'multer'
 import {
+  BadRequestException,
   Body,
   Controller,
   HttpCode,
+  HttpException,
   Inject,
   MaxFileSizeValidator,
   Param,
   ParseFilePipe,
   Post,
+  Query,
   UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common'
@@ -31,6 +34,7 @@ import {
   UUIDValidationPipe,
   FileTypeValidationPipe,
   EnumValidationPipe,
+  IsStringValidationPipe,
 } from '@dmr.is/pipelines'
 import {
   ALLOWED_MIME_TYPES,
@@ -45,6 +49,7 @@ import {
   ApiResponse,
 } from '@nestjs/swagger'
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { isString } from 'class-validator'
 
 @Controller({
   path: 'applications',
@@ -329,16 +334,16 @@ export class ApplicationController {
     method: 'delete',
     operationId: 'deleteApplicationAttachment',
     params: [{ name: 'id', type: String, required: true }],
-    bodyType: DeleteApplicationAttachmentBody,
+    query: [{ name: 'key', type: String, required: true }],
   })
   async deleteApplicationAttachment(
     @Param('id', UUIDValidationPipe) applicationId: string,
-    @Body() body: DeleteApplicationAttachmentBody,
+    @Query('key', IsStringValidationPipe) key: string,
   ) {
     ResultWrapper.unwrap(
       await this.applicationService.deleteApplicationAttachment(
         applicationId,
-        body.key,
+        key,
       ),
     )
   }

--- a/libs/shared/pipelines/src/lib/index.ts
+++ b/libs/shared/pipelines/src/lib/index.ts
@@ -1,3 +1,4 @@
 export * from './uuid.pipe'
 export * from './file-type.pipe'
 export * from './enum-type.pipe'
+export * from './is-string.pipe'

--- a/libs/shared/pipelines/src/lib/is-string.pipe.ts
+++ b/libs/shared/pipelines/src/lib/is-string.pipe.ts
@@ -1,0 +1,12 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+import { isString } from 'class-validator'
+
+@Injectable()
+export class IsStringValidationPipe implements PipeTransform {
+  async transform(value: any) {
+    if (!isString(value)) {
+      throw new BadRequestException(`Missing or invalid parameter value`)
+    }
+    return value
+  }
+}


### PR DESCRIPTION
- new isString query validation pipe
- changed delete attachment to accept query string instead of body