### PR TITLE
chore(doe): Update naming for employee deviations to outliers

### DIFF
--- a/apps/directorate-of-equality-api/db/DIAGRAM.md
+++ b/apps/directorate-of-equality-api/db/DIAGRAM.md
@@ -73,7 +73,7 @@ erDiagram
         uuid id PK
         text title
     }
-    report_employee_deviation {
+    report_employee_outlier {
         uuid id PK
         uuid report_employee_id FK
         text reason
@@ -152,7 +152,7 @@ erDiagram
 
     report ||--o{ report_employee : "report_id"
     report_employee_role ||--o{ report_employee : "report_employee_role_id"
-    report_employee ||--o{ report_employee_deviation : "report_employee_id"
+    report_employee ||--o{ report_employee_outlier : "report_employee_id"
 
     report_employee_role ||--o{ report_employee_role_criterion_step : "report_employee_role_id"
     report_sub_criterion_step ||--o{ report_employee_role_criterion_step : "report_sub_criterion_step_id"

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -150,7 +150,7 @@ Each report is evaluated against a set of weighted criteria:
 - `report_sub_criterion_step` — ordered scoring steps within a sub-criterion. Each step has a `score`.
 - Which steps apply to which role is captured in `report_employee_role_criterion_step`.
 - Which steps apply to a specific employee personally is captured in `report_employee_personal_criterion_step`.
-- Deviations from the standard evaluation (special circumstances for a specific employee) are recorded in `report_employee_deviation` with `reason`, `action`, and signatures.
+- Salary outlier justifications (special circumstances for a specific employee) are recorded in `report_employee_outlier` with `reason`, `action`, and signatures.
 
 The final `score` on `report_employee` is derived from the steps that apply to that employee — the sum of `report_sub_criterion_step.score` across the steps reachable via the employee's role (`report_employee_role_criterion_step`) and via their personal assignments (`report_employee_personal_criterion_step`), with steps assigned through both sources counted once. The total is computed at submission and persisted on the row; reviewers read it as-is.
 
@@ -358,7 +358,7 @@ Submission-time snapshot of a company participating in a report. `company_id` po
 | `id`    | `uuid` PK |
 | `title` | `text`    |
 
-### `report_employee_deviation`
+### `report_employee_outlier`
 
 | Column               | Type                   |
 | -------------------- | ---------------------- |
@@ -516,7 +516,7 @@ No FKs, no relationships. Standalone lookup table.
 - `company` ⟷ `report` via `company_report` (per-submission snapshot, with optional parent company).
 - `report` 1:N `report_criterion` 1:N `report_sub_criterion` 1:N `report_sub_criterion_step`.
 - `report` 1:N `report_employee` N:1 `report_employee_role`.
-- `report_employee` 1:N `report_employee_deviation`.
+- `report_employee` 1:N `report_employee_outlier`.
 - `report_employee_role` ⟷ `report_sub_criterion_step` via `report_employee_role_criterion_step`.
 - `report_employee` ⟷ `report_sub_criterion_step` via `report_employee_personal_criterion_step`.
 - `report` 1:1 `report_result`; optional future role snapshots are `report_result` 1:N `report_role_result` N:1 `report_employee_role`.
@@ -532,5 +532,5 @@ No FKs, no relationships. Standalone lookup table.
 - **Fines cron.** Daily job: `SELECT * FROM report WHERE fines_started_at IS NOT NULL AND status NOT IN ('APPROVED', 'SUPERSEDED')`. Accrual table (`report_fine` or similar) not yet designed.
 - **Scope.** This schema targets companies with ≥50 employees. Smaller-company flows + edge cases (mergers, liquidation, exemptions) TBD.
 - **Cascade vs soft-delete.** Postgres `ON DELETE CASCADE` only fires on real `DELETE` rows. Lifecycle here is status-based, not soft-delete — do not add `deleted_at` to children expecting cascade propagation.
-- **Outlier-preview endpoint (planned).** `report_employee_deviation` rows are populated at submission, but the company needs to know *which* employees are outliers before they can justify them. The plan is a dedicated API endpoint (separate from `POST /reports/salary`) that takes the unsaved parsed payload, runs `assessSalaryDeviationInBucket` from `report/lib/compensation-aggregates.ts` (half the configured `salary_difference_threshold_percent` around the score-bucket median), and returns the flagged employees alongside the calculations driving the verdict so the company can verify before submitting. Endpoint shape, response payload, and home module are TBD.
-- **Submit-side outlier-vs-deviation guard (planned, ships with the preview endpoint).** The submit endpoint currently trusts whatever `deviations[]` the caller sends — it only verifies each entry's `employeeOrdinal` resolves to a real employee, not that the employee is actually an outlier. A company could (intentionally or not) submit deviations for non-outliers, or omit deviations for actual outliers. The detection rule needs to live in one place across both endpoints, so the planned approach is: extract a helper `detectOutlierOrdinals(parsed, threshold) → Set<number>` from the same `assessSalaryDeviationInBucket` machinery, then call it from both the preview endpoint (returns it to the caller with calculations) and the submit pre-flight (asserts `deviations[].employeeOrdinal` matches the detected set; reject extras and/or missing per policy). Until this guard lands, the mismatch is reviewer-visible (the snapshot's score-bucket data exposes outliers) but not API-enforced.
+- **Outlier-preview endpoint (planned).** `report_employee_outlier` rows are populated at submission, but the company needs to know *which* employees are outliers before they can justify them. The plan is a dedicated API endpoint (separate from `POST /reports/salary`) that takes the unsaved parsed payload, runs `assessSalaryOutlierInBucket` from `report/lib/compensation-aggregates.ts` (half the configured `salary_difference_threshold_percent` around the score-bucket median), and returns the flagged employees alongside the calculations driving the verdict so the company can verify before submitting. Endpoint shape, response payload, and home module are TBD.
+- **Submit-side outlier guard (planned, ships with the preview endpoint).** The submit endpoint currently trusts whatever `outliers[]` the caller sends — it only verifies each entry's `employeeOrdinal` resolves to a real employee, not that the employee is actually an outlier. A company could (intentionally or not) submit outlier justifications for non-outliers, or omit justifications for actual outliers. The detection rule needs to live in one place across both endpoints, so the planned approach is: extract a helper `detectOutlierOrdinals(parsed, threshold) → Set<number>` from the same `assessSalaryOutlierInBucket` machinery, then call it from both the preview endpoint (returns it to the caller with calculations) and the submit pre-flight (asserts `outliers[].employeeOrdinal` matches the detected set; reject extras and/or missing per policy). Until this guard lands, the mismatch is reviewer-visible (the snapshot's score-bucket data exposes outliers) but not API-enforced.

--- a/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
+++ b/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
@@ -213,7 +213,7 @@ module.exports = {
       score DECIMAL(6, 2) NOT NULL
     );
 
-    CREATE TABLE report_employee_deviation (
+    CREATE TABLE report_employee_outlier (
       id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
       created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
@@ -374,8 +374,8 @@ module.exports = {
       ON report_employee (report_id);
     CREATE INDEX report_employee_role_id_idx
       ON report_employee (report_employee_role_id);
-    CREATE INDEX report_employee_deviation_report_employee_id_idx
-      ON report_employee_deviation (report_employee_id);
+    CREATE INDEX report_employee_outlier_report_employee_id_idx
+      ON report_employee_outlier (report_employee_id);
 
     CREATE INDEX report_employee_role_criterion_step_step_idx
       ON report_employee_role_criterion_step (report_sub_criterion_step_id);
@@ -479,7 +479,7 @@ module.exports = {
     DROP TABLE IF EXISTS report_result;
     DROP TABLE IF EXISTS report_employee_personal_criterion_step;
     DROP TABLE IF EXISTS report_employee_role_criterion_step;
-    DROP TABLE IF EXISTS report_employee_deviation;
+    DROP TABLE IF EXISTS report_employee_outlier;
     DROP TABLE IF EXISTS report_employee;
     DROP TABLE IF EXISTS report_sub_criterion_step;
     DROP TABLE IF EXISTS report_sub_criterion;

--- a/apps/directorate-of-equality-api/project.json
+++ b/apps/directorate-of-equality-api/project.json
@@ -45,8 +45,8 @@
       "cache": false,
       "options": {
         "commands": [
-          "nx format:write --projects=doe-api",
-          "nx run doe-api:lint --fix=true --skip-nx-cache"
+          "nx format:write --projects=directorate-of-equality-api",
+          "nx run directorate-of-equality-api:lint --fix=true --skip-nx-cache"
         ],
         "parallel": false
       }
@@ -57,15 +57,15 @@
       "defaultConfiguration": "development",
       "dependsOn": ["build"],
       "options": {
-        "buildTarget": "doe-api:build",
+        "buildTarget": "directorate-of-equality-api:build",
         "runBuildTargetDependencies": false
       },
       "configurations": {
         "development": {
-          "buildTarget": "doe-api:build:development"
+          "buildTarget": "directorate-of-equality-api:build:development"
         },
         "production": {
-          "buildTarget": "doe-api:build:production"
+          "buildTarget": "directorate-of-equality-api:build:production"
         }
       }
     },
@@ -97,9 +97,9 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "yarn nx run doe-api:dev-services",
-          "yarn nx run doe-api:migrate",
-          "yarn nx run doe-api:seed"
+          "yarn nx run directorate-of-equality-api:dev-services",
+          "yarn nx run directorate-of-equality-api:migrate",
+          "yarn nx run directorate-of-equality-api:seed"
         ],
         "parallel": false
       }

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -27,7 +27,7 @@ import { ReportCriterionModel } from '../modules/report-criterion/models/report-
 import { ReportSubCriterionModel } from '../modules/report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../modules/report-criterion/models/report-sub-criterion-step.model'
 import { ReportEmployeeModel } from '../modules/report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../modules/report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../modules/report-employee/models/report-employee-outlier.model'
 import { ReportEmployeePersonalCriterionStepModel } from '../modules/report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../modules/report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../modules/report-employee/models/report-employee-role-criterion-step.model'
@@ -66,7 +66,7 @@ import { UserModule } from '../modules/user/user.module'
             ReportSubCriterionModel,
             ReportSubCriterionStepModel,
             ReportEmployeeModel,
-            ReportEmployeeDeviationModel,
+            ReportEmployeeOutlierModel,
             ReportEmployeeRoleCriterionStepModel,
             ReportEmployeePersonalCriterionStepModel,
             ReportResultModel,

--- a/apps/directorate-of-equality-api/src/core/constants.ts
+++ b/apps/directorate-of-equality-api/src/core/constants.ts
@@ -10,7 +10,7 @@ export enum DoeModels {
   REPORT_SUB_CRITERION_STEP = 'report_sub_criterion_step',
   REPORT_EMPLOYEE = 'report_employee',
   REPORT_EMPLOYEE_ROLE = 'report_employee_role',
-  REPORT_EMPLOYEE_DEVIATION = 'report_employee_deviation',
+  REPORT_EMPLOYEE_OUTLIER = 'report_employee_outlier',
   REPORT_EMPLOYEE_ROLE_CRITERION_STEP = 'report_employee_role_criterion_step',
   REPORT_EMPLOYEE_PERSONAL_CRITERION_STEP = 'report_employee_personal_criterion_step',
   REPORT_RESULT = 'report_result',

--- a/apps/directorate-of-equality-api/src/modules/report-create/dto/create-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/dto/create-report.dto.ts
@@ -22,12 +22,12 @@ import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
 /**
  * One row per employee flagged as a salary outlier — populated by the company
  * after the outlier-preview step (see `db/README.md` Notes / open questions).
- * Persisted into `report_employee_deviation`.
+ * Persisted into `report_employee_outlier`.
  */
-export class CreateReportDeviationDto {
+export class CreateReportOutlierDto {
   @ApiNumber({
     description:
-      'Ordinal of the employee in `parsed.employees[]` this deviation applies to.',
+      'Ordinal of the employee in `parsed.employees[]` this outlier justification applies to.',
   })
   employeeOrdinal!: number
 
@@ -148,6 +148,6 @@ export class CreateReportDto {
    * fine when no outliers were flagged. Each entry references its employee
    * by `ordinal` from `parsed.employees[]`.
    */
-  @ApiOptionalDtoArray(CreateReportDeviationDto)
-  deviations?: CreateReportDeviationDto[]
+  @ApiOptionalDtoArray(CreateReportOutlierDto)
+  outliers?: CreateReportOutlierDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.module.ts
@@ -8,7 +8,7 @@ import { ReportCriterionModel } from '../report-criterion/models/report-criterio
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
@@ -25,7 +25,7 @@ import { IReportCreateService } from './report-create.service.interface'
       CompanyReportModel,
       ReportEmployeeRoleModel,
       ReportEmployeeModel,
-      ReportEmployeeDeviationModel,
+      ReportEmployeeOutlierModel,
       ReportEmployeeRoleCriterionStepModel,
       ReportEmployeePersonalCriterionStepModel,
       ReportCriterionModel,

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -18,7 +18,7 @@ import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-c
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { EducationEnum } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
@@ -49,7 +49,7 @@ describe('ReportCreateService', () => {
   let employeeBulkCreate: jest.Mock
   let roleStepBulkCreate: jest.Mock
   let personalStepBulkCreate: jest.Mock
-  let deviationBulkCreate: jest.Mock
+  let outlierBulkCreate: jest.Mock
   let criterionCreate: jest.Mock
   let subCriterionCreate: jest.Mock
   let subCriterionStepBulkCreate: jest.Mock
@@ -74,7 +74,7 @@ describe('ReportCreateService', () => {
     personalStepBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `ps-${i}` })),
     )
-    deviationBulkCreate = jest.fn(async (rows) =>
+    outlierBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `dev-${i}` })),
     )
     criterionCreate = jest.fn(async (input) => ({ ...input, id: `cri-${Date.now()}-${Math.random()}` }))
@@ -120,8 +120,8 @@ describe('ReportCreateService', () => {
           useValue: { bulkCreate: personalStepBulkCreate },
         },
         {
-          provide: getModelToken(ReportEmployeeDeviationModel),
-          useValue: { bulkCreate: deviationBulkCreate },
+          provide: getModelToken(ReportEmployeeOutlierModel),
+          useValue: { bulkCreate: outlierBulkCreate },
         },
         {
           provide: getModelToken(ReportCriterionModel),
@@ -289,18 +289,18 @@ describe('ReportCreateService', () => {
     expect(reportEventCreate).not.toHaveBeenCalled()
   })
 
-  it('skips the deviation insert when none are flagged', async () => {
+  it('skips the outlier insert when none are flagged', async () => {
     const input = makeInput()
-    input.deviations = []
+    input.outliers = []
 
     await service.createSalary(input)
 
-    expect(deviationBulkCreate).not.toHaveBeenCalled()
+    expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
-  it('persists deviations resolving employeeOrdinal to the new employee id', async () => {
+  it('persists outliers resolving employeeOrdinal to the new employee id', async () => {
     const input = makeInput()
-    input.deviations = [
+    input.outliers = [
       {
         employeeOrdinal: 1,
         reason: 'On parental leave for 6 months',
@@ -312,8 +312,8 @@ describe('ReportCreateService', () => {
 
     await service.createSalary(input)
 
-    expect(deviationBulkCreate).toHaveBeenCalledTimes(1)
-    expect(deviationBulkCreate.mock.calls[0][0]).toEqual([
+    expect(outlierBulkCreate).toHaveBeenCalledTimes(1)
+    expect(outlierBulkCreate.mock.calls[0][0]).toEqual([
       expect.objectContaining({
         reportEmployeeId: 'emp-0',
         reason: 'On parental leave for 6 months',
@@ -324,9 +324,9 @@ describe('ReportCreateService', () => {
     ])
   })
 
-  it('rejects deviations referencing an unknown employee ordinal', async () => {
+  it('rejects outliers referencing an unknown employee ordinal', async () => {
     const input = makeInput()
-    input.deviations = [
+    input.outliers = [
       {
         employeeOrdinal: 999,
         reason: 'r',
@@ -338,7 +338,7 @@ describe('ReportCreateService', () => {
 
     await expect(service.createSalary(input)).rejects.toThrow(BadRequestException)
     expect(reportCreate).not.toHaveBeenCalled()
-    expect(deviationBulkCreate).not.toHaveBeenCalled()
+    expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
   // ── createEquality path ────────────────────────────────────────────

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -24,7 +24,7 @@ import { ReportCriterionModel } from '../report-criterion/models/report-criterio
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
@@ -62,8 +62,8 @@ export class ReportCreateService implements IReportCreateService {
     private readonly roleStepModel: typeof ReportEmployeeRoleCriterionStepModel,
     @InjectModel(ReportEmployeePersonalCriterionStepModel)
     private readonly personalStepModel: typeof ReportEmployeePersonalCriterionStepModel,
-    @InjectModel(ReportEmployeeDeviationModel)
-    private readonly reportEmployeeDeviationModel: typeof ReportEmployeeDeviationModel,
+    @InjectModel(ReportEmployeeOutlierModel)
+    private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
     @InjectModel(ReportCriterionModel)
     private readonly reportCriterionModel: typeof ReportCriterionModel,
     @InjectModel(ReportSubCriterionModel)
@@ -89,7 +89,7 @@ export class ReportCreateService implements IReportCreateService {
   ): Promise<CreateReportResponseDto> {
     const stepScoreByKey = this.assertParsedPayloadIntegrity(input.parsed)
     const employeeScores = this.computeEmployeeScores(input.parsed, stepScoreByKey)
-    this.assertDeviationsReferenceParsedEmployees(input)
+    this.assertOutliersReferenceParsedEmployees(input)
 
     await this.assertEqualityReportApproved(input.equalityReportId)
 
@@ -237,24 +237,24 @@ export class ReportCreateService implements IReportCreateService {
       await this.personalStepModel.bulkCreate(personalStepRows)
     }
 
-    // 8. Salary-outlier deviations — only employees the company flagged
+    // 8. Salary outliers — only employees the company flagged
     //    via the outlier-preview flow get a row here.
-    if (input.deviations && input.deviations.length > 0) {
+    if (input.outliers && input.outliers.length > 0) {
       const employeeOrdinalToId = new Map<number, string>()
       input.parsed.employees.forEach((employee, index) => {
         employeeOrdinalToId.set(employee.ordinal, employeeRows[index].id)
       })
 
-      await this.reportEmployeeDeviationModel.bulkCreate(
-        input.deviations.map((deviation) => ({
+      await this.reportEmployeeOutlierModel.bulkCreate(
+        input.outliers.map((outlier) => ({
           // Pre-flight already verified every ordinal resolves.
           reportEmployeeId: employeeOrdinalToId.get(
-            deviation.employeeOrdinal,
+            outlier.employeeOrdinal,
           ) as string,
-          reason: deviation.reason,
-          action: deviation.action,
-          signatureName: deviation.signatureName,
-          signatureRole: deviation.signatureRole,
+          reason: outlier.reason,
+          action: outlier.action,
+          signatureName: outlier.signatureName,
+          signatureRole: outlier.signatureRole,
         })),
       )
     }
@@ -432,20 +432,20 @@ export class ReportCreateService implements IReportCreateService {
   }
 
   /**
-   * Each `deviations[].employeeOrdinal` must match an `ordinal` in the parsed
+   * Each `outliers[].employeeOrdinal` must match an `ordinal` in the parsed
    * employees array. Outlier detection is the application's responsibility
    * (planned outlier-preview endpoint — see `db/README.md` Notes); this
    * service trusts the caller's flagging but rejects orphan references.
    */
-  private assertDeviationsReferenceParsedEmployees(input: CreateReportDto) {
-    if (!input.deviations || input.deviations.length === 0) {
+  private assertOutliersReferenceParsedEmployees(input: CreateReportDto) {
+    if (!input.outliers || input.outliers.length === 0) {
       return
     }
     const knownOrdinals = new Set(input.parsed.employees.map((e) => e.ordinal))
-    for (const deviation of input.deviations) {
-      if (!knownOrdinals.has(deviation.employeeOrdinal)) {
+    for (const outlier of input.outliers) {
+      if (!knownOrdinals.has(outlier.employeeOrdinal)) {
         throw new BadRequestException(
-          `Deviation references unknown employee ordinal ${deviation.employeeOrdinal}`,
+          `Outlier references unknown employee ordinal ${outlier.employeeOrdinal}`,
         )
       }
     }

--- a/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
@@ -1,6 +1,6 @@
 import { ApiString, ApiUUId } from '@dmr.is/decorators'
 
-export class ReportEmployeeDeviationDto {
+export class ReportEmployeeOutlierDto {
   @ApiUUId()
   id!: string
 

--- a/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
@@ -3,10 +3,10 @@ import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
 import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 
 import { DoeModels } from '../../../core/constants'
-import type { ReportEmployeeDeviationDto } from '../dto/report-employee-deviation.dto'
+import type { ReportEmployeeOutlierDto } from '../dto/report-employee-outlier.dto'
 import { ReportEmployeeModel } from './report-employee.model'
 
-type ReportEmployeeDeviationAttributes = {
+type ReportEmployeeOutlierAttributes = {
   reportEmployeeId: string
   reason: string
   action: string
@@ -14,12 +14,12 @@ type ReportEmployeeDeviationAttributes = {
   signatureRole: string
 }
 
-type ReportEmployeeDeviationCreateAttributes = ReportEmployeeDeviationAttributes
+type ReportEmployeeOutlierCreateAttributes = ReportEmployeeOutlierAttributes
 
-@MutableTable({ tableName: DoeModels.REPORT_EMPLOYEE_DEVIATION })
-export class ReportEmployeeDeviationModel extends MutableModel<
-  ReportEmployeeDeviationAttributes,
-  ReportEmployeeDeviationCreateAttributes
+@MutableTable({ tableName: DoeModels.REPORT_EMPLOYEE_OUTLIER })
+export class ReportEmployeeOutlierModel extends MutableModel<
+  ReportEmployeeOutlierAttributes,
+  ReportEmployeeOutlierCreateAttributes
 > {
   @ForeignKey(() => ReportEmployeeModel)
   @Column({
@@ -48,8 +48,8 @@ export class ReportEmployeeDeviationModel extends MutableModel<
   reportEmployee?: ReportEmployeeModel
 
   static fromModel(
-    model: ReportEmployeeDeviationModel,
-  ): ReportEmployeeDeviationDto {
+    model: ReportEmployeeOutlierModel,
+  ): ReportEmployeeOutlierDto {
     return {
       id: model.id,
       reportEmployeeId: model.reportEmployeeId,
@@ -60,7 +60,7 @@ export class ReportEmployeeDeviationModel extends MutableModel<
     }
   }
 
-  fromModel(): ReportEmployeeDeviationDto {
-    return ReportEmployeeDeviationModel.fromModel(this)
+  fromModel(): ReportEmployeeOutlierDto {
+    return ReportEmployeeOutlierModel.fromModel(this)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/report-excel/README.md
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/README.md
@@ -107,4 +107,4 @@ report-excel/
   `@CurrentUser()` is wired back to extract company context from the token.
 - **Export**: `GET /reports/:id/export` deferred — needs persisted reports
   to exist first (future `/reports` endpoint).
-- **Deviations**: handled post-scoring on the `/reports` side, not here.
+- **Outliers**: handled post-scoring on the `/reports` side, not here.

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
@@ -1,7 +1,7 @@
 import { ApiDto, ApiDtoArray, ApiOptionalDto } from '@dmr.is/decorators'
 
 import { CompanyReportDto } from '../../company/dto/company-report.dto'
-import { ReportEmployeeDeviationDto } from '../../report-employee/dto/report-employee-deviation.dto'
+import { ReportEmployeeOutlierDto } from '../../report-employee/dto/report-employee-outlier.dto'
 import { ReportResultDto } from '../../report-result/dto/report-result.dto'
 import { ReportRoleResultDto } from '../../report-result/dto/report-role-result.dto'
 import { EqualityReportDto } from './equality-report.dto'
@@ -27,11 +27,11 @@ import { ReportTimelineItemDto } from './report-timeline-item.dto'
  *   (`EVENT` | `COMMENT`) and exactly one of `event` / `comment`
  *   populated. Paranoid-deleted comments are excluded.
  *
- * - `result` / `roleResults` / `employeeDeviations`: salary-only calculation
+ * - `result` / `roleResults` / `employeeOutliers`: salary-only calculation
  *   outputs. For equality reports these are `null` / `[]`; for salary reports
  *   they're populated once the scoring engine has run. The UI uses them to
  *   render the Launagreining charts: `result` → gender-gap summary, `roleResults`
- *   → scatter-plot points per role, `employeeDeviations` → the Úrbótaáætlun
+ *   → scatter-plot points per role, `employeeOutliers` → the Úrbótaáætlun
  *   table listing employees who fall outside the acceptable pay-gap threshold.
  */
 export class ReportDetailDto extends ReportDto {
@@ -50,6 +50,6 @@ export class ReportDetailDto extends ReportDto {
   @ApiDtoArray(ReportRoleResultDto)
   roleResults!: ReportRoleResultDto[]
 
-  @ApiDtoArray(ReportEmployeeDeviationDto)
-  employeeDeviations!: ReportEmployeeDeviationDto[]
+  @ApiDtoArray(ReportEmployeeOutlierDto)
+  employeeOutliers!: ReportEmployeeOutlierDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
@@ -1,7 +1,7 @@
 import { GenderEnum } from '../models/report.model'
 import {
-  assessSalaryDeviationFromReference,
-  assessSalaryDeviationInBucket,
+  assessSalaryOutlierFromReference,
+  assessSalaryOutlierInBucket,
   computeCompensationAggregates,
   computeSalaryAggregateSnapshot,
   roundSalaryAggregateSnapshot,
@@ -237,34 +237,34 @@ describe('compensation-aggregates', () => {
     })
   })
 
-  it('marks salaries outside half the threshold from a reference as deviations', () => {
+  it('marks salaries outside half the threshold from a reference as outliers', () => {
     expect(
-      assessSalaryDeviationFromReference({
+      assessSalaryOutlierFromReference({
         salary: 102000,
         referenceSalary: 100000,
         thresholdPercent: 3.9,
       }),
     ).toMatchObject({
-      isDeviation: true,
+      isOutlier: true,
       direction: 'ABOVE',
       allowedDifferencePercent: 1.95,
       referenceSalary: 100000,
     })
 
     expect(
-      assessSalaryDeviationFromReference({
+      assessSalaryOutlierFromReference({
         salary: 98100,
         referenceSalary: 100000,
         thresholdPercent: 3.9,
       }),
     ).toMatchObject({
-      isDeviation: false,
+      isOutlier: false,
       direction: 'BELOW',
       allowedDifferencePercent: 1.95,
     })
   })
 
-  it('assesses salary deviation against a score bucket median', () => {
+  it('assesses salary outlier against a score bucket median', () => {
     const aggregates = computeCompensationAggregates({
       employees: [
         {
@@ -300,13 +300,13 @@ describe('compensation-aggregates', () => {
     const bucket = aggregates.report.base.scoreBuckets[0]
 
     expect(
-      assessSalaryDeviationInBucket({
+      assessSalaryOutlierInBucket({
         salary: 104000,
         bucket,
         thresholdPercent: 3.9,
       }),
     ).toMatchObject({
-      isDeviation: false,
+      isOutlier: false,
       direction: 'EQUAL',
       referenceSalary: 104000,
     })

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
@@ -62,11 +62,11 @@ export type SalaryResultSnapshot = {
   scoreBuckets: SalaryScoreBucketSnapshot[]
 }
 
-export type SalaryDeviationDirection = 'ABOVE' | 'BELOW' | 'EQUAL'
+export type SalaryOutlierDirection = 'ABOVE' | 'BELOW' | 'EQUAL'
 
-export type SalaryDeviationAssessment = {
-  isDeviation: boolean
-  direction: SalaryDeviationDirection | null
+export type SalaryOutlierAssessment = {
+  isOutlier: boolean
+  direction: SalaryOutlierDirection | null
   differencePercent: number | null
   allowedDifferencePercent: number
   referenceSalary: number | null
@@ -266,12 +266,12 @@ export function roundSalaryResultSnapshot(
   }
 }
 
-export function assessSalaryDeviationFromReference(input: {
+export function assessSalaryOutlierFromReference(input: {
   salary: number
   referenceSalary: number | null
   thresholdPercent: number
   useHalfThreshold?: boolean
-}): SalaryDeviationAssessment {
+}): SalaryOutlierAssessment {
   const allowedDifferencePercent =
     input.useHalfThreshold === false
       ? input.thresholdPercent
@@ -279,7 +279,7 @@ export function assessSalaryDeviationFromReference(input: {
 
   if (input.referenceSalary === null || input.referenceSalary === 0) {
     return {
-      isDeviation: false,
+      isOutlier: false,
       direction: null,
       differencePercent: null,
       allowedDifferencePercent,
@@ -292,8 +292,8 @@ export function assessSalaryDeviationFromReference(input: {
   const absoluteDifferencePercent = Math.abs(differencePercent)
 
   return {
-    isDeviation: absoluteDifferencePercent >= allowedDifferencePercent,
-    direction: getSalaryDeviationDirection(differencePercent),
+    isOutlier: absoluteDifferencePercent >= allowedDifferencePercent,
+    direction: getSalaryOutlierDirection(differencePercent),
     differencePercent,
     allowedDifferencePercent,
     referenceSalary: input.referenceSalary,
@@ -301,22 +301,22 @@ export function assessSalaryDeviationFromReference(input: {
 }
 
 /**
- * Salary deviation/outlier rule for a score bucket:
+ * Salary outlier rule for a score bucket:
  *
  * 1. Place the employee in a score bucket.
  * 2. Use the bucket's overall median salary as the reference salary.
  * 3. Use half of the configured salary-difference threshold by default.
  *    Example: `3.9` becomes an allowed +/- `1.95%` band around the median.
- * 4. Mark the employee as a deviation when their adjusted salary is greater
+ * 4. Mark the employee as an outlier when their adjusted salary is greater
  *    than or equal to that allowed percentage above or below the bucket median.
  */
-export function assessSalaryDeviationInBucket(input: {
+export function assessSalaryOutlierInBucket(input: {
   salary: number
   bucket: SalaryScoreBucketSnapshot
   thresholdPercent: number
   useHalfThreshold?: boolean
-}): SalaryDeviationAssessment {
-  return assessSalaryDeviationFromReference({
+}): SalaryOutlierAssessment {
+  return assessSalaryOutlierFromReference({
     salary: input.salary,
     referenceSalary: input.bucket.totals.overall.median,
     thresholdPercent: input.thresholdPercent,
@@ -389,9 +389,9 @@ function countSamplesByCohort(
   }
 }
 
-function getSalaryDeviationDirection(
+function getSalaryOutlierDirection(
   differencePercent: number,
-): SalaryDeviationDirection {
+): SalaryOutlierDirection {
   if (differencePercent > 0) {
     return 'ABOVE'
   }

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -128,7 +128,7 @@ type ReportCreateAttributes = {
         order: [['createdAt', 'DESC']],
       },
       // Salary-only aggregate — null for equality reports. Per-role
-      // breakdown + employee deviations are loaded via separate queries
+      // breakdown + employee outliers are loaded via separate queries
       // in the service (keyed off `result.id` and `report.id`) to avoid
       // modifying the report-result / report-employee modules owned by
       // teammates.

--- a/apps/directorate-of-equality-api/src/modules/report/report.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.module.ts
@@ -3,7 +3,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportResultModel } from '../report-result/models/report-result.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { UserModel } from '../user/models/user.model'
@@ -25,7 +25,7 @@ import { IReportService } from './report.service.interface'
       ReportResultModel,
       ReportRoleResultModel,
       ReportEmployeeModel,
-      ReportEmployeeDeviationModel,
+      ReportEmployeeOutlierModel,
     ]),
   ],
   controllers: [ReportController],

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -87,30 +87,30 @@ const makeService = () => {
   // paths don't touch them and salary paths return predictable zero-value
   // outputs unless a test overrides.
   const roleResultFindAll = jest.fn().mockResolvedValue([])
-  const deviationFindAll = jest.fn().mockResolvedValue([])
+  const outlierFindAll = jest.fn().mockResolvedValue([])
   const reportEventModel = {
     findAll: jest.fn().mockResolvedValue([]),
   } as unknown as typeof import('./models/report-event.model').ReportEventModel
   const reportRoleResultModel = {
     findAll: roleResultFindAll,
   } as unknown as typeof import('../report-result/models/report-role-result.model').ReportRoleResultModel
-  const reportEmployeeDeviationModel = {
-    findAll: deviationFindAll,
-  } as unknown as typeof import('../report-employee/models/report-employee-deviation.model').ReportEmployeeDeviationModel
+  const reportEmployeeOutlierModel = {
+    findAll: outlierFindAll,
+  } as unknown as typeof import('../report-employee/models/report-employee-outlier.model').ReportEmployeeOutlierModel
 
   const service = new ReportService(
     logger,
     reportModel,
     reportEventModel,
     reportRoleResultModel,
-    reportEmployeeDeviationModel,
+    reportEmployeeOutlierModel,
   )
   return {
     service,
     findAndCountAll,
     findByPkOrThrow,
     roleResultFindAll,
-    deviationFindAll,
+    outlierFindAll,
     logger,
   }
 }
@@ -558,8 +558,8 @@ describe('ReportService.getById', () => {
   })
 
   describe('salary calculations', () => {
-    it('returns null/empty calc blocks for equality reports without querying role results or deviations', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, deviationFindAll } =
+    it('returns null/empty calc blocks for equality reports without querying role results or outliers', async () => {
+      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
         makeService()
       findByPkOrThrow.mockResolvedValueOnce(
         makeDetailedReportRow({
@@ -572,13 +572,13 @@ describe('ReportService.getById', () => {
 
       expect(detail.result).toBeNull()
       expect(detail.roleResults).toEqual([])
-      expect(detail.employeeDeviations).toEqual([])
+      expect(detail.employeeOutliers).toEqual([])
       expect(roleResultFindAll).not.toHaveBeenCalled()
-      expect(deviationFindAll).not.toHaveBeenCalled()
+      expect(outlierFindAll).not.toHaveBeenCalled()
     })
 
     it('returns null/empty calc blocks for salary reports before scoring has run (result missing)', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, deviationFindAll } =
+      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
         makeService()
       findByPkOrThrow.mockResolvedValueOnce(
         makeDetailedReportRow({
@@ -599,13 +599,13 @@ describe('ReportService.getById', () => {
 
       expect(detail.result).toBeNull()
       expect(detail.roleResults).toEqual([])
-      expect(detail.employeeDeviations).toEqual([])
+      expect(detail.employeeOutliers).toEqual([])
       expect(roleResultFindAll).not.toHaveBeenCalled()
-      expect(deviationFindAll).not.toHaveBeenCalled()
+      expect(outlierFindAll).not.toHaveBeenCalled()
     })
 
-    it('loads role results and employee deviations when result exists on salary report', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, deviationFindAll } =
+    it('loads role results and employee outliers when result exists on salary report', async () => {
+      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
         makeService()
 
       const resultId = '00000000-0000-0000-0000-000000000111'
@@ -664,7 +664,7 @@ describe('ReportService.getById', () => {
         maximumFemaleSalary: 1200,
         maximumNeutralSalary: 0,
       })
-      const deviationRow = withFromModel({
+      const outlierRow = withFromModel({
         id: 'd1',
         reportEmployeeId: 'e1',
         reason: 'Seniority premium',
@@ -673,7 +673,7 @@ describe('ReportService.getById', () => {
         signatureRole: 'HR',
       })
       roleResultFindAll.mockResolvedValueOnce([roleResultRow])
-      deviationFindAll.mockResolvedValueOnce([deviationRow])
+      outlierFindAll.mockResolvedValueOnce([outlierRow])
 
       const detail = await service.getById(baseReport.id)
 
@@ -684,15 +684,15 @@ describe('ReportService.getById', () => {
       expect(detail.roleResults[0]).toEqual(
         expect.objectContaining({ reportResultId: resultId }),
       )
-      expect(detail.employeeDeviations).toHaveLength(1)
-      expect(detail.employeeDeviations[0]).toEqual(
+      expect(detail.employeeOutliers).toHaveLength(1)
+      expect(detail.employeeOutliers[0]).toEqual(
         expect.objectContaining({ reason: 'Seniority premium' }),
       )
 
       expect(roleResultFindAll).toHaveBeenCalledWith({
         where: { reportResultId: resultId },
       })
-      expect(deviationFindAll).toHaveBeenCalledWith(
+      expect(outlierFindAll).toHaveBeenCalledWith(
         expect.objectContaining({
           include: expect.any(Array),
         }),

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -29,7 +29,7 @@ import {
 
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeDeviationModel } from '../report-employee/models/report-employee-deviation.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { EqualityReportDto } from './dto/equality-report.dto'
 import {
@@ -66,8 +66,8 @@ export class ReportService implements IReportService {
     private readonly reportEventModel: typeof ReportEventModel,
     @InjectModel(ReportRoleResultModel)
     private readonly reportRoleResultModel: typeof ReportRoleResultModel,
-    @InjectModel(ReportEmployeeDeviationModel)
-    private readonly reportEmployeeDeviationModel: typeof ReportEmployeeDeviationModel,
+    @InjectModel(ReportEmployeeOutlierModel)
+    private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
   ) {}
 
   async list(query: GetReportsQueryDto): Promise<GetReportsResponseDto> {
@@ -140,7 +140,7 @@ export class ReportService implements IReportService {
       )
     }
 
-    const [{ result, roleResults, employeeDeviations }, timeline] =
+    const [{ result, roleResults, employeeOutliers }, timeline] =
       await Promise.all([
         this.loadSalaryCalculations(report),
         this.buildTimeline(id, report.comments ?? []),
@@ -153,7 +153,7 @@ export class ReportService implements IReportService {
       timeline,
       result,
       roleResults,
-      employeeDeviations,
+      employeeOutliers,
     }
   }
 
@@ -197,17 +197,17 @@ export class ReportService implements IReportService {
   private async loadSalaryCalculations(report: ReportModel): Promise<{
     result: ReportDetailDto['result']
     roleResults: ReportDetailDto['roleResults']
-    employeeDeviations: ReportDetailDto['employeeDeviations']
+    employeeOutliers: ReportDetailDto['employeeOutliers']
   }> {
     if (report.type !== ReportTypeEnum.SALARY || !report.result) {
-      return { result: null, roleResults: [], employeeDeviations: [] }
+      return { result: null, roleResults: [], employeeOutliers: [] }
     }
 
-    const [roleResultRows, deviationRows] = await Promise.all([
+    const [roleResultRows, outlierRows] = await Promise.all([
       this.reportRoleResultModel.findAll({
         where: { reportResultId: report.result.id },
       }),
-      this.reportEmployeeDeviationModel.findAll({
+      this.reportEmployeeOutlierModel.findAll({
         include: [
           {
             model: ReportEmployeeModel,
@@ -223,7 +223,7 @@ export class ReportService implements IReportService {
     return {
       result: report.result.fromModel(),
       roleResults: roleResultRows.map((r) => r.fromModel()),
-      employeeDeviations: deviationRows.map((d) => d.fromModel()),
+      employeeOutliers: outlierRows.map((d) => d.fromModel()),
     }
   }
 


### PR DESCRIPTION
Renamed the DOE salary “deviation” concept to “outlier” across the API, schema, docs, and tests

The employees captured by this flow are better described as salary outliers: they fall outside the accepted salary band and require justification. “Deviation” reads more like the numeric difference from a reference value, while “outlier” describes the employee/classification the business process is acting on