### PR TITLE
feat(doe): wire CI/CD pipeline and Docker builds for directorate-of-equality

### DIFF
--- a/.github/actions/deploy/update-terragrunt-jafnrettisstofa/action.yml
+++ b/.github/actions/deploy/update-terragrunt-jafnrettisstofa/action.yml
@@ -1,0 +1,93 @@
+name: '🚀 Update Terragrunt Jafnréttisstofa Deployment'
+description: 'Deploy DOE services using Terragrunt apply in DMR-Jafnrettisstofa workload'
+
+inputs:
+  PAT:
+    description: 'The personal access token to use'
+    required: true
+  ENV:
+    description: 'The environment to deploy to'
+    required: true
+  VERSION_TAG:
+    description: 'The version tag to deploy'
+    required: true
+  AWS_ENV_ROLE_ARN:
+    description: 'The AWS IAM role ARN to assume for the target environment'
+    required: true
+  INFRA_REPO:
+    description: 'The infrastructure repository to deploy to'
+    required: true
+    default: 'DMR-is/infrastructure'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: Homebrew/actions/setup-homebrew@master
+      name: ☕️Set up Homebrew
+      id: set-up-homebrew
+
+    - name: 🗄️Cache Homebrew Bundler RubyGems
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+        key: ubuntu-latest-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+        restore-keys: ubuntu-latest-rubygems-
+
+    - name: 📥 Install Terragrunt
+      shell: bash
+      run: brew install terragrunt tfenv
+
+    - name: Setup Terraform v1.11.2
+      uses: hashicorp/setup-Terraform@v3
+      with:
+        terraform_version: 1.11.2
+
+    - name: Terragrunt version
+      shell: bash
+      run: terragrunt --version
+
+    - name: Terraform version
+      shell: bash
+      run: terraform --version
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.AWS_ENV_ROLE_ARN }}
+        role-session-name: GitHub-Action-Role
+        aws-region: eu-west-1
+
+    - name: 📁 Checkout
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.INFRA_REPO }}
+        token: ${{ inputs.PAT }}
+        path: infrastructure
+
+    - name: 🚀 Deploy services with Terragrunt
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd infrastructure/DMR-Jafnrettisstofa
+
+        echo "🚀 Deploying DOE services with Terragrunt run --all..."
+
+        ../scripts/apply_services.sh \
+          --environment ${{ inputs.ENV }} \
+          --version ${{ inputs.VERSION_TAG }} \
+          --parallelism 2 \
+          --commit false \
+          --ignore-dirty true \
+          --service doe_api:doe_api_version_tag \
+          --service doe_web:doe_web_version_tag
+
+        echo "✅ All DOE services deployed successfully!"
+
+    - name: 💾 Commit
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: 'chore: update Jafnréttisstofa to ${{ inputs.VERSION_TAG }}'
+        branch: main
+        skip_fetch: false
+        repository: infrastructure

--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: eu-west-1
   AWS_SHARED_ACCOUNT_ID: 592944621100
   AWS_DEV_ACCOUNT_ID: 555454216281
+  AWS_JAFNRETTISSTOFA_DEV_ACCOUNT_ID: 067362060381
 
 permissions:
   id-token: write # Required f. IAM Token
@@ -43,7 +44,7 @@ jobs:
       - name: Determine affected containers
         id: set-affected
         run: |
-          ALL_CONTAINERS='["official-journal-api","official-journal-admin-api","official-journal-application-api","official-journal-web","regulations-api","legal-gazette-api","legal-gazette-web","legal-gazette-application-web","legal-gazette-public-web"]'
+          ALL_CONTAINERS='["official-journal-api","official-journal-admin-api","official-journal-application-api","official-journal-web","regulations-api","legal-gazette-api","legal-gazette-web","legal-gazette-application-web","legal-gazette-public-web","directorate-of-equality-api","directorate-of-equality-web"]'
 
           mkdir -p /tmp/nx-tmp && npm install --prefix /tmp/nx-tmp --no-save --ignore-scripts --legacy-peer-deps --no-audit --no-fund nx@22.5.1
           cp -r /tmp/nx-tmp/node_modules/. node_modules/
@@ -230,3 +231,57 @@ jobs:
           aws ecs wait services-stable \
             --cluster dev-dmr-utgafa \
             --services ${{ matrix.container }}
