### PR TITLE
feat(doe): Report events and workflow

### DIFF
--- a/apps/directorate-of-equality-api/db/DIAGRAM.md
+++ b/apps/directorate-of-equality-api/db/DIAGRAM.md
@@ -123,6 +123,8 @@ erDiagram
         ReportStatusEnum report_status "snapshot"
         ReportStatusEnum from_status "nullable, on STATUS_CHANGED"
         ReportStatusEnum to_status "nullable, on STATUS_CHANGED"
+        text reason "nullable, on STATUS_CHANGED→DENIED"
+        uuid related_report_id FK "nullable, on SUPERSEDED"
     }
     report_comment {
         uuid id PK
@@ -166,6 +168,7 @@ erDiagram
     report ||--o{ report_event : "report_id"
     doe_user |o--o{ report_event : "actor_user_id"
     doe_user |o--o{ report_event : "assigned_user_id"
+    report |o--o{ report_event : "related_report_id"
 
     report ||--o{ report_comment : "report_id"
     doe_user |o--o{ report_comment : "author_user_id"

--- a/apps/directorate-of-equality-api/db/DIAGRAM.md
+++ b/apps/directorate-of-equality-api/db/DIAGRAM.md
@@ -125,6 +125,7 @@ erDiagram
         ReportStatusEnum to_status "nullable, on STATUS_CHANGED"
         text reason "nullable, on STATUS_CHANGED→DENIED"
         uuid related_report_id FK "nullable, on SUPERSEDED"
+        uuid company_id FK "nullable, on SUBMITTED"
     }
     report_comment {
         uuid id PK
@@ -169,6 +170,7 @@ erDiagram
     doe_user |o--o{ report_event : "actor_user_id"
     doe_user |o--o{ report_event : "assigned_user_id"
     report |o--o{ report_event : "related_report_id"
+    company |o--o{ report_event : "company_id"
 
     report ||--o{ report_comment : "report_id"
     doe_user |o--o{ report_comment : "author_user_id"

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -62,7 +62,7 @@ State-by-state:
 - **`DRAFT`** — company admin is still editing. Not visible to reviewers. Most columns may be null. Can transition to `SUBMITTED`.
 - **`SUBMITTED`** — company finalized the submission. `submitted_at` stamped. Waits in reviewer queue.
 - **`IN_REVIEW`** — a reviewer has picked up the report. (If you want reviewer-assignment tracking, stamp `reviewer_user_id` on pickup; currently it's stamped on the final decision.)
-- **`DENIED`** — reviewer rejected the submission. `reviewer_user_id`, `reviewed_at`, `denial_reason` set. The company must submit a new report (new row) — this denied row **stays forever** as audit.
+- **`DENIED`** — reviewer rejected the submission. `reviewer_user_id` set on the report. Denial reason is stored on the `STATUS_CHANGED` event (`reason` column) rather than the report row — keeps the audit trail self-contained. The company must submit a new report (new row) — this denied row **stays forever** as audit.
 - **`APPROVED`** — reviewer accepted. `approved_at` set, `valid_until = approved_at + 3 years`. A `public_report` row is inserted as part of this transition.
 - **`SUPERSEDED`** — a newer report from the same company has been approved. Old `valid_until` gets stamped to `now()`. Only one `APPROVED` report per company is "current" at any time.
 
@@ -168,7 +168,7 @@ The final `score` on `report_employee` is derived from the steps that apply to t
 | `EducationEnum`           | `COMPULSORY`, `UPPER_SECONDARY`, `VOCATIONAL`, `BACHELOR`, `MASTER`, `DOCTORATE`, `PROFESSIONAL` |
 | `ReportStatusEnum`        | `DRAFT`, `SUBMITTED`, `IN_REVIEW`, `DENIED`, `APPROVED`, `SUPERSEDED`                            |
 | `ReportTypeEnum`          | `SALARY`, `EQUALITY`                                                                             |
-| `ReportEventTypeEnum`     | `SUBMITTED`, `ASSIGNED`, `STATUS_CHANGED`                                                        |
+| `ReportEventTypeEnum`     | `SUBMITTED`, `ASSIGNED`, `STATUS_CHANGED`, `SUPERSEDED`                                          |
 | `CommentVisibilityEnum`   | `INTERNAL`, `EXTERNAL`                                                                           |
 | `CommentAuthorKindEnum`   | `REVIEWER`, `COMPANY_ADMIN`                                                                      |
 
@@ -296,7 +296,6 @@ Submission-time snapshot of a company participating in a report. `company_id` po
 | `status`                         | `ReportStatusEnum`                                                                                                             |
 | `equality_report_id`             | `fk → report` (nullable — set on `type = SALARY` rows, points to the approved equality report this salary was audited against) |
 | `reviewer_user_id`               | `fk → doe_user` (nullable)                                                                                                     |
-| `denial_reason`                  | `text` (nullable)                                                                                                              |
 | `approved_at`                    | `timestamp` (nullable)                                                                                                         |
 | `valid_until`                    | `timestamp` (nullable — approved_at + 3y; stamped `now()` on supersede)                                                        |
 | `correction_deadline`            | `timestamp` (nullable)                                                                                                         |
@@ -394,14 +393,14 @@ Join: which sub-criteria steps apply to a given employee personally.
 
 Aggregated per-report salary stats. Stored as an immutable calculation snapshot.
 
-| Column                              | Type                                  |
-| ----------------------------------- | ------------------------------------- |
-| `id`                                | `uuid` PK                             |
-| `report_id`                         | `fk → report` (unique)                |
+| Column                                | Type                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------- |
+| `id`                                  | `uuid` PK                                                                     |
+| `report_id`                           | `fk → report` (unique)                                                        |
 | `salary_difference_threshold_percent` | `decimal(5, 2)` nullable threshold snapshot from `config` at time of creation |
-| `calculation_version`               | `text` (default `v1`)                 |
-| `base_snapshot`                     | `jsonb` adjusted base salary snapshot |
-| `full_snapshot`                     | `jsonb` adjusted full salary snapshot |
+| `calculation_version`                 | `text` (default `v1`)                                                         |
+| `base_snapshot`                       | `jsonb` adjusted base salary snapshot                                         |
+| `full_snapshot`                       | `jsonb` adjusted full salary snapshot                                         |
 
 `base_snapshot` and `full_snapshot` share the same shape:
 
@@ -434,14 +433,14 @@ Unique constraint: `(report_result_id, report_employee_role_id)`.
 
 Insert-only snapshot published when a private report is approved. No PII, no FK to `company`. Anonymized aggregate shown on public site. Immutable by design.
 
-| Column                             | Type                                                      |
-| ---------------------------------- | --------------------------------------------------------- |
-| `id`                               | `uuid` PK                                                 |
-| `source_report_id`                 | `fk → report` (internal trace only, not exposed publicly) |
-| `size_bucket`                      | `text` (company size bracket, e.g. `50-99`, `100+`)       |
-| `isat_category`                    | `text` (industry field)                                   |
-| `published_at`                     | `timestamp`                                               |
-| `valid_until`                      | `timestamp`                                               |
+| Column             | Type                                                      |
+| ------------------ | --------------------------------------------------------- |
+| `id`               | `uuid` PK                                                 |
+| `source_report_id` | `fk → report` (internal trace only, not exposed publicly) |
+| `size_bucket`      | `text` (company size bracket, e.g. `50-99`, `100+`)       |
+| `isat_category`    | `text` (industry field)                                   |
+| `published_at`     | `timestamp`                                               |
+| `valid_until`      | `timestamp`                                               |
 
 Full six permutations precomputed — public consumer does no math. Exact aggregate column set still TBD — minimum/maximum/median and role-level breakdown probably omitted, confirm with stakeholders.
 
@@ -449,21 +448,24 @@ Full six permutations precomputed — public consumer does no math. Exact aggreg
 
 Immutable audit row emitted on state-changing actions. Insert-only. See "Audit timeline" for semantics.
 
-| Column             | Type                                                                       |
-| ------------------ | -------------------------------------------------------------------------- |
-| `id`               | `uuid` PK                                                                  |
-| `report_id`        | `fk → report`                                                              |
-| `event_type`       | `ReportEventTypeEnum`                                                      |
-| `actor_user_id`    | `fk → doe_user` (nullable — null for company admin or cron)                |
-| `report_status`    | `ReportStatusEnum` (snapshot at insert; `= to_status` on `STATUS_CHANGED`) |
-| `from_status`      | `ReportStatusEnum` (nullable — set on `STATUS_CHANGED`)                    |
-| `to_status`        | `ReportStatusEnum` (nullable — set on `STATUS_CHANGED`)                    |
-| `assigned_user_id` | `fk → doe_user` (nullable — set on `ASSIGNED`)                             |
+| Column              | Type                                                                                                            |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `id`                | `uuid` PK                                                                                                       |
+| `report_id`         | `fk → report`                                                                                                   |
+| `event_type`        | `ReportEventTypeEnum`                                                                                           |
+| `actor_user_id`     | `fk → doe_user` (nullable — null for company admin, cron, or system)                                            |
+| `report_status`     | `ReportStatusEnum` (snapshot at insert; `= to_status` on `STATUS_CHANGED`)                                      |
+| `from_status`       | `ReportStatusEnum` (nullable — set on `STATUS_CHANGED`)                                                         |
+| `to_status`         | `ReportStatusEnum` (nullable — set on `STATUS_CHANGED`)                                                         |
+| `assigned_user_id`  | `fk → doe_user` (nullable — set on `ASSIGNED`)                                                                  |
+| `reason`            | `text` (nullable — set on `STATUS_CHANGED` → `DENIED`; carries the denial reason)                               |
+| `related_report_id` | `fk → report` (nullable — set on `SUPERSEDED`; points to the newly approved report that triggered supersession) |
 
 Invariants (enforce via CHECK):
 
 - `event_type = 'STATUS_CHANGED'` ⇒ `from_status IS NOT NULL AND to_status IS NOT NULL AND report_status = to_status`.
 - `event_type = 'ASSIGNED'` ⇒ `assigned_user_id IS NOT NULL`.
+- `event_type = 'SUPERSEDED'` ⇒ `related_report_id IS NOT NULL`.
 
 ### `report_comment`
 

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -460,7 +460,7 @@ Immutable audit row emitted on state-changing actions. Insert-only. See "Audit t
 | `assigned_user_id`  | `fk → doe_user` (nullable — set on `ASSIGNED`)                                                                  |
 | `reason`            | `text` (nullable — set on `STATUS_CHANGED` → `DENIED`; carries the denial reason)                               |
 | `related_report_id` | `fk → report` (nullable — set on `SUPERSEDED`; points to the newly approved report that triggered supersession) |
-| `company_id`        | `fk → company` (nullable — set on `SUBMITTED`; identifies the submitting company for audit purposes)             |
+| `company_id`        | `fk → company` (nullable — set on `SUBMITTED`; identifies the submitting company for audit purposes)            |
 
 Invariants (enforce via CHECK):
 

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -460,12 +460,14 @@ Immutable audit row emitted on state-changing actions. Insert-only. See "Audit t
 | `assigned_user_id`  | `fk → doe_user` (nullable — set on `ASSIGNED`)                                                                  |
 | `reason`            | `text` (nullable — set on `STATUS_CHANGED` → `DENIED`; carries the denial reason)                               |
 | `related_report_id` | `fk → report` (nullable — set on `SUPERSEDED`; points to the newly approved report that triggered supersession) |
+| `company_id`        | `fk → company` (nullable — set on `SUBMITTED`; identifies the submitting company for audit purposes)             |
 
 Invariants (enforce via CHECK):
 
 - `event_type = 'STATUS_CHANGED'` ⇒ `from_status IS NOT NULL AND to_status IS NOT NULL AND report_status = to_status`.
 - `event_type = 'ASSIGNED'` ⇒ `assigned_user_id IS NOT NULL`.
 - `event_type = 'SUPERSEDED'` ⇒ `related_report_id IS NOT NULL`.
+- `event_type = 'SUBMITTED'` ⇒ `company_id IS NOT NULL`.
 
 ### `report_comment`
 
@@ -521,7 +523,7 @@ No FKs, no relationships. Standalone lookup table.
 - `report` 1:N `public_report` (one public snapshot per approval; new approvals insert new rows).
 - `report` → `report` self-ref via `equality_report_id` (salary row points to the approved equality row it was audited against).
 - `report` N:1 `doe_user` via `reviewer_user_id` (DoE reviewer who accepted/denied).
-- `report` 1:N `report_event`; `doe_user` 1:N `report_event` via `actor_user_id` (nullable) and `assigned_user_id` (nullable, set on `ASSIGNED`).
+- `report` 1:N `report_event`; `doe_user` 1:N `report_event` via `actor_user_id` (nullable) and `assigned_user_id` (nullable, set on `ASSIGNED`); `company` 1:N `report_event` via `company_id` (nullable, set on `SUBMITTED`).
 - `report` 1:N `report_comment`; `doe_user` 1:N `report_comment` via `author_user_id` (nullable, set when `author_kind = REVIEWER`).
 
 ## Notes / open questions

--- a/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
+++ b/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
@@ -52,7 +52,8 @@ module.exports = {
     CREATE TYPE report_event_type_enum AS ENUM (
       'SUBMITTED',
       'ASSIGNED',
-      'STATUS_CHANGED'
+      'STATUS_CHANGED',
+      'SUPERSEDED'
     );
 
     CREATE TYPE comment_visibility_enum AS ENUM ('INTERNAL', 'EXTERNAL');
@@ -129,7 +130,6 @@ module.exports = {
       equality_report_id UUID DEFAULT NULL REFERENCES report(id),
       reviewer_user_id UUID DEFAULT NULL REFERENCES doe_user(id),
 
-      denial_reason TEXT DEFAULT NULL,
       approved_at TIMESTAMPTZ DEFAULT NULL,
       valid_until TIMESTAMPTZ DEFAULT NULL,
       correction_deadline TIMESTAMPTZ DEFAULT NULL,
@@ -303,6 +303,8 @@ module.exports = {
       from_status report_status_enum DEFAULT NULL,
       to_status report_status_enum DEFAULT NULL,
       assigned_user_id UUID DEFAULT NULL REFERENCES doe_user(id),
+      reason TEXT DEFAULT NULL,
+      related_report_id UUID DEFAULT NULL REFERENCES report(id),
 
       CONSTRAINT report_event_status_changed_chk CHECK (
         event_type <> 'STATUS_CHANGED' OR (
@@ -313,6 +315,9 @@ module.exports = {
       ),
       CONSTRAINT report_event_assigned_chk CHECK (
         event_type <> 'ASSIGNED' OR assigned_user_id IS NOT NULL
+      ),
+      CONSTRAINT report_event_superseded_chk CHECK (
+        event_type <> 'SUPERSEDED' OR related_report_id IS NOT NULL
       )
     );
 
@@ -394,6 +399,8 @@ module.exports = {
       ON report_event (actor_user_id);
     CREATE INDEX report_event_assigned_user_id_idx
       ON report_event (assigned_user_id);
+    CREATE INDEX report_event_related_report_id_idx
+      ON report_event (related_report_id);
 
     CREATE INDEX report_comment_report_id_idx
       ON report_comment (report_id);

--- a/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
+++ b/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
@@ -305,6 +305,7 @@ module.exports = {
       assigned_user_id UUID DEFAULT NULL REFERENCES doe_user(id),
       reason TEXT DEFAULT NULL,
       related_report_id UUID DEFAULT NULL REFERENCES report(id),
+      company_id UUID DEFAULT NULL REFERENCES company(id),
 
       CONSTRAINT report_event_status_changed_chk CHECK (
         event_type <> 'STATUS_CHANGED' OR (
@@ -318,6 +319,9 @@ module.exports = {
       ),
       CONSTRAINT report_event_superseded_chk CHECK (
         event_type <> 'SUPERSEDED' OR related_report_id IS NOT NULL
+      ),
+      CONSTRAINT report_event_submitted_company_chk CHECK (
+        event_type <> 'SUBMITTED' OR company_id IS NOT NULL
       )
     );
 
@@ -401,6 +405,8 @@ module.exports = {
       ON report_event (assigned_user_id);
     CREATE INDEX report_event_related_report_id_idx
       ON report_event (related_report_id);
+    CREATE INDEX report_event_company_id_idx
+      ON report_event (company_id);
 
     CREATE INDEX report_comment_report_id_idx
       ON report_comment (report_id);

--- a/apps/directorate-of-equality-api/project.json
+++ b/apps/directorate-of-equality-api/project.json
@@ -42,10 +42,11 @@
     },
     "format": {
       "executor": "nx:run-commands",
+      "cache": false,
       "options": {
         "commands": [
-          "nx run doe-api:lint --fix=true",
-          "nx format:write --projects=doe-api --since=main"
+          "nx format:write --projects=doe-api",
+          "nx run doe-api:lint --fix=true --skip-nx-cache"
         ],
         "parallel": false
       }

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { ReportResultModel } from '../modules/report-result/models/report-result
 import { ReportRoleResultModel } from '../modules/report-result/models/report-role-result.model'
 import { ReportResultModule } from '../modules/report-result/report-result.module'
 import { ReportStatisticsModule } from '../modules/report-statistics/report-statistics.module'
+import { ReportWorkflowModule } from '../modules/report-workflow/report-workflow.module'
 import { UserModel } from '../modules/user/models/user.model'
 import { UserModule } from '../modules/user/user.module'
 @Module({
@@ -86,6 +87,7 @@ import { UserModule } from '../modules/user/user.module'
     ReportCommentModule,
     ReportResultModule,
     ReportStatisticsModule,
+    ReportWorkflowModule,
     ReportModule,
   ],
   controllers: [],

--- a/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.spec.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.spec.ts
@@ -1,0 +1,85 @@
+import { ForbiddenException } from '@nestjs/common'
+
+import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
+
+import { AdminGuard } from './admin.guard'
+
+const createUser = (nationalId: string): DMRUser =>
+  ({
+    nationalId,
+    name: 'Test User',
+    fullName: 'Test User',
+    scope: [],
+    client: 'test',
+    authorization: 'Bearer test',
+  }) as DMRUser
+
+const createExecutionContext = (request: Record<string, unknown>) =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  }) as never
+
+describe('AdminGuard', () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const userModel = {
+    findOne: jest.fn(),
+  }
+
+  let guard: AdminGuard
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    guard = new AdminGuard(logger as never, userModel as never)
+  })
+
+  it('allows an active reviewer and attaches adminUser to the request', async () => {
+    const reviewer = { id: 'reviewer-1', nationalId: '1201743399' }
+    const request: Record<string, unknown> = {
+      user: createUser('1201743399'),
+    }
+
+    userModel.findOne.mockResolvedValue(reviewer)
+
+    const allowed = await guard.canActivate(createExecutionContext(request))
+
+    expect(allowed).toBe(true)
+    expect(request.adminUser).toBe(reviewer)
+    expect(userModel.findOne).toHaveBeenCalledWith({
+      where: { nationalId: '1201743399', isActive: true },
+    })
+  })
+
+  it('throws ForbiddenException when user is not in doe_user', async () => {
+    const request: Record<string, unknown> = {
+      user: createUser('9999999999'),
+    }
+
+    userModel.findOne.mockResolvedValue(null)
+
+    await expect(
+      guard.canActivate(createExecutionContext(request)),
+    ).rejects.toBeInstanceOf(ForbiddenException)
+
+    expect(request.adminUser).toBeUndefined()
+  })
+
+  it('throws ForbiddenException when user is inactive', async () => {
+    const request: Record<string, unknown> = {
+      user: createUser('1201743399'),
+    }
+
+    userModel.findOne.mockResolvedValue(null)
+
+    await expect(
+      guard.canActivate(createExecutionContext(request)),
+    ).rejects.toBeInstanceOf(ForbiddenException)
+  })
+})

--- a/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
@@ -1,0 +1,47 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
+import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { UserModel } from '../../../modules/user/models/user.model'
+
+const LOGGING_CONTEXT = 'AdminGuard'
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(UserModel)
+    private readonly userModel: typeof UserModel,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest()
+    const user = request.user as DMRUser
+
+    const adminUser = await this.userModel.findOne({
+      where: { nationalId: user.nationalId, isActive: true },
+    })
+
+    if (!adminUser) {
+      this.logger.warn(
+        'Access denied — user not found in doe_user or inactive',
+        {
+          context: LOGGING_CONTEXT,
+          nationalId: user.nationalId,
+        },
+      )
+      throw new ForbiddenException('Access restricted to DoE reviewers')
+    }
+
+    request.adminUser = adminUser
+    return true
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { ReportEventModel } from '../report/models/report-event.model'
+import { ReportEventService } from './report-event.service'
+import { IReportEventService } from './report-event.service.interface'
+
+@Module({
+  imports: [SequelizeModule.forFeature([ReportEventModel])],
+  providers: [
+    {
+      provide: IReportEventService,
+      useClass: ReportEventService,
+    },
+  ],
+  exports: [IReportEventService],
+})
+export class ReportEventModule {}

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
@@ -1,7 +1,7 @@
 import { ReportStatusEnum } from '../report/models/report.model'
 
 export interface IReportEventService {
-  emitSubmitted(reportId: string): Promise<void>
+  emitSubmitted(reportId: string, companyId: string): Promise<void>
   emitAssigned(
     reportId: string,
     actorUserId: string,

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
@@ -1,0 +1,20 @@
+import { ReportStatusEnum } from '../report/models/report.model'
+
+export interface IReportEventService {
+  emitSubmitted(reportId: string): Promise<void>
+  emitAssigned(
+    reportId: string,
+    actorUserId: string,
+    assignedUserId: string,
+  ): Promise<void>
+  emitStatusChanged(
+    reportId: string,
+    fromStatus: ReportStatusEnum,
+    toStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+    reason?: string | null,
+  ): Promise<void>
+  emitSuperseded(reportId: string, relatedReportId: string): Promise<void>
+}
+
+export const IReportEventService = Symbol('IReportEventService')

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
@@ -22,16 +22,17 @@ describe('ReportEventService', () => {
   })
 
   describe('emitSubmitted', () => {
-    it('creates a SUBMITTED event with null actor', async () => {
+    it('creates a SUBMITTED event with null actor and company reference', async () => {
       reportEventModel.create.mockResolvedValue({})
 
-      await service.emitSubmitted('report-1')
+      await service.emitSubmitted('report-1', 'company-1')
 
       expect(reportEventModel.create).toHaveBeenCalledWith({
         reportId: 'report-1',
         eventType: ReportEventTypeEnum.SUBMITTED,
         actorUserId: null,
         reportStatus: ReportStatusEnum.SUBMITTED,
+        companyId: 'company-1',
       })
     })
   })

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
@@ -1,5 +1,5 @@
-import { ReportEventTypeEnum } from '../report/models/report-event.model'
 import { ReportStatusEnum } from '../report/models/report.model'
+import { ReportEventTypeEnum } from '../report/models/report-event.model'
 import { ReportEventService } from './report-event.service'
 
 describe('ReportEventService', () => {

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.spec.ts
@@ -1,0 +1,126 @@
+import { ReportEventTypeEnum } from '../report/models/report-event.model'
+import { ReportStatusEnum } from '../report/models/report.model'
+import { ReportEventService } from './report-event.service'
+
+describe('ReportEventService', () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const reportEventModel = {
+    create: jest.fn(),
+  }
+
+  let service: ReportEventService
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new ReportEventService(logger as never, reportEventModel as never)
+  })
+
+  describe('emitSubmitted', () => {
+    it('creates a SUBMITTED event with null actor', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitSubmitted('report-1')
+
+      expect(reportEventModel.create).toHaveBeenCalledWith({
+        reportId: 'report-1',
+        eventType: ReportEventTypeEnum.SUBMITTED,
+        actorUserId: null,
+        reportStatus: ReportStatusEnum.SUBMITTED,
+      })
+    })
+  })
+
+  describe('emitAssigned', () => {
+    it('creates an ASSIGNED event with IN_REVIEW status snapshot', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitAssigned('report-1', 'reviewer-1', 'reviewer-1')
+
+      expect(reportEventModel.create).toHaveBeenCalledWith({
+        reportId: 'report-1',
+        eventType: ReportEventTypeEnum.ASSIGNED,
+        actorUserId: 'reviewer-1',
+        reportStatus: ReportStatusEnum.IN_REVIEW,
+        assignedUserId: 'reviewer-1',
+      })
+    })
+  })
+
+  describe('emitStatusChanged', () => {
+    it('creates a STATUS_CHANGED event with toStatus as the snapshot', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitStatusChanged(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.APPROVED,
+        'reviewer-1',
+      )
+
+      expect(reportEventModel.create).toHaveBeenCalledWith({
+        reportId: 'report-1',
+        eventType: ReportEventTypeEnum.STATUS_CHANGED,
+        actorUserId: 'reviewer-1',
+        reportStatus: ReportStatusEnum.APPROVED,
+        fromStatus: ReportStatusEnum.IN_REVIEW,
+        toStatus: ReportStatusEnum.APPROVED,
+        reason: null,
+      })
+    })
+
+    it('includes denial reason when provided', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitStatusChanged(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.DENIED,
+        'reviewer-1',
+        'Missing required documents',
+      )
+
+      expect(reportEventModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'Missing required documents',
+          toStatus: ReportStatusEnum.DENIED,
+        }),
+      )
+    })
+
+    it('defaults actorUserId and reason to null when omitted', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitStatusChanged(
+        'report-1',
+        ReportStatusEnum.DRAFT,
+        ReportStatusEnum.SUBMITTED,
+      )
+
+      expect(reportEventModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({ actorUserId: null, reason: null }),
+      )
+    })
+  })
+
+  describe('emitSuperseded', () => {
+    it('creates a SUPERSEDED event linking to the new report', async () => {
+      reportEventModel.create.mockResolvedValue({})
+
+      await service.emitSuperseded('old-report-1', 'new-report-1')
+
+      expect(reportEventModel.create).toHaveBeenCalledWith({
+        reportId: 'old-report-1',
+        eventType: ReportEventTypeEnum.SUPERSEDED,
+        actorUserId: null,
+        reportStatus: ReportStatusEnum.SUPERSEDED,
+        relatedReportId: 'new-report-1',
+      })
+    })
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
@@ -20,7 +20,7 @@ export class ReportEventService implements IReportEventService {
     private readonly reportEventModel: typeof ReportEventModel,
   ) {}
 
-  async emitSubmitted(reportId: string): Promise<void> {
+  async emitSubmitted(reportId: string, companyId: string): Promise<void> {
     this.logger.info(`Emitting SUBMITTED event for report ${reportId}`, {
       context: LOGGING_CONTEXT,
       reportId: reportId,
@@ -31,6 +31,7 @@ export class ReportEventService implements IReportEventService {
       eventType: ReportEventTypeEnum.SUBMITTED,
       actorUserId: null,
       reportStatus: ReportStatusEnum.SUBMITTED,
+      companyId,
     })
   }
 
@@ -62,7 +63,7 @@ export class ReportEventService implements IReportEventService {
   ): Promise<void> {
     this.logger.info(
       `Emitting STATUS_CHANGED event for report ${reportId}: ${fromStatus} → ${toStatus}`,
-      { context: LOGGING_CONTEXT },
+      { context: LOGGING_CONTEXT, reportId: reportId, fromStatus, toStatus },
     )
 
     await this.reportEventModel.create({
@@ -82,6 +83,8 @@ export class ReportEventService implements IReportEventService {
   ): Promise<void> {
     this.logger.info(`Emitting SUPERSEDED event for report ${reportId}`, {
       context: LOGGING_CONTEXT,
+      reportId: reportId,
+      relatedReportId: relatedReportId,
     })
 
     await this.reportEventModel.create({

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
@@ -1,0 +1,95 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { ReportStatusEnum } from '../report/models/report.model'
+import {
+  ReportEventModel,
+  ReportEventTypeEnum,
+} from '../report/models/report-event.model'
+import { IReportEventService } from './report-event.service.interface'
+
+const LOGGING_CONTEXT = 'ReportEventService'
+
+@Injectable()
+export class ReportEventService implements IReportEventService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(ReportEventModel)
+    private readonly reportEventModel: typeof ReportEventModel,
+  ) {}
+
+  async emitSubmitted(reportId: string): Promise<void> {
+    this.logger.info(`Emitting SUBMITTED event for report ${reportId}`, {
+      context: LOGGING_CONTEXT,
+      reportId: reportId,
+    })
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.SUBMITTED,
+      actorUserId: null,
+      reportStatus: ReportStatusEnum.SUBMITTED,
+    })
+  }
+
+  async emitAssigned(
+    reportId: string,
+    actorUserId: string,
+    assignedUserId: string,
+  ): Promise<void> {
+    this.logger.info(`Emitting ASSIGNED event for report ${reportId}`, {
+      context: LOGGING_CONTEXT,
+      reportId: reportId,
+    })
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.ASSIGNED,
+      actorUserId,
+      reportStatus: ReportStatusEnum.IN_REVIEW,
+      assignedUserId,
+    })
+  }
+
+  async emitStatusChanged(
+    reportId: string,
+    fromStatus: ReportStatusEnum,
+    toStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+    reason?: string | null,
+  ): Promise<void> {
+    this.logger.info(
+      `Emitting STATUS_CHANGED event for report ${reportId}: ${fromStatus} → ${toStatus}`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.STATUS_CHANGED,
+      actorUserId: actorUserId ?? null,
+      reportStatus: toStatus,
+      fromStatus,
+      toStatus,
+      reason: reason ?? null,
+    })
+  }
+
+  async emitSuperseded(
+    reportId: string,
+    relatedReportId: string,
+  ): Promise<void> {
+    this.logger.info(`Emitting SUPERSEDED event for report ${reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.SUPERSEDED,
+      actorUserId: null,
+      reportStatus: ReportStatusEnum.SUPERSEDED,
+      relatedReportId,
+    })
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.spec.ts
@@ -78,26 +78,24 @@ describe('ReportResultService', () => {
       id: REPORT_ID,
       type: ReportTypeEnum.SALARY,
     })
-    resultFindOne
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
+    resultFindOne.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'result-1',
+      reportId: REPORT_ID,
+      fromModel: jest.fn().mockReturnValue({
         id: 'result-1',
         reportId: REPORT_ID,
-        fromModel: jest.fn().mockReturnValue({
-          id: 'result-1',
-          reportId: REPORT_ID,
-          salaryDifferenceThresholdPercent: 3.9,
-          calculationVersion: 'v1',
-          base: {
-            totals: { overall: { average: 500000 } },
-            scoreBuckets: [],
-          },
-          full: {
-            totals: { overall: { average: 625000 } },
-            scoreBuckets: [],
-          },
-        }),
-      })
+        salaryDifferenceThresholdPercent: 3.9,
+        calculationVersion: 'v1',
+        base: {
+          totals: { overall: { average: 500000 } },
+          scoreBuckets: [],
+        },
+        full: {
+          totals: { overall: { average: 625000 } },
+          scoreBuckets: [],
+        },
+      }),
+    })
     employeeFindAll.mockResolvedValue([
       makeEmployee('role-b', 120, GenderEnum.MALE, 1, 400000, 100000, 50000),
       makeEmployee('role-a', 220, GenderEnum.FEMALE, 0.5, 300000, 50000, null),

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
@@ -3,6 +3,8 @@ import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger'
 
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+
 import { BenefitsBreakdownDto } from './dto/benefits-breakdown.dto'
 import { GenderWageGapDto } from './dto/gender-wage-gap.dto'
 import { SalaryByGenderAndScoreDto } from './dto/salary-by-gender-and-score.dto'
@@ -13,7 +15,7 @@ import { IReportStatisticsService } from './report-statistics.service.interface'
   version: '1',
 })
 @ApiBearerAuth()
-@UseGuards(TokenJwtAuthGuard)
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
 export class ReportStatisticsController {
   constructor(
     @Inject(IReportStatisticsService)

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
@@ -4,7 +4,6 @@ import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-
 import { BenefitsBreakdownDto } from './dto/benefits-breakdown.dto'
 import { GenderWageGapDto } from './dto/gender-wage-gap.dto'
 import { SalaryByGenderAndScoreDto } from './dto/salary-by-gender-and-score.dto'

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
+import { UserModel } from '../user/models/user.model'
 import { ReportStatisticsController } from './report-statistics.controller'
 import { ReportStatisticsService } from './report-statistics.service'
 import { IReportStatisticsService } from './report-statistics.service.interface'
@@ -20,10 +22,12 @@ import { IReportStatisticsService } from './report-statistics.service.interface'
       ReportSubCriterionStepModel,
       ReportEmployeeRoleCriterionStepModel,
       ReportEmployeePersonalCriterionStepModel,
+      UserModel,
     ]),
   ],
   controllers: [ReportStatisticsController],
   providers: [
+    AdminGuard,
     {
       provide: IReportStatisticsService,
       useClass: ReportStatisticsService,

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.spec.ts
@@ -61,7 +61,11 @@ const makeSubCriterion = (id: string, reportCriterionId: string) =>
   ({ id, reportCriterionId }) as unknown as ReportSubCriterionModel
 
 const makeStep = (id: string, reportSubCriterionId: string, score: number) =>
-  ({ id, reportSubCriterionId, score }) as unknown as ReportSubCriterionStepModel
+  ({
+    id,
+    reportSubCriterionId,
+    score,
+  }) as unknown as ReportSubCriterionStepModel
 
 const makeRoleStepLink = (roleId: string, stepId: string) =>
   ({
@@ -358,8 +362,7 @@ describe('ReportStatisticsService', () => {
       ])
       personalStepFindAll.mockResolvedValue([])
 
-      const result =
-        await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
+      const result = await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
 
       expect(result.dataPoints).toHaveLength(1)
       expect(result.dataPoints[0].score).toBe(500) // 200 + 300
@@ -383,8 +386,7 @@ describe('ReportStatisticsService', () => {
       ])
       personalStepFindAll.mockResolvedValue([])
 
-      const result =
-        await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
+      const result = await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
 
       // Only STEP_WORK_A counts (score 200), STEP_PERSONAL is excluded
       expect(result.dataPoints[0].score).toBe(200)
@@ -408,8 +410,7 @@ describe('ReportStatisticsService', () => {
         makePersonalStepLink('emp-1', STEP_WORK_B),
       ])
 
-      const result =
-        await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
+      const result = await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
 
       // 200 (role) + 300 (personal, but work-type) = 500
       expect(result.dataPoints[0].score).toBe(500)
@@ -433,8 +434,7 @@ describe('ReportStatisticsService', () => {
         makePersonalStepLink('emp-1', STEP_WORK_A),
       ])
 
-      const result =
-        await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
+      const result = await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
 
       // Step A (200) counted once, not twice
       expect(result.dataPoints[0].score).toBe(200)
@@ -453,8 +453,7 @@ describe('ReportStatisticsService', () => {
       roleStepFindAll.mockResolvedValue([])
       personalStepFindAll.mockResolvedValue([])
 
-      const result =
-        await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
+      const result = await service.getBaseSalaryByGenderAndScoreWork(REPORT_ID)
 
       expect(result.dataPoints[0].score).toBe(0)
     })
@@ -473,8 +472,7 @@ describe('ReportStatisticsService', () => {
         }),
       ])
 
-      const result =
-        await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
+      const result = await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
 
       expect(result.dataPoints).toHaveLength(1)
       expect(result.dataPoints[0].adjustedSalary).toBe(1250000)
@@ -490,8 +488,7 @@ describe('ReportStatisticsService', () => {
         }),
       ])
 
-      const result =
-        await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
+      const result = await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
 
       expect(result.dataPoints[0].adjustedSalary).toBe(1000000)
     })
@@ -503,8 +500,7 @@ describe('ReportStatisticsService', () => {
         }),
       ])
 
-      const result =
-        await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
+      const result = await service.getFullSalaryByGenderAndScoreAll(REPORT_ID)
 
       expect(result.dataPoints[0].score).toBe(450)
     })

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.ts
@@ -177,9 +177,7 @@ export class ReportStatisticsService implements IReportStatisticsService {
     return buildWageGapResponse(points)
   }
 
-  async getBenefitsBreakdown(
-    reportId: string,
-  ): Promise<BenefitsBreakdownDto> {
+  async getBenefitsBreakdown(reportId: string): Promise<BenefitsBreakdownDto> {
     this.logger.debug(
       'Computing benefits breakdown (additional + bonus) by gender',
       { context: LOGGING_CONTEXT, reportId },
@@ -248,9 +246,7 @@ export class ReportStatisticsService implements IReportStatisticsService {
     })
 
     if (employees.length === 0) {
-      throw new NotFoundException(
-        `No employees found for report "${reportId}"`,
-      )
+      throw new NotFoundException(`No employees found for report "${reportId}"`)
     }
 
     return employees
@@ -446,36 +442,37 @@ function computeScoreBuckets(points: EmployeeDataPoint[]): ScoreBucketDto[] {
     salary: point.adjustedSalary,
   }))
 
-  return computeSalaryScoreBucketSnapshots(
-    salaryPoints,
-    BUCKET_WIDTH,
-  ).map((bucket) => {
-    const snapshot = bucket.totals
+  return computeSalaryScoreBucketSnapshots(salaryPoints, BUCKET_WIDTH).map(
+    (bucket) => {
+      const snapshot = bucket.totals
 
-    return {
-      rangeFrom: bucket.rangeFrom,
-      rangeTo: bucket.rangeTo,
-      maleAverageSalary:
-        snapshot.male.average !== null
-          ? Math.round(snapshot.male.average)
-          : null,
-      femaleAverageSalary:
-        snapshot.female.average !== null
-          ? Math.round(snapshot.female.average)
-          : null,
-      overallAverageSalary: Math.round(snapshot.overall.average ?? 0),
-      maleMedianSalary:
-        snapshot.male.median !== null ? Math.round(snapshot.male.median) : null,
-      femaleMedianSalary:
-        snapshot.female.median !== null
-          ? Math.round(snapshot.female.median)
-          : null,
-      overallMedianSalary: Math.round(snapshot.overall.median ?? 0),
-      wageGapPercent: roundNullable(snapshot.salaryDifferences.maleFemale, 1),
-      maleCount: bucket.counts.male,
-      femaleCount: bucket.counts.female,
-    }
-  })
+      return {
+        rangeFrom: bucket.rangeFrom,
+        rangeTo: bucket.rangeTo,
+        maleAverageSalary:
+          snapshot.male.average !== null
+            ? Math.round(snapshot.male.average)
+            : null,
+        femaleAverageSalary:
+          snapshot.female.average !== null
+            ? Math.round(snapshot.female.average)
+            : null,
+        overallAverageSalary: Math.round(snapshot.overall.average ?? 0),
+        maleMedianSalary:
+          snapshot.male.median !== null
+            ? Math.round(snapshot.male.median)
+            : null,
+        femaleMedianSalary:
+          snapshot.female.median !== null
+            ? Math.round(snapshot.female.median)
+            : null,
+        overallMedianSalary: Math.round(snapshot.overall.median ?? 0),
+        wageGapPercent: roundNullable(snapshot.salaryDifferences.maleFemale, 1),
+        maleCount: bucket.counts.male,
+        femaleCount: bucket.counts.female,
+      }
+    },
+  )
 }
 
 function computeTotals(points: EmployeeDataPoint[]): SalaryTotalsDto {

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/dto/deny-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/dto/deny-report.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty, IsString } from 'class-validator'
+
+import { ApiString } from '@dmr.is/decorators'
+
+export class DenyReportDto {
+  @ApiString()
+  @IsString()
+  @IsNotEmpty()
+  denialReason!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Inject,
+  Post,
+  UseGuards,
+} from '@nestjs/common'
+import { ApiBearerAuth, ApiOperation, ApiResponse } from '@nestjs/swagger'
+
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { ReportResourceGuard } from '../../core/guards/report-resource/report-resource.guard'
+import { CurrentReportResourceContext } from '../report/decorators/current-report-resource-context.decorator'
+import { type ReportResourceContext } from '../report/types/report-resource-context'
+import { DenyReportDto } from './dto/deny-report.dto'
+import { IReportWorkflowService } from './report-workflow.service.interface'
+
+@Controller({
+  path: 'reports/:reportId',
+  version: '1',
+})
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
+export class ReportWorkflowController {
+  constructor(
+    @Inject(IReportWorkflowService)
+    private readonly reportWorkflowService: IReportWorkflowService,
+  ) {}
+
+  @Post('assign')
+  @HttpCode(204)
+  @ApiOperation({ operationId: 'assignReport' })
+  @ApiResponse({ status: 204 })
+  async assign(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+  ): Promise<void> {
+    return this.reportWorkflowService.assign(context)
+  }
+
+  @Post('deny')
+  @HttpCode(204)
+  @ApiOperation({ operationId: 'denyReport' })
+  @ApiResponse({ status: 204 })
+  async deny(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+    @Body() dto: DenyReportDto,
+  ): Promise<void> {
+    return this.reportWorkflowService.deny(context, dto)
+  }
+
+  @Post('approve')
+  @HttpCode(204)
+  @ApiOperation({ operationId: 'approveReport' })
+  @ApiResponse({ status: 204 })
+  async approve(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+  ): Promise<void> {
+    return this.reportWorkflowService.approve(context)
+  }
+
+  @Post('start-fines')
+  @HttpCode(204)
+  @ApiOperation({ operationId: 'startReportFines' })
+  @ApiResponse({ status: 204 })
+  async startFines(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+  ): Promise<void> {
+    return this.reportWorkflowService.startFines(context)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { ReportResourceGuard } from '../../core/guards/report-resource/report-resource.guard'
+import { CompanyReportModel } from '../company/models/company-report.model'
+import { ReportModel } from '../report/models/report.model'
+import { ReportEventModule } from '../report-event/report-event.module'
+import { UserModel } from '../user/models/user.model'
+import { ReportWorkflowController } from './report-workflow.controller'
+import { ReportWorkflowService } from './report-workflow.service'
+import { IReportWorkflowService } from './report-workflow.service.interface'
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([ReportModel, CompanyReportModel, UserModel]),
+    ReportEventModule,
+  ],
+  controllers: [ReportWorkflowController],
+  providers: [
+    AdminGuard,
+    ReportResourceGuard,
+    {
+      provide: IReportWorkflowService,
+      useClass: ReportWorkflowService,
+    },
+  ],
+  exports: [IReportWorkflowService],
+})
+export class ReportWorkflowModule {}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.interface.ts
@@ -1,0 +1,11 @@
+import { type ReportResourceContext } from '../report/types/report-resource-context'
+import { DenyReportDto } from './dto/deny-report.dto'
+
+export interface IReportWorkflowService {
+  assign(context: ReportResourceContext): Promise<void>
+  deny(context: ReportResourceContext, dto: DenyReportDto): Promise<void>
+  approve(context: ReportResourceContext): Promise<void>
+  startFines(context: ReportResourceContext): Promise<void>
+}
+
+export const IReportWorkflowService = Symbol('IReportWorkflowService')

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -1,0 +1,242 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common'
+
+import { ReportStatusEnum } from '../report/models/report.model'
+import {
+  type ReportResourceContext,
+  ReportRoleEnum,
+} from '../report/types/report-resource-context'
+import { DenyReportDto } from './dto/deny-report.dto'
+import { ReportWorkflowService } from './report-workflow.service'
+
+describe('ReportWorkflowService', () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }
+
+  const reportEventService = {
+    emitSubmitted: jest.fn(),
+    emitAssigned: jest.fn(),
+    emitStatusChanged: jest.fn(),
+    emitSuperseded: jest.fn(),
+  }
+
+  const reportModel = {
+    update: jest.fn(),
+    findAll: jest.fn(),
+  }
+
+  const companyReportModel = {
+    findOne: jest.fn(),
+    findAll: jest.fn(),
+  }
+
+  const sequelize = {
+    transaction: jest
+      .fn()
+      .mockImplementation((cb: () => Promise<void>) => cb()),
+  }
+
+  let service: ReportWorkflowService
+
+  const reviewerContext = (
+    status: ReportStatusEnum,
+  ): ReportResourceContext => ({
+    reportId: 'report-1',
+    reportStatus: status,
+    actor: { kind: ReportRoleEnum.REVIEWER, userId: 'reviewer-1' },
+  })
+
+  const companyContext = (status: ReportStatusEnum): ReportResourceContext => ({
+    reportId: 'report-1',
+    reportStatus: status,
+    actor: { kind: ReportRoleEnum.COMPANY, nationalId: '5500000000' },
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    service = new ReportWorkflowService(
+      logger as never,
+      reportEventService as never,
+      reportModel as never,
+      companyReportModel as never,
+      sequelize as never,
+    )
+  })
+
+  describe('assign', () => {
+    it('transitions SUBMITTED → IN_REVIEW and emits STATUS_CHANGED + ASSIGNED', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      reportEventService.emitAssigned.mockResolvedValue(undefined)
+
+      await service.assign(reviewerContext(ReportStatusEnum.SUBMITTED))
+
+      expect(reportModel.update).toHaveBeenCalledWith(
+        { status: ReportStatusEnum.IN_REVIEW },
+        { where: { id: 'report-1' } },
+      )
+      expect(reportEventService.emitAssigned).toHaveBeenCalledWith(
+        'report-1',
+        'reviewer-1',
+        'reviewer-1',
+      )
+      expect(reportEventService.emitStatusChanged).not.toHaveBeenCalled()
+    })
+
+    it('rejects non-SUBMITTED reports', async () => {
+      await expect(
+        service.assign(reviewerContext(ReportStatusEnum.DRAFT)),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects company actors', async () => {
+      await expect(
+        service.assign(companyContext(ReportStatusEnum.SUBMITTED)),
+      ).rejects.toBeInstanceOf(ForbiddenException)
+
+      expect(reportModel.update).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deny', () => {
+    it('transitions IN_REVIEW → DENIED with denial reason and emits STATUS_CHANGED', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+
+      const dto: DenyReportDto = { denialReason: '  Missing data  ' }
+      await service.deny(reviewerContext(ReportStatusEnum.IN_REVIEW), dto)
+
+      expect(reportModel.update).toHaveBeenCalledWith(
+        {
+          status: ReportStatusEnum.DENIED,
+          reviewerUserId: 'reviewer-1',
+        },
+        { where: { id: 'report-1' } },
+      )
+      expect(reportEventService.emitStatusChanged).toHaveBeenCalledWith(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.DENIED,
+        'reviewer-1',
+        'Missing data',
+      )
+    })
+
+    it('rejects non-IN_REVIEW reports', async () => {
+      await expect(
+        service.deny(reviewerContext(ReportStatusEnum.SUBMITTED), {
+          denialReason: 'reason',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects blank denial reason', async () => {
+      await expect(
+        service.deny(reviewerContext(ReportStatusEnum.IN_REVIEW), {
+          denialReason: '   ',
+        }),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects company actors', async () => {
+      await expect(
+        service.deny(companyContext(ReportStatusEnum.IN_REVIEW), {
+          denialReason: 'reason',
+        }),
+      ).rejects.toBeInstanceOf(ForbiddenException)
+    })
+  })
+
+  describe('approve', () => {
+    it('transitions IN_REVIEW → APPROVED, supersedes prior approvals, emits STATUS_CHANGED + SUPERSEDED', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportModel.findAll.mockResolvedValue([{ id: 'old-report-1' }])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      reportEventService.emitSuperseded.mockResolvedValue(undefined)
+      companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })
+      companyReportModel.findAll.mockResolvedValue([
+        { reportId: 'old-report-1' },
+        { reportId: 'report-1' },
+      ])
+
+      await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(reportModel.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: ReportStatusEnum.APPROVED,
+          reviewerUserId: 'reviewer-1',
+        }),
+        { where: { id: 'report-1' } },
+      )
+      expect(reportModel.update).toHaveBeenCalledWith(
+        { status: ReportStatusEnum.SUPERSEDED, validUntil: expect.any(Date) },
+        { where: { id: ['old-report-1'] } },
+      )
+      expect(reportEventService.emitSuperseded).toHaveBeenCalledWith(
+        'old-report-1',
+        'report-1',
+      )
+      expect(reportEventService.emitStatusChanged).toHaveBeenCalledWith(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.APPROVED,
+        'reviewer-1',
+      )
+    })
+
+    it('skips supersede when no sibling reports are APPROVED', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportModel.findAll.mockResolvedValue([])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })
+      companyReportModel.findAll.mockResolvedValue([{ reportId: 'report-1' }])
+
+      await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(reportModel.update).toHaveBeenCalledTimes(1)
+      expect(reportEventService.emitSuperseded).not.toHaveBeenCalled()
+    })
+
+    it('rejects non-IN_REVIEW reports', async () => {
+      await expect(
+        service.approve(reviewerContext(ReportStatusEnum.SUBMITTED)),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects company actors', async () => {
+      await expect(
+        service.approve(companyContext(ReportStatusEnum.IN_REVIEW)),
+      ).rejects.toBeInstanceOf(ForbiddenException)
+    })
+  })
+
+  describe('startFines', () => {
+    it('stamps finesStartedAt on the report', async () => {
+      reportModel.update.mockResolvedValue([1])
+
+      await service.startFines(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(reportModel.update).toHaveBeenCalledWith(
+        { finesStartedAt: expect.any(Date) },
+        { where: { id: 'report-1' } },
+      )
+    })
+
+    it('rejects company actors', async () => {
+      await expect(
+        service.startFines(companyContext(ReportStatusEnum.IN_REVIEW)),
+      ).rejects.toBeInstanceOf(ForbiddenException)
+    })
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -1,12 +1,10 @@
-import { Sequelize } from 'sequelize-typescript'
-
 import {
   BadRequestException,
   ForbiddenException,
   Inject,
   Injectable,
 } from '@nestjs/common'
-import { InjectConnection, InjectModel } from '@nestjs/sequelize'
+import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
@@ -32,7 +30,6 @@ export class ReportWorkflowService implements IReportWorkflowService {
     private readonly reportModel: typeof ReportModel,
     @InjectModel(CompanyReportModel)
     private readonly companyReportModel: typeof CompanyReportModel,
-    @InjectConnection() private readonly sequelize: Sequelize,
   ) {}
 
   async assign(context: ReportResourceContext): Promise<void> {
@@ -52,18 +49,16 @@ export class ReportWorkflowService implements IReportWorkflowService {
 
     const actorUserId = context.actor.userId
 
-    await this.sequelize.transaction(async () => {
-      await this.reportModel.update(
-        { status: ReportStatusEnum.IN_REVIEW },
-        { where: { id: context.reportId } },
-      )
+    await this.reportModel.update(
+      { status: ReportStatusEnum.IN_REVIEW },
+      { where: { id: context.reportId } },
+    )
 
-      await this.reportEventService.emitAssigned(
-        context.reportId,
-        actorUserId,
-        actorUserId,
-      )
-    })
+    await this.reportEventService.emitAssigned(
+      context.reportId,
+      actorUserId,
+      actorUserId,
+    )
   }
 
   async deny(
@@ -92,23 +87,21 @@ export class ReportWorkflowService implements IReportWorkflowService {
 
     const actorUserId = context.actor.userId
 
-    await this.sequelize.transaction(async () => {
-      await this.reportModel.update(
-        {
-          status: ReportStatusEnum.DENIED,
-          reviewerUserId: actorUserId,
-        },
-        { where: { id: context.reportId } },
-      )
+    await this.reportModel.update(
+      {
+        status: ReportStatusEnum.DENIED,
+        reviewerUserId: actorUserId,
+      },
+      { where: { id: context.reportId } },
+    )
 
-      await this.reportEventService.emitStatusChanged(
-        context.reportId,
-        ReportStatusEnum.IN_REVIEW,
-        ReportStatusEnum.DENIED,
-        actorUserId,
-        denialReason,
-      )
-    })
+    await this.reportEventService.emitStatusChanged(
+      context.reportId,
+      ReportStatusEnum.IN_REVIEW,
+      ReportStatusEnum.DENIED,
+      actorUserId,
+      denialReason,
+    )
   }
 
   async approve(context: ReportResourceContext): Promise<void> {
@@ -131,28 +124,26 @@ export class ReportWorkflowService implements IReportWorkflowService {
     const validUntil = new Date(now)
     validUntil.setFullYear(validUntil.getFullYear() + 3)
 
-    await this.sequelize.transaction(async () => {
-      await this.reportModel.update(
-        {
-          status: ReportStatusEnum.APPROVED,
-          approvedAt: now,
-          validUntil,
-          reviewerUserId: actorUserId,
-        },
-        { where: { id: context.reportId } },
-      )
+    await this.reportModel.update(
+      {
+        status: ReportStatusEnum.APPROVED,
+        approvedAt: now,
+        validUntil,
+        reviewerUserId: actorUserId,
+      },
+      { where: { id: context.reportId } },
+    )
 
-      await this.supersedePreviousApproved(context.reportId)
+    await this.supersedePreviousApproved(context.reportId)
 
-      await this.reportEventService.emitStatusChanged(
-        context.reportId,
-        ReportStatusEnum.IN_REVIEW,
-        ReportStatusEnum.APPROVED,
-        actorUserId,
-      )
+    await this.reportEventService.emitStatusChanged(
+      context.reportId,
+      ReportStatusEnum.IN_REVIEW,
+      ReportStatusEnum.APPROVED,
+      actorUserId,
+    )
 
-      // TODO: insert public_report row as part of approval pipeline
-    })
+    // TODO: insert public_report row as part of approval pipeline
   }
 
   async startFines(context: ReportResourceContext): Promise<void> {

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -1,0 +1,214 @@
+import { Sequelize } from 'sequelize-typescript'
+
+import {
+  BadRequestException,
+  ForbiddenException,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
+import { InjectConnection, InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { CompanyReportModel } from '../company/models/company-report.model'
+import { ReportModel, ReportStatusEnum } from '../report/models/report.model'
+import {
+  type ReportResourceContext,
+  ReportRoleEnum,
+} from '../report/types/report-resource-context'
+import { IReportEventService } from '../report-event/report-event.service.interface'
+import { DenyReportDto } from './dto/deny-report.dto'
+import { IReportWorkflowService } from './report-workflow.service.interface'
+
+const LOGGING_CONTEXT = 'ReportWorkflowService'
+
+@Injectable()
+export class ReportWorkflowService implements IReportWorkflowService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @Inject(IReportEventService)
+    private readonly reportEventService: IReportEventService,
+    @InjectModel(ReportModel)
+    private readonly reportModel: typeof ReportModel,
+    @InjectModel(CompanyReportModel)
+    private readonly companyReportModel: typeof CompanyReportModel,
+    @InjectConnection() private readonly sequelize: Sequelize,
+  ) {}
+
+  async assign(context: ReportResourceContext): Promise<void> {
+    this.logger.info(`Assigning report ${context.reportId} to reviewer`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may assign reports')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.SUBMITTED) {
+      throw new BadRequestException(
+        `Cannot assign report with status ${context.reportStatus}`,
+      )
+    }
+
+    const actorUserId = context.actor.userId
+
+    await this.sequelize.transaction(async () => {
+      await this.reportModel.update(
+        { status: ReportStatusEnum.IN_REVIEW },
+        { where: { id: context.reportId } },
+      )
+
+      await this.reportEventService.emitAssigned(
+        context.reportId,
+        actorUserId,
+        actorUserId,
+      )
+    })
+  }
+
+  async deny(
+    context: ReportResourceContext,
+    dto: DenyReportDto,
+  ): Promise<void> {
+    this.logger.info(`Denying report ${context.reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may deny reports')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+      throw new BadRequestException(
+        `Cannot deny report with status ${context.reportStatus}`,
+      )
+    }
+
+    const denialReason = dto.denialReason.trim()
+
+    if (!denialReason) {
+      throw new BadRequestException('Denial reason cannot be empty')
+    }
+
+    const actorUserId = context.actor.userId
+
+    await this.sequelize.transaction(async () => {
+      await this.reportModel.update(
+        {
+          status: ReportStatusEnum.DENIED,
+          reviewerUserId: actorUserId,
+        },
+        { where: { id: context.reportId } },
+      )
+
+      await this.reportEventService.emitStatusChanged(
+        context.reportId,
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.DENIED,
+        actorUserId,
+        denialReason,
+      )
+    })
+  }
+
+  async approve(context: ReportResourceContext): Promise<void> {
+    this.logger.info(`Approving report ${context.reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may approve reports')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+      throw new BadRequestException(
+        `Cannot approve report with status ${context.reportStatus}`,
+      )
+    }
+
+    const actorUserId = context.actor.userId
+    const now = new Date()
+    const validUntil = new Date(now)
+    validUntil.setFullYear(validUntil.getFullYear() + 3)
+
+    await this.sequelize.transaction(async () => {
+      await this.reportModel.update(
+        {
+          status: ReportStatusEnum.APPROVED,
+          approvedAt: now,
+          validUntil,
+          reviewerUserId: actorUserId,
+        },
+        { where: { id: context.reportId } },
+      )
+
+      await this.supersedePreviousApproved(context.reportId)
+
+      await this.reportEventService.emitStatusChanged(
+        context.reportId,
+        ReportStatusEnum.IN_REVIEW,
+        ReportStatusEnum.APPROVED,
+        actorUserId,
+      )
+
+      // TODO: insert public_report row as part of approval pipeline
+    })
+  }
+
+  async startFines(context: ReportResourceContext): Promise<void> {
+    this.logger.info(`Starting fines for report ${context.reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may start fines')
+    }
+
+    await this.reportModel.update(
+      { finesStartedAt: new Date() },
+      { where: { id: context.reportId } },
+    )
+  }
+
+  private async supersedePreviousApproved(reportId: string): Promise<void> {
+    const companyReport = await this.companyReportModel.findOne({
+      where: { reportId },
+      attributes: ['companyId'],
+    })
+
+    if (!companyReport) {
+      return
+    }
+
+    const siblingReportIds = (
+      await this.companyReportModel.findAll({
+        where: { companyId: companyReport.companyId },
+        attributes: ['reportId'],
+      })
+    )
+      .map((cr) => cr.reportId)
+      .filter((id) => id !== reportId)
+
+    if (siblingReportIds.length === 0) {
+      return
+    }
+
+    const toSupersede = await this.reportModel.findAll({
+      where: { id: siblingReportIds, status: ReportStatusEnum.APPROVED },
+      attributes: ['id'],
+    })
+
+    if (toSupersede.length === 0) {
+      return
+    }
+
+    await this.reportModel.update(
+      { status: ReportStatusEnum.SUPERSEDED, validUntil: new Date() },
+      { where: { id: toSupersede.map((r) => r.id) } },
+    )
+
+    for (const report of toSupersede) {
+      await this.reportEventService.emitSuperseded(report.id, reportId)
+    }
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
@@ -1,12 +1,12 @@
 import { ApiDto, ApiDtoArray, ApiOptionalDto } from '@dmr.is/decorators'
 
 import { CompanyReportDto } from '../../company/dto/company-report.dto'
-import { ReportCommentDto } from '../../report-comment/dto/report-comment.dto'
 import { ReportEmployeeDeviationDto } from '../../report-employee/dto/report-employee-deviation.dto'
 import { ReportResultDto } from '../../report-result/dto/report-result.dto'
 import { ReportRoleResultDto } from '../../report-result/dto/report-role-result.dto'
 import { EqualityReportDto } from './equality-report.dto'
 import { ReportDto } from './report.dto'
+import { ReportTimelineItemDto } from './report-timeline-item.dto'
 
 /**
  * Full detail payload for a single report. Extends the base `ReportDto`
@@ -22,8 +22,10 @@ import { ReportDto } from './report.dto'
  *   without equality" is enforced server-side — if a salary report has no
  *   equality link, the service throws rather than returning null.
  *
- * - `comments`: most recent `ReportCommentModel` rows, both INTERNAL and
- *   EXTERNAL (admin context). Paranoid-deleted entries are excluded.
+ * - `timeline`: merged, `createdAt`-sorted list of `report_event` and
+ *   `report_comment` rows. Each item carries a `kind` discriminator
+ *   (`EVENT` | `COMMENT`) and exactly one of `event` / `comment`
+ *   populated. Paranoid-deleted comments are excluded.
  *
  * - `result` / `roleResults` / `employeeDeviations`: salary-only calculation
  *   outputs. For equality reports these are `null` / `[]`; for salary reports
@@ -39,8 +41,8 @@ export class ReportDetailDto extends ReportDto {
   @ApiDto(EqualityReportDto)
   equalityReport!: EqualityReportDto
 
-  @ApiDtoArray(ReportCommentDto)
-  comments!: ReportCommentDto[]
+  @ApiDtoArray(ReportTimelineItemDto)
+  timeline!: ReportTimelineItemDto[]
 
   @ApiOptionalDto(ReportResultDto, { nullable: true })
   result!: ReportResultDto | null

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
@@ -1,4 +1,5 @@
 import {
+  ApiDateTime,
   ApiEnum,
   ApiOptionalEnum,
   ApiOptionalString,
@@ -48,4 +49,7 @@ export class ReportEventDto {
 
   @ApiOptionalUuid({ nullable: true })
   companyId!: string | null
+
+  @ApiDateTime()
+  createdAt!: Date
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
@@ -1,6 +1,7 @@
 import {
   ApiEnum,
   ApiOptionalEnum,
+  ApiOptionalString,
   ApiOptionalUuid,
   ApiUUId,
 } from '@dmr.is/decorators'
@@ -38,4 +39,10 @@ export class ReportEventDto {
 
   @ApiOptionalUuid({ nullable: true })
   assignedUserId!: string | null
+
+  @ApiOptionalString({ nullable: true })
+  reason!: string | null
+
+  @ApiOptionalUuid({ nullable: true })
+  relatedReportId!: string | null
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
@@ -45,4 +45,7 @@ export class ReportEventDto {
 
   @ApiOptionalUuid({ nullable: true })
   relatedReportId!: string | null
+
+  @ApiOptionalUuid({ nullable: true })
+  companyId!: string | null
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-timeline-item.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-timeline-item.dto.ts
@@ -1,0 +1,25 @@
+import { ApiDateTime, ApiEnum, ApiOptionalDto } from '@dmr.is/decorators'
+
+import { ReportCommentDto } from '../../report-comment/dto/report-comment.dto'
+import { ReportEventDto } from './report-event.dto'
+
+export enum ReportTimelineItemKindEnum {
+  EVENT = 'EVENT',
+  COMMENT = 'COMMENT',
+}
+
+export class ReportTimelineItemDto {
+  @ApiEnum(ReportTimelineItemKindEnum, {
+    enumName: 'ReportTimelineItemKindEnum',
+  })
+  kind!: ReportTimelineItemKindEnum
+
+  @ApiDateTime()
+  createdAt!: Date
+
+  @ApiOptionalDto(ReportEventDto, { nullable: true })
+  event!: ReportEventDto | null
+
+  @ApiOptionalDto(ReportCommentDto, { nullable: true })
+  comment!: ReportCommentDto | null
+}

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report.dto.ts
@@ -79,9 +79,6 @@ export class ReportDto {
   @ApiOptionalUuid({ nullable: true })
   reviewerUserId!: string | null
 
-  @ApiOptionalString({ nullable: true })
-  denialReason!: string | null
-
   @ApiOptionalDateTime({ nullable: true })
   approvedAt!: Date | null
 

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
@@ -83,7 +83,12 @@ describe('compensation-aggregates', () => {
 
   it('rounds aggregate snapshots for persistence', () => {
     const rounded = roundSalaryAggregateSnapshot({
-      overall: { average: 1.234, median: 2.345, minimum: 0.555, maximum: 9.999 },
+      overall: {
+        average: 1.234,
+        median: 2.345,
+        minimum: 0.555,
+        maximum: 9.999,
+      },
       male: { average: 1.111, median: 2.222, minimum: 0.333, maximum: 9.444 },
       female: { average: null, median: null, minimum: null, maximum: null },
       neutral: { average: null, median: null, minimum: null, maximum: null },

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
@@ -225,14 +225,26 @@ export function roundSalaryAggregateSnapshot(
     female: roundMetrics(snapshot.female, precision),
     neutral: roundMetrics(snapshot.neutral, precision),
     salaryDifferences: {
-      maleFemale: roundNullable(snapshot.salaryDifferences.maleFemale, precision),
-      maleNeutral: roundNullable(snapshot.salaryDifferences.maleNeutral, precision),
-      femaleMale: roundNullable(snapshot.salaryDifferences.femaleMale, precision),
+      maleFemale: roundNullable(
+        snapshot.salaryDifferences.maleFemale,
+        precision,
+      ),
+      maleNeutral: roundNullable(
+        snapshot.salaryDifferences.maleNeutral,
+        precision,
+      ),
+      femaleMale: roundNullable(
+        snapshot.salaryDifferences.femaleMale,
+        precision,
+      ),
       femaleNeutral: roundNullable(
         snapshot.salaryDifferences.femaleNeutral,
         precision,
       ),
-      neutralMale: roundNullable(snapshot.salaryDifferences.neutralMale, precision),
+      neutralMale: roundNullable(
+        snapshot.salaryDifferences.neutralMale,
+        precision,
+      ),
       neutralFemale: roundNullable(
         snapshot.salaryDifferences.neutralFemale,
         precision,
@@ -260,9 +272,10 @@ export function assessSalaryDeviationFromReference(input: {
   thresholdPercent: number
   useHalfThreshold?: boolean
 }): SalaryDeviationAssessment {
-  const allowedDifferencePercent = input.useHalfThreshold === false
-    ? input.thresholdPercent
-    : input.thresholdPercent / 2
+  const allowedDifferencePercent =
+    input.useHalfThreshold === false
+      ? input.thresholdPercent
+      : input.thresholdPercent / 2
 
   if (input.referenceSalary === null || input.referenceSalary === 0) {
     return {
@@ -363,7 +376,9 @@ function groupSalaries(samples: GenderSalarySample[]): AggregateGroup {
   return grouped
 }
 
-function countSamplesByCohort(samples: GenderSalarySample[]): SalaryCohortCounts {
+function countSamplesByCohort(
+  samples: GenderSalarySample[],
+): SalaryCohortCounts {
   return {
     overall: samples.length,
     male: samples.filter((sample) => sample.gender === GenderEnum.MALE).length,

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -3,6 +3,7 @@ import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
 import { ImmutableModel, ImmutableTable } from '@dmr.is/shared-models-base'
 
 import { DoeModels } from '../../../core/constants'
+import { CompanyModel } from '../../company/models/company.model'
 import { UserModel } from '../../user/models/user.model'
 import type { ReportEventDto } from '../dto/report-event.dto'
 import { ReportModel, ReportStatusEnum } from './report.model'
@@ -24,6 +25,7 @@ type ReportEventAttributes = {
   assignedUserId: string | null
   reason: string | null
   relatedReportId: string | null
+  companyId: string | null
 }
 
 type ReportEventCreateAttributes = {
@@ -36,6 +38,7 @@ type ReportEventCreateAttributes = {
   assignedUserId?: string | null
   reason?: string | null
   relatedReportId?: string | null
+  companyId?: string | null
 }
 
 @ImmutableTable({ tableName: DoeModels.REPORT_EVENT })
@@ -90,6 +93,10 @@ export class ReportEventModel extends ImmutableModel<
   @Column({ type: DataType.UUID, allowNull: true, field: 'related_report_id' })
   relatedReportId!: string | null
 
+  @ForeignKey(() => CompanyModel)
+  @Column({ type: DataType.UUID, allowNull: true, field: 'company_id' })
+  companyId!: string | null
+
   @BelongsTo(() => ReportModel, { foreignKey: 'reportId', as: 'report' })
   report?: ReportModel
 
@@ -105,6 +112,9 @@ export class ReportEventModel extends ImmutableModel<
   })
   relatedReport?: ReportModel | null
 
+  @BelongsTo(() => CompanyModel, { foreignKey: 'companyId', as: 'company' })
+  company?: CompanyModel | null
+
   static fromModel(model: ReportEventModel): ReportEventDto {
     return {
       id: model.id,
@@ -117,6 +127,7 @@ export class ReportEventModel extends ImmutableModel<
       assignedUserId: model.assignedUserId,
       reason: model.reason,
       relatedReportId: model.relatedReportId,
+      companyId: model.companyId,
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -11,6 +11,7 @@ export enum ReportEventTypeEnum {
   SUBMITTED = 'SUBMITTED',
   ASSIGNED = 'ASSIGNED',
   STATUS_CHANGED = 'STATUS_CHANGED',
+  SUPERSEDED = 'SUPERSEDED',
 }
 
 type ReportEventAttributes = {
@@ -21,6 +22,8 @@ type ReportEventAttributes = {
   fromStatus: ReportStatusEnum | null
   toStatus: ReportStatusEnum | null
   assignedUserId: string | null
+  reason: string | null
+  relatedReportId: string | null
 }
 
 type ReportEventCreateAttributes = {
@@ -31,6 +34,8 @@ type ReportEventCreateAttributes = {
   fromStatus?: ReportStatusEnum | null
   toStatus?: ReportStatusEnum | null
   assignedUserId?: string | null
+  reason?: string | null
+  relatedReportId?: string | null
 }
 
 @ImmutableTable({ tableName: DoeModels.REPORT_EVENT })
@@ -78,6 +83,13 @@ export class ReportEventModel extends ImmutableModel<
   @Column({ type: DataType.UUID, allowNull: true, field: 'assigned_user_id' })
   assignedUserId!: string | null
 
+  @Column({ type: DataType.TEXT, allowNull: true })
+  reason!: string | null
+
+  @ForeignKey(() => ReportModel)
+  @Column({ type: DataType.UUID, allowNull: true, field: 'related_report_id' })
+  relatedReportId!: string | null
+
   @BelongsTo(() => ReportModel, { foreignKey: 'reportId', as: 'report' })
   report?: ReportModel
 
@@ -86,6 +98,12 @@ export class ReportEventModel extends ImmutableModel<
 
   @BelongsTo(() => UserModel, { foreignKey: 'assignedUserId', as: 'assignee' })
   assignee?: UserModel | null
+
+  @BelongsTo(() => ReportModel, {
+    foreignKey: 'relatedReportId',
+    as: 'relatedReport',
+  })
+  relatedReport?: ReportModel | null
 
   static fromModel(model: ReportEventModel): ReportEventDto {
     return {
@@ -97,6 +115,8 @@ export class ReportEventModel extends ImmutableModel<
       fromStatus: model.fromStatus,
       toStatus: model.toStatus,
       assignedUserId: model.assignedUserId,
+      reason: model.reason,
+      relatedReportId: model.relatedReportId,
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -128,6 +128,7 @@ export class ReportEventModel extends ImmutableModel<
       reason: model.reason,
       relatedReportId: model.relatedReportId,
       companyId: model.companyId,
+      createdAt: model.createdAt,
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -59,7 +59,6 @@ type ReportAttributes = {
   equalityReportId: string | null
   reviewerUserId: string | null
 
-  denialReason: string | null
   approvedAt: Date | null
   validUntil: Date | null
   correctionDeadline: Date | null
@@ -92,7 +91,6 @@ type ReportCreateAttributes = {
   equalityReportId?: string | null
   reviewerUserId?: string | null
 
-  denialReason?: string | null
   approvedAt?: Date | null
   validUntil?: Date | null
   correctionDeadline?: Date | null
@@ -257,9 +255,6 @@ export class ReportModel extends MutableModel<
   @Column({ type: DataType.UUID, allowNull: true, field: 'reviewer_user_id' })
   reviewerUserId!: string | null
 
-  @Column({ type: DataType.TEXT, allowNull: true, field: 'denial_reason' })
-  denialReason!: string | null
-
   @Column({ type: DataType.DATE, allowNull: true, field: 'approved_at' })
   approvedAt!: Date | null
 
@@ -327,7 +322,6 @@ export class ReportModel extends MutableModel<
       identifier: model.identifier,
       equalityReportId: model.equalityReportId,
       reviewerUserId: model.reviewerUserId,
-      denialReason: model.denialReason,
       approvedAt: model.approvedAt,
       validUntil: model.validUntil,
       correctionDeadline: model.correctionDeadline,

--- a/apps/directorate-of-equality-api/src/modules/report/report.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.module.ts
@@ -9,6 +9,7 @@ import { ReportRoleResultModel } from '../report-result/models/report-role-resul
 import { UserModel } from '../user/models/user.model'
 import { ReportModel } from './models/report.model'
 import { ReportCommentModel } from './models/report-comment.model'
+import { ReportEventModel } from './models/report-event.model'
 import { ReportController } from './report.controller'
 import { ReportService } from './report.service'
 import { IReportService } from './report.service.interface'
@@ -19,6 +20,7 @@ import { IReportService } from './report.service.interface'
       ReportModel,
       CompanyReportModel,
       ReportCommentModel,
+      ReportEventModel,
       UserModel,
       ReportResultModel,
       ReportRoleResultModel,

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -342,7 +342,6 @@ describe('ReportService.getById', () => {
     importedFromExcel: false,
     equalityReportId: null,
     reviewerUserId: null,
-    denialReason: null,
     approvedAt: null,
     validUntil: null,
     correctionDeadline: null,

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -88,6 +88,9 @@ const makeService = () => {
   // outputs unless a test overrides.
   const roleResultFindAll = jest.fn().mockResolvedValue([])
   const deviationFindAll = jest.fn().mockResolvedValue([])
+  const reportEventModel = {
+    findAll: jest.fn().mockResolvedValue([]),
+  } as unknown as typeof import('./models/report-event.model').ReportEventModel
   const reportRoleResultModel = {
     findAll: roleResultFindAll,
   } as unknown as typeof import('../report-result/models/report-role-result.model').ReportRoleResultModel
@@ -98,6 +101,7 @@ const makeService = () => {
   const service = new ReportService(
     logger,
     reportModel,
+    reportEventModel,
     reportRoleResultModel,
     reportEmployeeDeviationModel,
   )

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -38,9 +38,14 @@ import {
 } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
 import { ReportDetailDto } from './dto/report-detail.dto'
+import {
+  ReportTimelineItemDto,
+  ReportTimelineItemKindEnum,
+} from './dto/report-timeline-item.dto'
 import { ReportTypeEnum } from './models/report.enums'
 import { ReportModel } from './models/report.model'
 import { ReportCommentModel } from './models/report-comment.model'
+import { ReportEventModel } from './models/report-event.model'
 import { buildFreeTextWhere, dateRangeFilter } from './utils/filters'
 import { IReportService } from './report.service.interface'
 
@@ -57,6 +62,8 @@ export class ReportService implements IReportService {
   constructor(
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
     @InjectModel(ReportModel) private readonly reportModel: typeof ReportModel,
+    @InjectModel(ReportEventModel)
+    private readonly reportEventModel: typeof ReportEventModel,
     @InjectModel(ReportRoleResultModel)
     private readonly reportRoleResultModel: typeof ReportRoleResultModel,
     @InjectModel(ReportEmployeeDeviationModel)
@@ -133,20 +140,49 @@ export class ReportService implements IReportService {
       )
     }
 
-    const { result, roleResults, employeeDeviations } =
-      await this.loadSalaryCalculations(report)
+    const [{ result, roleResults, employeeDeviations }, timeline] =
+      await Promise.all([
+        this.loadSalaryCalculations(report),
+        this.buildTimeline(id, report.comments ?? []),
+      ])
 
     return {
       ...base,
       company: CompanyReportModel.fromModel(report.companyReport),
       equalityReport,
-      comments: (report.comments ?? []).map((c: ReportCommentModel) =>
-        ReportCommentModel.fromModel(c),
-      ),
+      timeline,
       result,
       roleResults,
       employeeDeviations,
     }
+  }
+
+  private async buildTimeline(
+    reportId: string,
+    comments: ReportCommentModel[],
+  ): Promise<ReportTimelineItemDto[]> {
+    const events = await this.reportEventModel.findAll({
+      where: { reportId },
+      order: [['createdAt', 'ASC']],
+    })
+
+    const eventItems: ReportTimelineItemDto[] = events.map((e) => ({
+      kind: ReportTimelineItemKindEnum.EVENT,
+      createdAt: e.createdAt,
+      event: ReportEventModel.fromModel(e),
+      comment: null,
+    }))
+
+    const commentItems: ReportTimelineItemDto[] = comments.map((c) => ({
+      kind: ReportTimelineItemKindEnum.COMMENT,
+      createdAt: c.createdAt,
+      event: null,
+      comment: ReportCommentModel.fromModel(c),
+    }))
+
+    return [...eventItems, ...commentItems].sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    )
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
@@ -6,7 +6,6 @@ import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-
 import { UserDto } from './dto/user.dto'
 import { IUserService } from './user.service.interface'
 

--- a/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
@@ -5,6 +5,8 @@ import { CurrentUser } from '@dmr.is/decorators'
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+
 import { UserDto } from './dto/user.dto'
 import { IUserService } from './user.service.interface'
 
@@ -13,7 +15,7 @@ import { IUserService } from './user.service.interface'
   version: '1',
 })
 @ApiBearerAuth()
-@UseGuards(TokenJwtAuthGuard)
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
 export class UserController {
   constructor(
     @Inject(IUserService) private readonly userService: IUserService,

--- a/apps/directorate-of-equality-api/src/modules/user/user.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { UserModel } from './models/user.model'
 import { UserController } from './user.controller'
 import { UserService } from './user.service'
@@ -10,6 +11,7 @@ import { IUserService } from './user.service.interface'
   imports: [SequelizeModule.forFeature([UserModel])],
   controllers: [UserController],
   providers: [
+    AdminGuard,
     {
       provide: IUserService,
       useClass: UserService,


### PR DESCRIPTION
## What                         
                                                                                                                                                                                    
  - `ReportEventService` — emits immutable audit rows on every state-changing action: `SUBMITTED` (with `company_id` FK for audit trail), `ASSIGNED`, `STATUS_CHANGED`              
  (DENIED/APPROVED), and `SUPERSEDED`
  - `ReportWorkflowService` — admin actions `assign`, `deny`, `approve`, `startFines`; `approve` auto-supersedes any existing approved report for the same company, all mutations   
  run in a transaction                                                                                                                                                              
  - `AdminGuard` — verifies the authenticated user is an active DoE reviewer (`doe_user.is_active = true`), attaches `adminUser` to the request
  - `ReportResourceGuard` — resolves report by ID, builds `ReportResourceContext` with actor role (REVIEWER vs COMPANY) consumed by workflow actions                                
  - Schema: added `reason`, `related_report_id`, `company_id` to `report_event` with DB-level CHECK constraints per event type; added `SUPERSEDED` to `report_event_type_enum`;     
  removed `denial_reason` from `report` (moved to the `STATUS_CHANGED` event)                                                                                                       
  - Unified timeline: `ReportDetailDto.comments` replaced by `ReportDetailDto.timeline` — a `createdAt`-sorted list of `ReportTimelineItemDto` items with a `kind: EVENT | COMMENT` 
  discriminator combining both streams                                                                                                                                              
                                                                       
  ## Why                                                                                                                                                                            
                                                                       
  The admin UI needs a full audit trail per report and the ability to act on submissions (assign, deny, approve). Events were the missing piece — without them the timeline was     
  comments-only and state transitions left no structured record. Denial reason moves to the event so the report row stays clean and the audit trail is self-contained. The unified
  timeline DTO lets the frontend render a single sorted list without client-side merging.