### PR TITLE
fix(web): Add year to published cases

### DIFF
--- a/apps/official-journal-web/src/components/tables/CaseTableOverview.tsx
+++ b/apps/official-journal-web/src/components/tables/CaseTableOverview.tsx
@@ -76,7 +76,11 @@ export const CaseTableOverview = ({
         ),
       },
       {
-        children: <Text variant="medium">{row.publicationNumber}</Text>,
+        children: (
+          <Text variant="medium">
+            {row.publicationNumber}/{row.year}
+          </Text>
+        ),
       },
       {
         children: (


### PR DESCRIPTION
Year is now visible in the publication number column in published cases table.