### PR TITLE
fix(ojoi): Pricing additional doc

### DIFF
--- a/libs/shared/dto/src/lib/cases/update-price-body.dto.ts
+++ b/libs/shared/dto/src/lib/cases/update-price-body.dto.ts
@@ -127,6 +127,14 @@ export class CaseFeeCalculationBody {
   @ApiProperty({
     type: Number,
     required: false,
+    description: 'Length of the Additional HTML content',
+  })
+  @IsOptional()
+  additionalHTMLLength?: number
+
+  @ApiProperty({
+    type: Number,
+    required: false,
     description: 'How much extra work is there, in percentage',
   })
   @IsOptional()


### PR DESCRIPTION
    // If there are additional documents, we only get main text body length, else we count main + additional.
    // If there are additional documents, the price of those are calculated separately.