### PR TITLE
fix(api): Signature service 

### DIFF
--- a/libs/shared/dto/src/lib/signatures/signature.dto.ts
+++ b/libs/shared/dto/src/lib/signatures/signature.dto.ts
@@ -49,13 +49,6 @@ export class Signature {
 export class CreateSignature {
   @ApiProperty({
     type: String,
-    description: 'ISO datestring of the signature',
-    required: true,
-  })
-  signatureDate!: string
-
-  @ApiProperty({
-    type: String,
     description: 'The involved party of the signature',
     required: true,
   })

--- a/libs/shared/modules/src/case/services/create/case-create.service.ts
+++ b/libs/shared/modules/src/case/services/create/case-create.service.ts
@@ -398,7 +398,6 @@ export class CaseCreateService implements ICaseCreateService {
     ResultWrapper.unwrap(
       await this.signatureService.createSignature(caseId, {
         involvedPartyId: values.caseBody.involvedPartyId,
-        signatureDate: values.signatureDate,
         records:
           application.answers.misc.signatureType === SignatureType.Regular
             ? application.answers.signatures.regular.map((signature) => ({


### PR DESCRIPTION
# API

- Fixed signature service findSignature method to always return the newest signature
- Removed the signatureDate property in create signature class, since we can calculate it upon creation