### PR TITLE
fix(doe): add health check endpoint to directorate-of-equality-api

### DIFF
--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -39,7 +39,6 @@ import { ReportStatisticsModule } from '../modules/report-statistics/report-stat
 import { ReportWorkflowModule } from '../modules/report-workflow/report-workflow.module'
 import { UserModel } from '../modules/user/models/user.model'
 import { UserModule } from '../modules/user/user.module'
-
 import { HealthController } from './health.controller'
 
 @Module({

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -39,6 +39,9 @@ import { ReportStatisticsModule } from '../modules/report-statistics/report-stat
 import { ReportWorkflowModule } from '../modules/report-workflow/report-workflow.module'
 import { UserModel } from '../modules/user/models/user.model'
 import { UserModule } from '../modules/user/user.module'
+
+import { HealthController } from './health.controller'
+
 @Module({
   imports: [
     LoggingModule,
@@ -92,7 +95,7 @@ import { UserModule } from '../modules/user/user.module'
     ReportModule,
     ReportCreateModule,
   ],
-  controllers: [],
+  controllers: [HealthController],
   providers: [
     {
       provide: APP_FILTER,

--- a/apps/directorate-of-equality-api/src/app/health.controller.ts
+++ b/apps/directorate-of-equality-api/src/app/health.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common'
+
+@Controller({ path: 'health', version: '1' })
+export class HealthController {
+  @Get()
+  health() {
+    return { status: 'ok' }
+  }
+}


### PR DESCRIPTION
## Problem

The ALB health check probes `GET /api/v1/health` but no such endpoint existed in the `directorate-of-equality-api` NestJS app. This caused ECS tasks to fail health checks on every deployment, triggering the deployment circuit breaker in both dev and prod — resulting in 0/2 running tasks in prod and continuous task cycling in dev.

## Fix

Added a `HealthController` at `GET /api/v1/health` (using `@Controller({ path: 'health', version: '1' })` to match the app's global prefix + URI versioning scheme) and registered it in `AppModule`.