### PR TITLE
fix(api): Advert type uppercsae

### DIFF
--- a/libs/shared/modules/src/advert-type/advert-type.service.ts
+++ b/libs/shared/modules/src/advert-type/advert-type.service.ts
@@ -289,7 +289,7 @@ export class AdvertTypeService implements IAdvertTypeService {
 
       const createBody = {
         id: id,
-        title: body.title,
+        title: body.title.toUpperCase(),
         slug: slug,
         departmentId: body.departmentId,
         mainTypeId: body.mainTypeId,


### PR DESCRIPTION
# API
- Advert types are now all uppercased