### PR TITLE
feat(doe): TRPC layer with HeyApi integration

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 
+import { ApiErrorDto } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { ConfigDto, UpdateConfigDto } from './dto/config.dto'
@@ -30,6 +31,7 @@ export class ConfigController {
   @Get()
   @ApiOperation({ operationId: 'getAllConfig' })
   @ApiResponse({ status: 200, type: [ConfigDto] })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   async getAll(): Promise<ConfigDto[]> {
     return this.configService.getAll()
   }
@@ -37,6 +39,8 @@ export class ConfigController {
   @Get(':key')
   @ApiOperation({ operationId: 'getConfigByKey' })
   @ApiResponse({ status: 200, type: ConfigDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async getByKey(@Param('key') key: string): Promise<ConfigDto> {
     return this.configService.getByKey(key)
   }
@@ -44,6 +48,8 @@ export class ConfigController {
   @Get(':key/history')
   @ApiOperation({ operationId: 'getConfigHistoryByKey' })
   @ApiResponse({ status: 200, type: [ConfigDto] })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async getHistoryByKey(@Param('key') key: string): Promise<ConfigDto[]> {
     return this.configService.getHistoryByKey(key)
   }
@@ -51,6 +57,9 @@ export class ConfigController {
   @Patch(':key')
   @ApiOperation({ operationId: 'updateConfigByKey' })
   @ApiResponse({ status: 200, type: ConfigDto })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async updateByKey(
     @Param('key') key: string,
     @Body() dto: UpdateConfigDto,

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
 
+import { ApiErrorDto } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { ReportResourceGuard } from '../../core/guards/report-resource/report-resource.guard'
@@ -37,6 +38,9 @@ export class ReportCommentController {
   @Get()
   @ApiOperation({ operationId: 'getReportComments' })
   @ApiResponse({ status: 200, type: [ReportCommentDto] })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async getByReportId(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<ReportCommentDto[]> {
@@ -46,6 +50,10 @@ export class ReportCommentController {
   @Post()
   @ApiOperation({ operationId: 'createReportComment' })
   @ApiResponse({ status: 201, type: ReportCommentDto })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async create(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Body() dto: CreateReportCommentDto,
@@ -58,6 +66,9 @@ export class ReportCommentController {
   @ApiOperation({ operationId: 'deleteReportComment' })
   @ApiParam({ name: 'commentId', type: String })
   @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async delete(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Param('commentId') commentId: string,

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger'
 
+import { ApiErrorDto } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
@@ -35,6 +36,9 @@ export class ReportWorkflowController {
   @HttpCode(204)
   @ApiOperation({ operationId: 'assignReport' })
   @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async assign(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -45,6 +49,10 @@ export class ReportWorkflowController {
   @HttpCode(204)
   @ApiOperation({ operationId: 'denyReport' })
   @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async deny(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Body() dto: DenyReportDto,
@@ -56,6 +64,9 @@ export class ReportWorkflowController {
   @HttpCode(204)
   @ApiOperation({ operationId: 'approveReport' })
   @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async approve(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -66,6 +77,9 @@ export class ReportWorkflowController {
   @HttpCode(204)
   @ApiOperation({ operationId: 'startReportFines' })
   @ApiResponse({ status: 204 })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async startFines(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -9,6 +9,7 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 
+import { ApiErrorDto } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
@@ -28,6 +29,8 @@ export class ReportController {
   @Get()
   @ApiOperation({ operationId: 'listReports' })
   @ApiResponse({ status: 200, type: GetReportsResponseDto })
+  @ApiResponse({ status: 400, type: ApiErrorDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
   async list(
     @Query() query: GetReportsQueryDto,
   ): Promise<GetReportsResponseDto> {
@@ -37,6 +40,8 @@ export class ReportController {
   @Get(':id')
   @ApiOperation({ operationId: 'getReportById' })
   @ApiResponse({ status: 200, type: ReportDetailDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async getById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<ReportDetailDto> {

--- a/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagg
 
 import { CurrentUser } from '@dmr.is/decorators'
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
+import { ApiErrorDto } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
@@ -24,6 +25,9 @@ export class UserController {
   @Get('me')
   @ApiOperation({ operationId: 'getMyUser' })
   @ApiResponse({ status: 200, type: UserDto })
+  @ApiResponse({ status: 401, type: ApiErrorDto })
+  @ApiResponse({ status: 403, type: ApiErrorDto })
+  @ApiResponse({ status: 404, type: ApiErrorDto })
   async getMyUser(@CurrentUser() user: DMRUser): Promise<UserDto> {
     return this.userService.getMyUser(user.nationalId)
   }

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -13,6 +13,30 @@
                 "schema": { "$ref": "#/components/schemas/UserDto" }
               }
             }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
           }
         },
         "security": [{ "bearer": [] }],
@@ -33,6 +57,14 @@
                   "type": "array",
                   "items": { "$ref": "#/components/schemas/ConfigDto" }
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
               }
             }
           }
@@ -59,6 +91,22 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ConfigDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
               }
             }
           }
@@ -93,6 +141,30 @@
                 "schema": { "$ref": "#/components/schemas/ConfigDto" }
               }
             }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
           }
         },
         "security": [{ "bearer": [] }],
@@ -120,6 +192,22 @@
                   "type": "array",
                   "items": { "$ref": "#/components/schemas/ConfigDto" }
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
               }
             }
           }
@@ -289,6 +377,22 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
           }
         },
         "security": [{ "bearer": [] }],
@@ -313,6 +417,22 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ReportDetailDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
               }
             }
           }
@@ -342,6 +462,30 @@
                   "type": "array",
                   "items": { "$ref": "#/components/schemas/ReportCommentDto" }
                 }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
               }
             }
           }
@@ -378,6 +522,38 @@
                 "schema": { "$ref": "#/components/schemas/ReportCommentDto" }
               }
             }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
           }
         },
         "security": [{ "bearer": [] }],
@@ -402,7 +578,33 @@
             "schema": { "type": "string" }
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
         "security": [{ "bearer": [] }],
         "summary": "",
         "tags": ["Report Comments"]
@@ -419,7 +621,33 @@
             "schema": { "type": "string" }
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
         "security": [{ "bearer": [] }],
         "summary": "",
         "tags": ["Report Workflow"]
@@ -444,7 +672,41 @@
             }
           }
         },
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
         "security": [{ "bearer": [] }],
         "summary": "",
         "tags": ["Report Workflow"]
