### PR TITLE
feat(api): HTML as base64

### DIFF
--- a/apps/official-journal-api/src/app/journal/journal.controller.ts
+++ b/apps/official-journal-api/src/app/journal/journal.controller.ts
@@ -30,6 +30,7 @@ import { ResultWrapper } from '@dmr.is/types'
 import {
   Controller,
   Get,
+  Header,
   Inject,
   InternalServerErrorException,
   NotFoundException,
@@ -192,6 +193,7 @@ export class JournalController {
       },
     },
   })
+  @Header('Content-Type', 'text/rss+xml')
   async getRssFeed(@Param('id') id: string) {
     const adverts = ResultWrapper.unwrap(
       await this.journalService.getAdverts({

--- a/libs/shared/dto/src/lib/application/application-advert.ts
+++ b/libs/shared/dto/src/lib/application/application-advert.ts
@@ -1,4 +1,4 @@
-import { Transform } from 'class-transformer'
+import { Transform, Type } from 'class-transformer'
 import {
   IsDateString,
   IsEnum,
@@ -59,6 +59,21 @@ export class ApplicationAddition {
   })
   @IsString()
   @IsOptional()
+  @Transform(({ value }) => {
+    const isBase64 = (str: string) => {
+      try {
+        return btoa(atob(str)) === str
+      } catch (err) {
+        return false
+      }
+    }
+
+    if (!isBase64(value)) {
+      return value
+    }
+
+    return atob(value)
+  })
   content?: string
 
   @ApiProperty({
@@ -153,6 +168,7 @@ export class ApplicationAdvert {
     description: 'Additions to the advert',
   })
   @IsOptional()
+  @Type(() => ApplicationAddition)
   additions?: ApplicationAddition[]
 
   @ApiProperty({

--- a/libs/shared/dto/src/lib/application/application-advert.ts
+++ b/libs/shared/dto/src/lib/application/application-advert.ts
@@ -1,3 +1,4 @@
+import { Transform } from 'class-transformer'
 import {
   IsDateString,
   IsEnum,
@@ -109,6 +110,21 @@ export class ApplicationAdvert {
     description: 'HTML contents of the advert',
   })
   @IsString()
+  @Transform(({ value }) => {
+    const isBase64 = (str: string) => {
+      try {
+        return btoa(atob(str)) === str
+      } catch (err) {
+        return false
+      }
+    }
+
+    if (!isBase64(value)) {
+      return value
+    }
+
+    return atob(value)
+  })
   html!: string
 
   @ApiProperty({

--- a/libs/shared/dto/src/lib/application/application-answers.dto.ts
+++ b/libs/shared/dto/src/lib/application/application-answers.dto.ts
@@ -1,3 +1,5 @@
+import { Type } from 'class-transformer'
+
 import { ApiProperty } from '@nestjs/swagger'
 
 import { ApplicationAdvert } from './application-advert'
@@ -9,17 +11,20 @@ export class ApplicationAnswers {
     type: ApplicationAdvert,
     description: 'Answers for the advert application',
   })
+  @Type(() => ApplicationAdvert)
   advert!: ApplicationAdvert
 
   @ApiProperty({
     type: ApplicationMisc,
     description: 'Misc answers',
   })
+  @Type(() => ApplicationMisc)
   misc?: ApplicationMisc
 
   @ApiProperty({
     type: ApplicationSignatures,
     description: 'Signature answers',
   })
+  @Type(() => ApplicationSignatures)
   signature!: ApplicationSignatures
 }

--- a/libs/shared/dto/src/lib/application/application.dto.ts
+++ b/libs/shared/dto/src/lib/application/application.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer'
 import { ApplicationStates } from '@dmr.is/constants'
 
 import { ApiProperty } from '@nestjs/swagger'
@@ -84,6 +85,7 @@ export class Application {
     type: ApplicationAnswers,
     description: 'Application answers',
   })
+  @Type(() => ApplicationAnswers)
   answers!: ApplicationAnswers
 
   @ApiProperty({

--- a/libs/shared/modules/src/application/application.service.ts
+++ b/libs/shared/modules/src/application/application.service.ts
@@ -1,3 +1,4 @@
+import { plainToInstance } from 'class-transformer'
 import { Op, Transaction } from 'sequelize'
 import { Sequelize } from 'sequelize-typescript'
 import { ApplicationEvent, AttachmentTypeParam } from '@dmr.is/constants'
@@ -148,7 +149,9 @@ export class ApplicationService implements IApplicationService {
       })
     }
 
-    const application: Application = await res.json()
+    const raw = await res.json()
+
+    const application = plainToInstance(Application, raw)
 
     return ResultWrapper.ok({
       application,

--- a/libs/shared/modules/src/case/services/update/case-update.service.ts
+++ b/libs/shared/modules/src/case/services/update/case-update.service.ts
@@ -799,7 +799,7 @@ export class CaseUpdateService implements ICaseUpdateService {
             {
               answers: {
                 advert: {
-                  html: body.advertHtml,
+                  html: btoa(body.advertHtml),
                 },
               },
             },


### PR DESCRIPTION
We now transform incoming html from base 64 to plain string, and also convert the html to base64 when sending it out.