### PR TITLE
fix(lg): don't do national registry lookup when go back step

### DIFF
--- a/apps/legal-gazette-application-web/src/components/national-id-lookup/NationalIdLookup.tsx
+++ b/apps/legal-gazette-application-web/src/components/national-id-lookup/NationalIdLookup.tsx
@@ -67,6 +67,7 @@ export const NationalIdLookup = ({
       },
     }),
   )
+
   const [nationalId, setNationalId] = useState(defaultValue)
 
   const onChangeHandler = (val: string) => {
@@ -81,7 +82,7 @@ export const NationalIdLookup = ({
     formState.errors.fields?.settlementFields?.nationalId?.message
 
   useEffect(() => {
-    if (isValidId) {
+    if (isValidId && nationalId !== defaultValue) {
       mutate({ nationalId })
     }
   }, [isValidId, nationalId, mutate])


### PR DESCRIPTION
don't look up national registry if there is already a kennitala that has been fetched