@@ -461,7 +723,33 @@
             "schema": { "type": "string" }
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
         "security": [{ "bearer": [] }],
         "summary": "",
         "tags": ["Report Workflow"]
@@ -478,7 +766,33 @@
             "schema": { "type": "string" }
           }
         ],
-        "responses": { "204": { "description": "" } },
+        "responses": {
+          "204": { "description": "" },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
         "security": [{ "bearer": [] }],
         "summary": "",
         "tags": ["Report Workflow"]
@@ -517,6 +831,45 @@
           "email",
           "isActive"
         ]
+      },
+      "ApiErrorDto": {
+        "type": "object",
+        "properties": {
+          "statusCode": { "type": "number" },
+          "timestamp": { "type": "string" },
+          "name": {
+            "type": "string",
+            "enum": [
+              "NotFound",
+              "ValidationError",
+              "ForeignKeyConstraintError",
+              "UniqueConstraintError",
+              "TimeoutError",
+              "Unauthorized",
+              "Forbidden",
+              "BadRequest",
+              "InternalServerError",
+              "ConnectionAcquireTimeoutError",
+              "UnknownError"
+            ],
+            "example": [
+              "NotFound",
+              "ValidationError",
+              "ForeignKeyConstraintError",
+              "UniqueConstraintError",
+              "TimeoutError",
+              "Unauthorized",
+              "Forbidden",
+              "BadRequest",
+              "InternalServerError",
+              "ConnectionAcquireTimeoutError",
+              "UnknownError"
+            ]
+          },
+          "message": { "type": "string" },
+          "details": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["statusCode", "timestamp"]
       },
       "ConfigDto": {
         "type": "object",
@@ -945,7 +1298,7 @@
           "full"
         ]
       },
-      "ReportEmployeeDeviationDto": {
+      "ReportEmployeeOutlierDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "format": "uuid" },
@@ -1049,11 +1402,9 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/ReportRoleResultDto" }
           },
