### PR TITLE
feat(api): Add publication markup to adverts

### DIFF
--- a/libs/shared/modules/src/case/case.service.ts
+++ b/libs/shared/modules/src/case/case.service.ts
@@ -51,6 +51,7 @@ import {
   enumMapper,
   generatePaging,
   getLimitAndOffset,
+  getPublicationTemplate,
   getS3Bucket,
 } from '@dmr.is/utils'
 
@@ -884,6 +885,11 @@ export class CaseService implements ICaseService {
 
     await this.createPdfAndUpload(caseId, pdfFileName)
 
+    const publicationHtml = getPublicationTemplate(
+      caseToPublish.department.title,
+      now,
+    )
+
     const advertCreateResult = await this.journalService.create(
       {
         departmentId: caseToPublish.departmentId,
@@ -894,7 +900,7 @@ export class CaseService implements ICaseService {
         categories: caseToPublish.categories?.map((c) => c.id) ?? [],
         publicationDate: now.toISOString(),
         signatureDate: caseToPublish.signature.signatureDate,
-        content: caseToPublish.html + signatureHtml,
+        content: caseToPublish.html + signatureHtml + publicationHtml,
         pdfUrl: pdfFileName,
       },
       transaction,

--- a/libs/shared/utils/src/lib/serverUtils.ts
+++ b/libs/shared/utils/src/lib/serverUtils.ts
@@ -549,3 +549,26 @@ export const applicationSignatureTemplate = (
 
   return recordsMarkup
 }
+
+/**
+ *
+ * @param department Ex. "A deild", "B deild", "C deild"
+ * @param publicationDate iso string of the publication date
+ * @returns
+ */
+
+export const getPublicationTemplate = (
+  department: string,
+  publicationDate: string | Date,
+) => {
+  const dateToUse =
+    typeof publicationDate === 'string'
+      ? new Date(publicationDate)
+      : publicationDate
+
+  const formatted = format(dateToUse, 'd. MMMM yyyy', {
+    locale: is,
+  })
+
+  return `<p align="center" style="margin-top: 1.5em;"><strong>${department} - Útgáfud.: ${formatted}</strong></p>`
+}


### PR DESCRIPTION
# API
- Added new getPublicationTemplate method that returns html markup for publication data
- Used the method and added it the html contents of the advert when created