### PR TITLE
fix(ojoi): hide date and person

### DIFF
--- a/libs/shared/modules/src/pdf/pdf.css.ts
+++ b/libs/shared/modules/src/pdf/pdf.css.ts
@@ -507,7 +507,7 @@ export const pdfCss = `
 
   /* ======================================================================= */
 
-  .regulation__signature {
+  .regulation__signature, .signature {
     margin-top: 2em;
     page-break-inside: avoid;
     page-break-before: avoid;

--- a/libs/shared/modules/src/pdf/pdf.css.ts
+++ b/libs/shared/modules/src/pdf/pdf.css.ts
@@ -515,7 +515,7 @@ export const pdfCss = `
 
   /* ======================================================================= */
 
-  .signature__date, signature__content, .signature__member {
+  .signature__date, .signature__content, .signature__member {
     display: none;
   }
 

--- a/libs/shared/modules/src/pdf/pdf.css.ts
+++ b/libs/shared/modules/src/pdf/pdf.css.ts
@@ -515,6 +515,12 @@ export const pdfCss = `
 
   /* ======================================================================= */
 
+  .signature__date, signature__content, .signature__member {
+    display: none;
+  }
+
+  /* ======================================================================= */
+
   .disclaimer {
     margin-top: 3em;
     page-break-inside: avoid;


### PR DESCRIPTION
* Hide date and signee from signature in PDF 
* Add css class signature to css. As the wrapper used currently is `class="signature"`.