### PR TITLE
fix(ojoi): Add timeout and retry for lean adverts

### DIFF
--- a/libs/shared/modules/src/journal/journal.service.ts
+++ b/libs/shared/modules/src/journal/journal.service.ts
@@ -78,6 +78,7 @@ import {
   AdvertModel,
   AdvertStatusModel,
 } from './models'
+const DEFAULT_PAGE = 1
 const DEFAULT_PAGE_SIZE = 20
 const LOGGING_CATEGORY = 'journal-service'
 @Injectable()
@@ -1273,7 +1274,7 @@ export class JournalService implements IJournalService {
   async getAdvertsLean(
     params?: GetAdvertsQueryParams,
   ): Promise<ResultWrapper<GetLeanAdvertsResponse>> {
-    const page = params?.page ?? 1
+    const page = params?.page ?? DEFAULT_PAGE
     const pageSize = params?.pageSize ?? DEFAULT_PAGE_SIZE
 
     // First attempt with 15-second timeout
@@ -1316,7 +1317,7 @@ export class JournalService implements IJournalService {
 
   private async executeGetAdvertsLean(
     params?: GetAdvertsQueryParams,
-    page: number = 1,
+    page: number = DEFAULT_PAGE,
     pageSize: number = DEFAULT_PAGE_SIZE,
   ): Promise<ResultWrapper<GetLeanAdvertsResponse>> {
     // ----- Direct lookup by 11‑digit internal case number -----


### PR DESCRIPTION
* Add timeout and retry for lean adverts
It can take up to 30 sec before crashing the api.
We want to cancel and retry after 15 sec. If retry fails, then we should just return an error, so not to crash anything.