+
+  deploy-to-dev-jafnrettisstofa:
+    runs-on: ubuntu-latest
+    needs: [detect-affected, build-affected, retag-unaffected]
+    if: |
+      always() &&
+      (
+        contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-api') ||
+        contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-web')
+      ) &&
+      (needs.build-affected.result == 'success' || needs.build-affected.result == 'skipped') &&
+      (needs.retag-unaffected.result == 'success' || needs.retag-unaffected.result == 'skipped')
+    environment: development
+    name: Deploy DOE services to dev (Jafnréttisstofa)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.AWS_JAFNRETTISSTOFA_DEV_ACCOUNT_ID }}:role/dev-github-ci-role
+          role-session-name: GitHub-Action-Role
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Deploy directorate-of-equality-api if affected
+        if: contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-api')
+        run: |
+          aws ecs update-service \
+            --cluster dev-dmr-jafnrettisstofa \
+            --service directorate-of-equality-api \
+            --force-new-deployment
+
+      - name: Deploy directorate-of-equality-web if affected
+        if: contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-web')
+        run: |
+          aws ecs update-service \
+            --cluster dev-dmr-jafnrettisstofa \
+            --service directorate-of-equality-web \
+            --force-new-deployment
+
+      - name: Wait for directorate-of-equality-api to stabilize
+        if: contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-api')
+        run: |
+          aws ecs wait services-stable \
+            --cluster dev-dmr-jafnrettisstofa \
+            --services directorate-of-equality-api
+
+      - name: Wait for directorate-of-equality-web to stabilize
+        if: contains(needs.detect-affected.outputs.affected, 'directorate-of-equality-web')
+        run: |
+          aws ecs wait services-stable \
+            --cluster dev-dmr-jafnrettisstofa \
+            --services directorate-of-equality-web

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -17,6 +17,7 @@ permissions:
 
 env:
   AWS_PROD_ACCOUNT_ID: 704383808130
+  AWS_JAFNRETTISSTOFA_PROD_ACCOUNT_ID: 048844501286
   ENV: prod
 
 jobs:
@@ -34,3 +35,17 @@ jobs:
           VERSION_TAG: ${{ github.event.inputs.version-tag }}
           PAT: ${{ secrets.DMR_ACCOUNT_PAT }}
           SERVICES: official-journal-api official-journal-admin-api official-journal-application-api official-journal-web regulations-api legal-gazette-api legal-gazette-web legal-gazette-application-web legal-gazette-public-web
+
+  deploy-jafnrettisstofa-to-prod:
+    name: 🚀 Deploy Jafnréttisstofa to Prod
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📁 Checkout
+        uses: actions/checkout@v4
+      - name: 🚀 Deploy to Prod
+        uses: ./.github/actions/deploy/update-terragrunt-jafnrettisstofa
+        with:
+          ENV: ${{ env.ENV }}
+          AWS_ENV_ROLE_ARN: arn:aws:iam::${{ env.AWS_JAFNRETTISSTOFA_PROD_ACCOUNT_ID }}:role/${{ env.ENV }}-github-ci-role
+          VERSION_TAG: ${{ github.event.inputs.version-tag }}
+          PAT: ${{ secrets.DMR_ACCOUNT_PAT }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,6 +8,7 @@ permissions:
   contents: write
 env:
   AWS_PROD_ACCOUNT_ID: 704383808130
+  AWS_JAFNRETTISSTOFA_PROD_ACCOUNT_ID: 048844501286
   ENV: prod
 
 jobs:
@@ -27,6 +28,8 @@ jobs:
             legal-gazette-web,
             legal-gazette-application-web,
             legal-gazette-public-web,
+            directorate-of-equality-api,
+            directorate-of-equality-web,
           ]
     steps:
       - name: 📁 Checkout
@@ -52,4 +55,20 @@ jobs:
           VERSION_TAG: ${{ github.ref_name }}
           PAT: ${{ secrets.DMR_ACCOUNT_PAT }}
           SERVICES: official-journal-api official-journal-admin-api official-journal-application-api official-journal-web regulations-api legal-gazette-api legal-gazette-web legal-gazette-application-web legal-gazette-public-web
+
+  deploy-jafnrettisstofa:
+    name: 🚀 Deploy Jafnréttisstofa to Prod
+    runs-on: ubuntu-latest
+    environment: production
+    needs: version-tag
+    steps:
+      - name: 📁 Checkout
+        uses: actions/checkout@v4
+      - name: 🚀 Deploy to Prod
+        uses: ./.github/actions/deploy/update-terragrunt-jafnrettisstofa
+        with:
+          ENV: ${{ env.ENV }}
+          AWS_ENV_ROLE_ARN: arn:aws:iam::${{ env.AWS_JAFNRETTISSTOFA_PROD_ACCOUNT_ID }}:role/${{ env.ENV }}-github-ci-role
+          VERSION_TAG: ${{ github.ref_name }}
+          PAT: ${{ secrets.DMR_ACCOUNT_PAT }}
 

