### PR TITLE
fix(ojoi): Update price service addition handling

### DIFF
--- a/apps/official-journal-web/src/components/price/calculator.tsx
+++ b/apps/official-journal-web/src/components/price/calculator.tsx
@@ -105,7 +105,7 @@ export const PriceCalculator = () => {
 
   useEffect(() => {
     updateAllPrices()
-  }, [currentCase.html, currentCase.fastTrack])
+  }, [currentCase.html, currentCase.fastTrack, currentCase.additions])
 
   return (
     <>

--- a/libs/shared/utils/src/lib/serverUtils.ts
+++ b/libs/shared/utils/src/lib/serverUtils.ts
@@ -679,3 +679,14 @@ export const getNextWeekDay = (date: Date | string) => {
 
   return dateToUse
 }
+
+export const getBodyHTMLlength = (
+  bodyLength: number,
+  additionsLength: number,
+  additionalDocCount?: number | null,
+) => {
+  if (additionalDocCount) {
+    return bodyLength
+  }
+  return bodyLength + additionsLength
+}


### PR DESCRIPTION
    // If there are additional documents, we only get main text body length, else we count main + additional.
    // If there are additional documents, the price of those are calculated separately.
    
    These changes break down the expenses and improve error log.