### PR TITLE
fix(api): Fix application auth guard

### DIFF
--- a/libs/shared/modules/src/application-user/application-user.service.interface.ts
+++ b/libs/shared/modules/src/application-user/application-user.service.interface.ts
@@ -10,7 +10,7 @@ import { ResultWrapper } from '@dmr.is/types'
 
 export interface IApplicationUserService {
   checkIfUserHasInvolvedParty(
-    nationalId: string,
+    id: string,
     institutionId: string,
   ): Promise<ResultWrapper<{ hasInvolvedParty: boolean }>>
 

--- a/libs/shared/modules/src/application-user/application-user.service.ts
+++ b/libs/shared/modules/src/application-user/application-user.service.ts
@@ -312,11 +312,11 @@ export class ApplicationUserService implements IApplicationUserService {
   @LogAndHandle()
   @Transactional()
   async checkIfUserHasInvolvedParty(
-    nationalId: string,
+    id: string,
     institutionId: string,
     transaction?: Transaction,
   ): Promise<ResultWrapper<{ hasInvolvedParty: boolean }>> {
-    const userLookup = await this.getUser(nationalId, transaction)
+    const userLookup = await this.getUser(id, transaction)
 
     if (!userLookup.result.ok) {
       return ResultWrapper.err({

--- a/libs/shared/modules/src/guards/application-auth.guard.ts
+++ b/libs/shared/modules/src/guards/application-auth.guard.ts
@@ -141,7 +141,7 @@ export class ApplicationAuthGaurd implements CanActivate {
 
         const hasInvolvedParty =
           await this.applicationUserService.checkIfUserHasInvolvedParty(
-            currentUser.nationalId,
+            currentUser.id,
             caseLookup.result.value.involvedPartyId,
           )
 


### PR DESCRIPTION
Fixed application auth guard so that it passes the user id instead of national id when doing the involved party lookup.