### PR TITLE
fix(doe): Remove trailing comma in public_report migration table

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
+++ b/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
@@ -278,7 +278,7 @@ module.exports = {
       size_bucket TEXT NOT NULL,
       isat_category TEXT NOT NULL,
       published_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      valid_until TIMESTAMPTZ NOT NULL,
+      valid_until TIMESTAMPTZ NOT NULL
     );
 
     CREATE TABLE config (


### PR DESCRIPTION
## Summary

- Removes trailing comma after `valid_until` column in the `public_report` `CREATE TABLE` statement in the initial migration
- The trailing comma caused a PostgreSQL syntax error, making every container startup fail with exit code 1 (migration runs before `node main.js` in the Dockerfile)
- Bug was introduced in #1225 (commit `667beebb`) yesterday — the migration had never been run against a real PostgreSQL instance since that commit