### PR TITLE
feat(api): Pdf served as base64 instead of stream

### DIFF
--- a/libs/shared/dto/src/lib/pdf/get-pdf-response.dto.ts
+++ b/libs/shared/dto/src/lib/pdf/get-pdf-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class GetPdfRespone {
+  @ApiProperty({
+    type: String,
+    description: 'Base64 encoded PDF',
+  })
+  content!: string
+}

--- a/libs/shared/dto/src/lib/pdf/index.ts
+++ b/libs/shared/dto/src/lib/pdf/index.ts
@@ -1,1 +1,2 @@
 export * from './get-case-pdf-response.dto'
+export * from './get-pdf-response.dto'

--- a/libs/shared/modules/src/application/application.service.ts
+++ b/libs/shared/modules/src/application/application.service.ts
@@ -188,8 +188,6 @@ export class ApplicationService implements IApplicationService {
       },
     )
 
-    console.log(res)
-
     if (!res.ok) {
       this.logger.error(
         `Appliction.service.getApplication, could not get application<${id}>`,

--- a/libs/shared/modules/src/application/application.service.ts
+++ b/libs/shared/modules/src/application/application.service.ts
@@ -188,6 +188,8 @@ export class ApplicationService implements IApplicationService {
       },
     )
 
+    console.log(res)
+
     if (!res.ok) {
       this.logger.error(
         `Appliction.service.getApplication, could not get application<${id}>`,

--- a/libs/shared/modules/src/pdf/pdf.controller.ts
+++ b/libs/shared/modules/src/pdf/pdf.controller.ts
@@ -1,9 +1,10 @@
 import { Route } from '@dmr.is/decorators'
 import { UUIDValidationPipe } from '@dmr.is/pipelines'
-import { GetPdfUrlResponse } from '@dmr.is/shared/dto'
+import { GetPdfRespone, GetPdfUrlResponse } from '@dmr.is/shared/dto'
 import { ResultWrapper } from '@dmr.is/types'
 
-import { Controller, Inject, Param, StreamableFile } from '@nestjs/common'
+import { Controller, Inject, Param, Res, StreamableFile } from '@nestjs/common'
+import {} from '@nestjs/swagger'
 
 import { IUtilityService } from '../utility/utility.service.interface'
 import { IPdfService } from './pdf.service.interface'
@@ -28,17 +29,17 @@ export class PdfController {
         required: true,
       },
     ],
-    responseType: StreamableFile,
+    responseType: GetPdfRespone,
   })
   async getPdfByCaseId(
     @Param('id', new UUIDValidationPipe()) id: string,
-  ): Promise<StreamableFile> {
+  ): Promise<GetPdfRespone> {
     const pdf = (await this.pdfService.getPdfByCaseId(id)).unwrap()
 
-    return new StreamableFile(pdf, {
-      type: 'application/pdf',
-      disposition: 'inline',
-    })
+    const result = pdf.toString('base64')
+    return {
+      content: result,
+    }
   }
 
   @Route({
@@ -51,17 +52,17 @@ export class PdfController {
         required: true,
       },
     ],
-    responseType: StreamableFile,
+    responseType: GetPdfRespone,
   })
   async getPdfByApplicationId(
     @Param('id', new UUIDValidationPipe()) id: string,
-  ): Promise<StreamableFile> {
+  ): Promise<GetPdfRespone> {
     const pdf = (await this.pdfService.getPdfByApplicationId(id)).unwrap()
 
-    return new StreamableFile(pdf, {
-      type: 'application/pdf',
-      disposition: 'inline',
-    })
+    const result = pdf.toString('base64')
+    return {
+      content: result,
+    }
   }
 
   @Route({


### PR DESCRIPTION
For compatibility we are serving pdfs as base64 instead of streams.