### PR TITLE
fix(lg): styling for legacy html in new application

### DIFF
--- a/libs/shared/dmr-ui/src/lib/components/AdvertDisplay/AdvertDisplay.css.ts
+++ b/libs/shared/dmr-ui/src/lib/components/AdvertDisplay/AdvertDisplay.css.ts
@@ -24,12 +24,22 @@ globalStyle(
   },
 )
 
-globalStyle(`.advertContent table `, {
+globalStyle(`${bodyText} table, .advertContent table `, {
   tableLayout: 'fixed',
 })
-globalStyle(`.advertContent table td, .advertContent table th`, {
-  border: 'none',
-  paddingRight: '1em',
+globalStyle(
+  `${bodyText} table td, ${bodyText} table th, .advertContent table td, .advertContent table th`,
+  {
+    border: 'none',
+    padding: '.125em .5em .125em 0',
+  },
+)
+
+globalStyle(`${bodyText} p `, {
+  marginBottom: '.5em',
+})
+globalStyle(`${bodyText} h1 `, {
+  marginTop: '1em',
 })
 
 globalStyle('.advert.legal-gazette .advert', {
@@ -82,7 +92,7 @@ globalStyle(`${legacyText} .advertType`, {
 globalStyle(`${legacyText} .advertType > td`, {
   paddingBottom: '4px',
 })
-globalStyle(`.advertText table `, {
+globalStyle(`${legacyText} table `, {
   tableLayout: 'fixed',
   width: '100%',
 })


### PR DESCRIPTION
fyrir
<img width="877" height="870" alt="image" src="https://github.com/user-attachments/assets/c16f6d78-6447-4084-8223-081119da7b90" />

eftir
<img width="833" height="750" alt="image" src="https://github.com/user-attachments/assets/e9940668-7fa4-4fa2-bad8-e8e418fe81fd" />