-          "employeeDeviations": {
+          "employeeOutliers": {
             "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ReportEmployeeDeviationDto"
-            }
+            "items": { "$ref": "#/components/schemas/ReportEmployeeOutlierDto" }
           }
         },
         "required": [
@@ -1065,7 +1416,7 @@
           "equalityReport",
           "timeline",
           "roleResults",
-          "employeeDeviations"
+          "employeeOutliers"
         ]
       },
       "CreateReportCommentDto": {

--- a/apps/directorate-of-equality-web/next-env.d.ts
+++ b/apps/directorate-of-equality-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/directorate-of-equality-web/openapi-ts.config.ts
+++ b/apps/directorate-of-equality-web/openapi-ts.config.ts
@@ -7,11 +7,12 @@ export default defineConfig({
     clean: true,
   },
   plugins: [
+    'zod',
     '@hey-api/client-fetch',
+    '@hey-api/sdk',
     {
       name: '@hey-api/typescript',
-      enums: 'typescript',
+      enums: 'javascript',
     },
-    '@hey-api/sdk',
   ],
 })

--- a/apps/directorate-of-equality-web/src/lib/api/apiCall.ts
+++ b/apps/directorate-of-equality-web/src/lib/api/apiCall.ts
@@ -1,7 +1,0 @@
-export async function apiCall<T>(
-  result: Promise<{ data?: T; error?: unknown; response?: Response }>,
-): Promise<T> {
-  const { data, error, response } = await result
-  if (error !== undefined) throw response ?? error
-  return data as T
-}

--- a/apps/directorate-of-equality-web/src/lib/api/createClient.ts
+++ b/apps/directorate-of-equality-web/src/lib/api/createClient.ts
@@ -11,6 +11,7 @@ export const getDoEClient = (token: string): Client => {
     createConfig({
       baseUrl: getBaseUrl(),
       auth: token,
+      throwOnError: true,
     }),
   )
 }

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/configRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/configRouter.ts
@@ -1,50 +1,36 @@
-import { z } from 'zod'
-
 import {
-  getAllConfig,
-  getConfigByKey,
-  getConfigHistoryByKey,
-  updateConfigByKey,
-} from '../../../../gen/fetch'
-import { apiCall } from '../../../api/apiCall'
+  zGetConfigByKeyPath,
+  zGetConfigHistoryByKeyPath,
+  zUpdateConfigByKeyBody,
+  zUpdateConfigByKeyPath,
+} from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
 
 export const configRouter = router({
-  getAll: protectedProcedure.query(async ({ ctx }) => {
-    return apiCall(getAllConfig({ client: ctx.client }))
-  }),
+  getAll: protectedProcedure.query(({ ctx }) => ctx.api.getAllConfig()),
 
   getByKey: protectedProcedure
-    .input(z.object({ key: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return apiCall(
-        getConfigByKey({ client: ctx.client, path: { key: input.key } }),
-      )
-    }),
+    .input(zGetConfigByKeyPath)
+    .query(({ ctx, input }) =>
+      ctx.api.getConfigByKey({
+        path: { key: input.key },
+      }),
+    ),
 
   updateByKey: protectedProcedure
-    .input(
-      z.object({
-        key: z.string(),
-        value: z.string(),
-        description: z.string().nullish(),
+    .input(zUpdateConfigByKeyPath.extend(zUpdateConfigByKeyBody.shape))
+    .mutation(({ ctx, input }) =>
+      ctx.api.updateConfigByKey({
+        path: { key: input.key },
+        body: { value: input.value, description: input.description },
       }),
-    )
-    .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        updateConfigByKey({
-          client: ctx.client,
-          path: { key: input.key },
-          body: { value: input.value, description: input.description },
-        }),
-      )
-    }),
+    ),
 
   getHistoryByKey: protectedProcedure
-    .input(z.object({ key: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return apiCall(
-        getConfigHistoryByKey({ client: ctx.client, path: { key: input.key } }),
-      )
-    }),
+    .input(zGetConfigHistoryByKeyPath)
+    .query(({ ctx, input }) =>
+      ctx.api.getConfigHistoryByKey({
+        path: { key: input.key },
+      }),
+    ),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportCommentsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportCommentsRouter.ts
@@ -1,52 +1,37 @@
-import { z } from 'zod'
-
-import { CommentVisibilityEnum } from '../../../../gen/fetch'
 import {
-  createReportComment,
-  deleteReportComment,
-  getReportComments,
-} from '../../../../gen/fetch'
-import { apiCall } from '../../../api/apiCall'
+  zCreateReportCommentBody,
+  zCreateReportCommentPath,
+  zDeleteReportCommentPath,
+  zGetReportCommentsPath,
+} from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
 
 export const reportCommentsRouter = router({
   list: protectedProcedure
-    .input(z.object({ reportId: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return apiCall(
-        getReportComments({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-        }),
-      )
-    }),
+    .input(zGetReportCommentsPath)
+    .query(({ ctx, input }) =>
+      ctx.api.getReportComments({
+        path: { reportId: input.reportId },
+      }),
+    ),
 
   create: protectedProcedure
-    .input(
-      z.object({
-        reportId: z.string(),
-        visibility: z.nativeEnum(CommentVisibilityEnum),
-        body: z.string(),
+    .input(zCreateReportCommentPath.extend(zCreateReportCommentBody.shape))
+    .mutation(({ ctx, input }) =>
+      ctx.api.createReportComment({
+        path: { reportId: input.reportId },
+        body: {
+          visibility: input.visibility,
+          body: input.body,
+        },
       }),
-    )
-    .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        createReportComment({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-          body: { visibility: input.visibility, body: input.body },
-        }),
-      )
-    }),
+    ),
 
   delete: protectedProcedure
-    .input(z.object({ reportId: z.string(), commentId: z.string() }))
+    .input(zDeleteReportCommentPath)
     .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        deleteReportComment({
-          client: ctx.client,
-          path: { reportId: input.reportId, commentId: input.commentId },
-        }),
-      )
+      await ctx.api.deleteReportComment({
+        path: { reportId: input.reportId, commentId: input.commentId },
+      })
     }),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportWorkflowRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportWorkflowRouter.ts
@@ -1,57 +1,43 @@
-import { z } from 'zod'
-
 import {
-  approveReport,
-  assignReport,
-  denyReport,
-  startReportFines,
-} from '../../../../gen/fetch'
-import { apiCall } from '../../../api/apiCall'
+  zApproveReportPath,
+  zAssignReportPath,
+  zDenyReportBody,
+  zDenyReportPath,
+  zStartReportFinesPath,
+} from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
 
 export const reportWorkflowRouter = router({
   assign: protectedProcedure
-    .input(z.object({ reportId: z.string() }))
+    .input(zAssignReportPath)
     .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        assignReport({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-        }),
-      )
+      await ctx.api.assignReport({
+        path: { reportId: input.reportId },
+      })
     }),
 
   deny: protectedProcedure