--- a/apps/directorate-of-equality-api/project.json
+++ b/apps/directorate-of-equality-api/project.json
@@ -95,6 +95,17 @@
         ],
         "parallel": false
       }
+    },
+    "container": {
+      "executor": "@nx-tools/nx-container:build",
+      "dependsOn": ["build"],
+      "options": {
+        "engine": "docker",
+        "metadata": {
+          "load": true
+        },
+        "file": "apps/directorate-of-equality-api/Dockerfile"
+      }
     }
   }
 }

--- a/apps/directorate-of-equality-web/Dockerfile
+++ b/apps/directorate-of-equality-web/Dockerfile
@@ -1,0 +1,18 @@
+FROM public.ecr.aws/docker/library/node:20-alpine as deps
+RUN apk add --no-cache libc6-compat
+WORKDIR /usr/src/app
+COPY ./apps/directorate-of-equality-web/dist/package.json ./
+RUN node -e "const f='package.json',p=JSON.parse(require('fs').readFileSync(f));for(const k of Object.keys(p.dependencies||{}))if(k.startsWith('@dmr.is/')&&p.dependencies[k]==='*')delete p.dependencies[k];require('fs').writeFileSync(f,JSON.stringify(p,null,2))"
+RUN npm install --omit=dev --legacy-peer-deps
+
+FROM public.ecr.aws/docker/library/node:22-alpine AS runner
+WORKDIR /usr/src/app
+ENV NODE_ENV=production
+COPY --from=deps /usr/src/app/node_modules ./node_modules
+COPY --from=deps /usr/src/app/package.json ./package.json
+COPY ./apps/directorate-of-equality-web/dist/.next/standalone/apps/directorate-of-equality-web ./
+COPY ./apps/directorate-of-equality-web/dist/public ./public
+COPY ./apps/directorate-of-equality-web/dist/.next/static ./dist/.next/static
+
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/apps/directorate-of-equality-web/project.json
+++ b/apps/directorate-of-equality-web/project.json
@@ -83,6 +83,17 @@
         ]
       },
       "outputs": ["{projectRoot}/gen/fetch"]
+    },
+    "container": {
+      "executor": "@nx-tools/nx-container:build",
+      "dependsOn": ["build"],
+      "options": {
+        "engine": "docker",
+        "metadata": {
+          "load": true
+        },
+        "file": "apps/directorate-of-equality-web/Dockerfile"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Wires the two bootstrapped `directorate-of-equality` apps into the full CI/CD pipeline and adds their Docker build configuration.

## Changes

### Docker builds
- Add `container` NX target to `doe-api/project.json` (NestJS, `apps/directorate-of-equality-api/Dockerfile`)
- Create `doe-web/Dockerfile` (Next.js standalone multi-stage build)
- Add `container` + `codegen` NX targets to `doe-web/project.json`
- Add `clientConfig.json` stub required by the `codegen` dependency

### CI/CD pipeline
- `deploy-containers.yml` — add both DOE containers to `ALL_CONTAINERS`, add `AWS_JAFNRETTISSTOFA_DEV_ACCOUNT_ID` env var, add `deploy-to-dev-jafnrettisstofa` job that conditionally updates ECS services on the `dev-dmr-jafnrettisstofa` cluster
- `deploy-to-prod.yml` — add `AWS_JAFNRETTISSTOFA_PROD_ACCOUNT_ID` env var, add `deploy-jafnrettisstofa-to-prod` job using new composite action
- `on-release.yml` — add DOE repos to ECR version-tag matrix, add `deploy-jafnrettisstofa` prod deploy job

### New composite action
- `.github/actions/deploy/update-terragrunt-jafnrettisstofa/action.yml` — mirrors `update-terragrunt-deployment` but targets `DMR-Jafnrettisstofa` workload with `doe_api` + `doe_web` services

## Notes

- Auth wiring is explicitly **deferred** — both apps are scaffold-only; auth will be a follow-up PR once business logic exists
- Infrastructure (ECR repos, ECS service definitions, ALB records) is in a companion PR in the `infrastructure` repo
- **Manual prerequisites before first deploy:**
  1. Apply `DMR-shared/shared/ecr` to create the ECR repos
  2. Set SSM parameters: `/ecs/directorate-of-equality/web/nextauth_secret` and `/ecs/directorate-of-equality/doe_web_client_secret` in both Jafnréttisstofa accounts
  3. Register `DOE_WEB_CLIENT_ID` OAuth client in the Identity Server
  4. Re-apply `DMR-Jafnrettisstofa/dev/alb` (and prod) to create the `api` subdomain DNS record