-    .input(z.object({ reportId: z.string(), denialReason: z.string() }))
+    .input(zDenyReportPath.extend(zDenyReportBody.shape))
     .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        denyReport({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-          body: { denialReason: input.denialReason },
-        }),
-      )
+      await ctx.api.denyReport({
+        path: { reportId: input.reportId },
+        body: { denialReason: input.denialReason },
+      })
     }),
 
   approve: protectedProcedure
-    .input(z.object({ reportId: z.string() }))
+    .input(zApproveReportPath)
     .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        approveReport({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-        }),
-      )
+      await ctx.api.approveReport({
+        path: { reportId: input.reportId },
+      })
     }),
 
   startFines: protectedProcedure
-    .input(z.object({ reportId: z.string() }))
+    .input(zStartReportFinesPath)
     .mutation(async ({ ctx, input }) => {
-      return apiCall(
-        startReportFines({
-          client: ctx.client,
-          path: { reportId: input.reportId },
-        }),
-      )
+      await ctx.api.startReportFines({
+        path: { reportId: input.reportId },
+      })
     }),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
@@ -1,47 +1,25 @@
-import { z } from 'zod'
-
 import {
-  ReportSortByEnum,
-  ReportStatusEnum,
-  ReportTypeEnum,
-  SortDirectionEnum,
-} from '../../../../gen/fetch'
-import { getReportById, listReports } from '../../../../gen/fetch'
-import { apiCall } from '../../../api/apiCall'
+  zGetReportByIdPath,
+  zListReportsQuery,
+} from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
-
-const listReportsInput = z.object({
-  page: z.number().optional(),
-  pageSize: z.number().optional(),
-  type: z.array(z.nativeEnum(ReportTypeEnum)).optional(),
-  status: z.array(z.nativeEnum(ReportStatusEnum)).optional(),
-  reviewerUserId: z.array(z.string()).optional(),
-  unassignedReviewer: z.boolean().optional(),
-  createdFrom: z.string().optional(),
-  createdTo: z.string().optional(),
-  approvedFrom: z.string().optional(),
-  approvedTo: z.string().optional(),
-  validUntilFrom: z.string().optional(),
-  validUntilTo: z.string().optional(),
-  correctionDeadlineFrom: z.string().optional(),
-  correctionDeadlineTo: z.string().optional(),
-  q: z.string().optional(),
-  sortBy: z.nativeEnum(ReportSortByEnum).optional(),
-  direction: z.nativeEnum(SortDirectionEnum).optional(),
-})
 
 export const reportsRouter = router({
   list: protectedProcedure
-    .input(listReportsInput.optional())
-    .query(async ({ ctx, input }) => {
-      return apiCall(listReports({ client: ctx.client, query: input }))
+    .input(zListReportsQuery.optional())
+    .query(({ ctx, input }) => {
+      const query = input
+        ? input
+        : undefined
+
+      return ctx.api.listReports({ query })
     }),
 
   getById: protectedProcedure
-    .input(z.object({ id: z.string() }))
-    .query(async ({ ctx, input }) => {
-      return apiCall(
-        getReportById({ client: ctx.client, path: { id: input.id } }),
-      )
-    }),
+    .input(zGetReportByIdPath)
+    .query(({ ctx, input }) =>
+      ctx.api.getReportById({
+        path: { id: input.id },
+      }),
+    ),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/userRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/userRouter.ts
@@ -1,9 +1,5 @@
-import { getMyUser } from '../../../../gen/fetch'
-import { apiCall } from '../../../api/apiCall'
 import { protectedProcedure, router } from '../trpc'
 
 export const userRouter = router({
-  getMyUser: protectedProcedure.query(async ({ ctx }) => {
-    return apiCall(getMyUser({ client: ctx.client }))
-  }),
+  getMyUser: protectedProcedure.query(({ ctx }) => ctx.api.getMyUser()),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/trpc.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/trpc.ts
@@ -4,10 +4,57 @@ import { cache } from 'react'
 
 import { apiErrorMiddleware } from '@dmr.is/trpc/utils/errorHandler'
 
+import type { Client } from '../../../gen/fetch/client'
+import * as doeApiSdk from '../../../gen/fetch/sdk.gen'
 import { getServerClient } from '../../api/serverClient'
 import { authOptions } from '../../auth/authOptions'
 
 import { initTRPC, TRPCError } from '@trpc/server'
+
+type SdkFunction = (...args: any[]) => any
+
+type DataResponse<T> = T extends Promise<infer TResult>
+  ? TResult extends { data: infer TData }
+    ? Promise<Exclude<TData, undefined>>
+    : Promise<TResult>
+  : T
+
+type BoundSdkOptions<T> = Omit<
+  T,
+  'client' | 'responseStyle' | 'throwOnError'
+>
+
+type BoundSdkFn<T extends SdkFunction> = Parameters<T> extends []
+  ? () => DataResponse<ReturnType<T>>
+  : undefined extends Parameters<T>[0]
+    ? (options?: BoundSdkOptions<NonNullable<Parameters<T>[0]>>) => DataResponse<ReturnType<T>>
+    : (options: BoundSdkOptions<Parameters<T>[0]>) => DataResponse<ReturnType<T>>
+
+type BoundSdk<T extends Record<string, SdkFunction>> = {
+  [K in keyof T]: BoundSdkFn<T[K]>
+}
+
+function bindSdk<T extends Record<string, SdkFunction>>(
+  client: Client,
+  sdk: T,
+): BoundSdk<T> {
+  return Object.fromEntries(
+    Object.entries(sdk).map(([key, fn]) => [
+      key,
+      async (options?: unknown) =>
+        fn(
+          options === undefined
+            ? { client, responseStyle: 'data', throwOnError: true }
+            : {
+                ...options,
+                client,
+                responseStyle: 'data',
+                throwOnError: true,
+              },
+        ),
+    ]),
+  ) as BoundSdk<T>
+}
 
 export const createTRPCContext = cache(async () => {
   const session = await getServerSession(authOptions)
@@ -18,8 +65,10 @@ export const createTRPCContext = cache(async () => {
     })
   }
 
+  const client = await getServerClient(session.idToken)
+
   return {
-    client: await getServerClient(session.idToken),
+    api: bindSdk(client, doeApiSdk),
   }
 })
 
@@ -56,14 +105,14 @@ export const publicProcedure = t.procedure.use(({ ctx, next }) => {
 
 export const protectedProcedure = publicProcedure
   .use(({ ctx, next }) => {
-    if (!ctx.client) {
+    if (!ctx.api) {
       throw new TRPCError({ code: 'UNAUTHORIZED' })
     }
 
     return next({
       ctx: {
         ...ctx,
-        client: ctx.client,
+        api: ctx.api,
       },
     })
   })

--- a/libs/shared/trpc/src/lib/utils/errorHandler.ts
+++ b/libs/shared/trpc/src/lib/utils/errorHandler.ts
@@ -98,6 +98,20 @@ function isTRPCError(
   return false
 }
 
+type ApiErrorShape = {
+  details?: string[]
+  message?: string
+  name?: string
+  statusCode: number
+}
+
+function isApiErrorDto(error: unknown): error is ApiErrorShape {
+  if (error === null || typeof error !== 'object') return false
+
+  const errorObj = error as Record<string, unknown>
+  return typeof errorObj.statusCode === 'number'
+}
+
 /**
  * Recursively search for a TRPCError in the error chain.
  * Handles cases where tanstack-query or other libraries wrap the error.
@@ -235,6 +249,19 @@ export async function createTRPCError(error: unknown): Promise<ApiTRPCError> {
     })
   }
 
+  if (isApiErrorDto(error)) {
+    const trpcErrorCode =
+      HTTP_CODE_TO_TRPC_ERROR_CODE[
+        error.statusCode as keyof typeof HTTP_CODE_TO_TRPC_ERROR_CODE
+      ] ?? 'INTERNAL_SERVER_ERROR'
+
+    return new ApiTRPCError({
+      code: trpcErrorCode,
+      message: error.details?.[0] ?? error.message ?? `API Error (${error.statusCode})`,
+      cause: error,
+    })
+  }
+
   // Handle Response objects (thrown by OpenAPI client)
   if (isResponseLike(error)) {
     // Get status from Response (handles node-fetch symbol properties)
@@ -318,13 +345,15 @@ export const apiErrorMiddleware = async <T>(opts: {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   next: () => Promise<{ ok: boolean; error?: any; [key: string]: any }>
 }): Promise<T> => {
-  const result = await opts.next()
+  try {
+    const result = await opts.next()
 
-  if (!result.ok && result.error?.cause) {
-    // Extract status from Response internals in the cause
+    if (!result.ok && result.error?.cause) {
+      return { ...result, error: await createTRPCError(result.error.cause) } as T
+    }
 
-    return { ...result, error: await createTRPCError(result.error.cause) } as T
+    return result as T
+  } catch (error) {
+    throw await createTRPCError(error)
   }
-
-  return result as T
 }


### PR DESCRIPTION
## What

- Replaced inline `zod` router inputs with generated schemas from `apps/directorate-of-equality-web/src/gen/fetch/zod.gen.ts`.
- Bound the generated Hey API SDK to the authenticated request-scoped client in tRPC context as `ctx.api`.
- Changed the bound SDK to always use `throwOnError: true` and `responseStyle: 'data'`, so routers return payloads directly.
- Moved REST-to-tRPC error translation into the shared tRPC middleware and removed router-level error handling.
- Switched Hey API enum generation from `typescript` enums to `javascript` `as const` enums and regenerated the client.
- Removed enum casts/adapters from routers after aligning generated enum types with Zod output.
- Replaced router schema `.merge(...)` usage with `.extend(...shape)` where path/body inputs are flattened into a single tRPC input.

## Why

- Generated Zod schemas should be the source of truth for router inputs instead of duplicating request shapes inline.
- Binding the SDK in tRPC context removes repeated `client: ctx.client` boilerplate and keeps auth request-scoped.
- Returning raw data from `ctx.api` avoids the extra `{ data }` envelope in routers and downstream tRPC consumers.
- Centralized error handling makes router procedures simpler and ensures backend API errors become proper tRPC errors consistently.
- `typescript` enum generation caused a mismatch between SDK input types and Zod literal unions, which forced casts and adapter code.
- Switching enum generation mode fixes that mismatch at the codegen boundary, which is more maintainable than preserving conversion maps in app code.
