### PR TITLE
feat(doe): Seperated the swagger into internal & application documents

### DIFF
--- a/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
+++ b/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
@@ -17,6 +17,7 @@ type DoeResponseParams = {
   type?: any
   successDescription?: string
   errors?: number[]
+  include404?: boolean
 }
 
 export function DoeResponse({
@@ -26,15 +27,18 @@ export function DoeResponse({
   description,
   successDescription,
   errors = DEFAULT_ERRORS,
+  include404 = false,
 }: DoeResponseParams) {
   const successDecorator =
     type || successDescription
       ? ApiResponse({ status, type, description: successDescription })
       : ApiNoContentResponse()
 
+  const effectiveErrors = include404 ? [...errors, 404] : errors
+
   return applyDecorators(
     ApiOperation({ operationId, description }),
     successDecorator,
-    ...errors.map((code) => ApiResponse({ status: code, type: ApiErrorDto })),
+    ...effectiveErrors.map((code) => ApiResponse({ status: code, type: ApiErrorDto })),
   )
 }

--- a/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
+++ b/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
@@ -7,6 +7,8 @@ import {
 
 import { ApiErrorDto } from '@dmr.is/shared-dto'
 
+const DEFAULT_ERRORS = [400, 401, 403, 500]
+
 type DoeResponseParams = {
   operationId: string
   description?: string
@@ -14,6 +16,7 @@ type DoeResponseParams = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type?: any
   successDescription?: string
+  errors?: number[]
 }
 
 export function DoeResponse({
@@ -22,6 +25,7 @@ export function DoeResponse({
   type,
   description,
   successDescription,
+  errors = DEFAULT_ERRORS,
 }: DoeResponseParams) {
   const successDecorator =
     type || successDescription
@@ -31,10 +35,6 @@ export function DoeResponse({
   return applyDecorators(
     ApiOperation({ operationId, description }),
     successDecorator,
-    ApiResponse({ status: 400, type: ApiErrorDto }),
-    ApiResponse({ status: 401, type: ApiErrorDto }),
-    ApiResponse({ status: 403, type: ApiErrorDto }),
-    ApiResponse({ status: 404, type: ApiErrorDto }),
-    ApiResponse({ status: 500, type: ApiErrorDto }),
+    ...errors.map((code) => ApiResponse({ status: code, type: ApiErrorDto })),
   )
 }

--- a/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.spec.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.spec.ts
@@ -22,22 +22,15 @@ const createExecutionContext = (request: Record<string, unknown>) =>
   }) as never
 
 describe('AdminGuard', () => {
-  const logger = {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  }
-
-  const userModel = {
-    findOne: jest.fn(),
+  const authorizationService = {
+    resolveAdminUser: jest.fn(),
   }
 
   let guard: AdminGuard
 
   beforeEach(() => {
     jest.clearAllMocks()
-    guard = new AdminGuard(logger as never, userModel as never)
+    guard = new AdminGuard(authorizationService as never)
   })
 
   it('allows an active reviewer and attaches adminUser to the request', async () => {
@@ -46,15 +39,15 @@ describe('AdminGuard', () => {
       user: createUser('1201743399'),
     }
 
-    userModel.findOne.mockResolvedValue(reviewer)
+    authorizationService.resolveAdminUser.mockResolvedValue(reviewer)
 
     const allowed = await guard.canActivate(createExecutionContext(request))
 
     expect(allowed).toBe(true)
     expect(request.adminUser).toBe(reviewer)
-    expect(userModel.findOne).toHaveBeenCalledWith({
-      where: { nationalId: '1201743399', isActive: true },
-    })
+    expect(authorizationService.resolveAdminUser).toHaveBeenCalledWith(
+      '1201743399',
+    )
   })
 
   it('throws ForbiddenException when user is not in doe_user', async () => {
@@ -62,7 +55,9 @@ describe('AdminGuard', () => {
       user: createUser('9999999999'),
     }
 
-    userModel.findOne.mockResolvedValue(null)
+    authorizationService.resolveAdminUser.mockRejectedValue(
+      new ForbiddenException('Access restricted to DoE reviewers'),
+    )
 
     await expect(
       guard.canActivate(createExecutionContext(request)),
@@ -76,7 +71,9 @@ describe('AdminGuard', () => {
       user: createUser('1201743399'),
     }
 
-    userModel.findOne.mockResolvedValue(null)
+    authorizationService.resolveAdminUser.mockRejectedValue(
+      new ForbiddenException('Access restricted to DoE reviewers'),
+    )
 
     await expect(
       guard.canActivate(createExecutionContext(request)),

--- a/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
@@ -1,47 +1,24 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  ForbiddenException,
-  Inject,
-  Injectable,
-} from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
+import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common'
 
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
-import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
-import { UserModel } from '../../../modules/user/models/user.model'
-
-const LOGGING_CONTEXT = 'AdminGuard'
+import { IAuthorizationService } from '../../../modules/authorization/authorization.service.interface'
 
 @Injectable()
 export class AdminGuard implements CanActivate {
   constructor(
-    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
-    @InjectModel(UserModel)
-    private readonly userModel: typeof UserModel,
+    @Inject(IAuthorizationService)
+    private readonly authorizationService: IAuthorizationService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest()
     const user = request.user as DMRUser
 
-    const adminUser = await this.userModel.findOne({
-      where: { nationalId: user.nationalId, isActive: true },
-    })
+    request.adminUser = await this.authorizationService.resolveAdminUser(
+      user.nationalId,
+    )
 
-    if (!adminUser) {
-      this.logger.warn(
-        'Access denied — user not found in doe_user or inactive',
-        {
-          context: LOGGING_CONTEXT,
-          nationalId: user.nationalId,
-        },
-      )
-      throw new ForbiddenException('Access restricted to DoE reviewers')
-    }
-
-    request.adminUser = adminUser
     return true
   }
 }

--- a/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.spec.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.spec.ts
@@ -25,82 +25,56 @@ const createExecutionContext = (request: Record<string, unknown>) =>
   }) as never
 
 describe('ReportResourceGuard', () => {
-  const logger = {
-    debug: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-  }
-
-  const reportModel = {
-    findByPkOrThrow: jest.fn(),
-  }
-
-  const userModel = {
-    findOne: jest.fn(),
+  const authorizationService = {
+    resolveReportResourceContext: jest.fn(),
   }
 
   let guard: ReportResourceGuard
 
   beforeEach(() => {
     jest.clearAllMocks()
-    guard = new ReportResourceGuard(
-      logger as never,
-      reportModel as never,
-      userModel as never,
-    )
+    guard = new ReportResourceGuard(authorizationService as never)
   })
 
   it('attaches reviewer resource context to the request', async () => {
+    const context = {
+      reportId: 'report-1',
+      reportStatus: ReportStatusEnum.IN_REVIEW,
+      actor: { kind: ReportRoleEnum.REVIEWER, userId: 'reviewer-1' },
+    }
     const request: Record<string, unknown> = {
       params: { reportId: 'report-1' },
       user: createUser('1201743399'),
     }
 
-    reportModel.findByPkOrThrow.mockResolvedValue({
-      id: 'report-1',
-      status: ReportStatusEnum.IN_REVIEW,
-      companyNationalId: '9999999999',
-    })
-    userModel.findOne.mockResolvedValue({ id: 'reviewer-1' })
+    authorizationService.resolveReportResourceContext.mockResolvedValue(context)
 
     const allowed = await guard.canActivate(createExecutionContext(request))
 
     expect(allowed).toBe(true)
-    expect(request.reportResourceContext).toEqual({
-      reportId: 'report-1',
-      reportStatus: ReportStatusEnum.IN_REVIEW,
-      actor: {
-        kind: ReportRoleEnum.REVIEWER,
-        userId: 'reviewer-1',
-      },
-    })
+    expect(request.reportResourceContext).toBe(context)
+    expect(
+      authorizationService.resolveReportResourceContext,
+    ).toHaveBeenCalledWith('report-1', '1201743399')
   })
 
   it('attaches contact resource context when the report contact matches', async () => {
+    const context = {
+      reportId: 'report-1',
+      reportStatus: ReportStatusEnum.SUBMITTED,
+      actor: { kind: ReportRoleEnum.COMPANY, nationalId: '5500000000' },
+    }
     const request: Record<string, unknown> = {
       params: { reportId: 'report-1' },
       user: createUser('5500000000'),
     }
 
-    reportModel.findByPkOrThrow.mockResolvedValue({
-      id: 'report-1',
-      status: ReportStatusEnum.SUBMITTED,
-      companyNationalId: '5500000000',
-    })
-    userModel.findOne.mockResolvedValue(null)
+    authorizationService.resolveReportResourceContext.mockResolvedValue(context)
 
     const allowed = await guard.canActivate(createExecutionContext(request))
 
     expect(allowed).toBe(true)
-    expect(request.reportResourceContext).toEqual({
-      reportId: 'report-1',
-      reportStatus: ReportStatusEnum.SUBMITTED,
-      actor: {
-        kind: ReportRoleEnum.COMPANY,
-        nationalId: '5500000000',
-      },
-    })
+    expect(request.reportResourceContext).toBe(context)
   })
 
   it('rejects users without report access', async () => {
@@ -109,12 +83,9 @@ describe('ReportResourceGuard', () => {
       user: createUser('1201743399'),
     }
 
-    reportModel.findByPkOrThrow.mockResolvedValue({
-      id: 'report-1',
-      status: ReportStatusEnum.SUBMITTED,
-      companyNationalId: '5500000000',
-    })
-    userModel.findOne.mockResolvedValue(null)
+    authorizationService.resolveReportResourceContext.mockRejectedValue(
+      new ForbiddenException('Current user is not allowed to access this report'),
+    )
 
     await expect(
       guard.canActivate(createExecutionContext(request)),

--- a/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.ts
@@ -1,32 +1,14 @@
-import {
-  CanActivate,
-  ExecutionContext,
-  ForbiddenException,
-  Inject,
-  Injectable,
-} from '@nestjs/common'
-import { InjectModel } from '@nestjs/sequelize'
+import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common'
 
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
-import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
-import { ReportModel } from '../../../modules/report/models/report.model'
-import {
-  type ReportResourceContext,
-  ReportRoleEnum,
-} from '../../../modules/report/types/report-resource-context'
-import { UserModel } from '../../../modules/user/models/user.model'
-
-const LOGGING_CONTEXT = 'ReportResourceGuard'
+import { IAuthorizationService } from '../../../modules/authorization/authorization.service.interface'
 
 @Injectable()
 export class ReportResourceGuard implements CanActivate {
   constructor(
-    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
-    @InjectModel(ReportModel)
-    private readonly reportModel: typeof ReportModel,
-    @InjectModel(UserModel)
-    private readonly userModel: typeof UserModel,
+    @Inject(IAuthorizationService)
+    private readonly authorizationService: IAuthorizationService,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -34,52 +16,12 @@ export class ReportResourceGuard implements CanActivate {
     const user = request.user as DMRUser
     const reportId = request.params.reportId as string
 
-    const report = await this.reportModel.findByPkOrThrow(reportId)
-    const actor = await this.resolveActor(report, user)
-
-    request.reportResourceContext = {
-      reportId: report.id,
-      reportStatus: report.status,
-      actor,
-    } satisfies ReportResourceContext
+    request.reportResourceContext =
+      await this.authorizationService.resolveReportResourceContext(
+        reportId,
+        user.nationalId,
+      )
 
     return true
-  }
-
-  private async resolveActor(
-    report: ReportModel,
-    user: DMRUser,
-  ): Promise<ReportResourceContext['actor']> {
-    const reviewer = await this.userModel.findOne({
-      where: {
-        nationalId: user.nationalId,
-        isActive: true,
-      },
-    })
-
-    if (reviewer) {
-      return {
-        kind: ReportRoleEnum.REVIEWER,
-        userId: reviewer.id,
-      }
-    }
-
-    if (report.companyNationalId === user.nationalId) {
-      return {
-        kind: ReportRoleEnum.COMPANY,
-        nationalId: user.nationalId,
-      }
-    }
-
-    this.logger.warn('Current user is not allowed to access this report', {
-      context: LOGGING_CONTEXT,
-      reportId: report.id,
-      nationalId: user.nationalId,
-      reportCompanyNationalId: report.companyNationalId,
-    })
-
-    throw new ForbiddenException(
-      'Current user is not allowed to access this report',
-    )
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -127,7 +127,7 @@ export class ApplicationController {
   @Get('reports/equality/active')
   @DoeResponse({
     operationId: 'getApplicationActiveEqualityReport',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       "Returns the resolved company's currently-APPROVED equality report (if any). The application portal references the returned `id` as `equalityReportId` when submitting a salary report.",
     type: EqualityReportSummaryDto,
@@ -170,7 +170,7 @@ export class ApplicationController {
   @ApiParam({ name: 'reportId', type: String })
   @DoeResponse({
     operationId: 'getApplicationReport',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Returns company-facing report detail with external comments only.',
     type: ApplicationReportDetailDto,

--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -127,6 +127,7 @@ export class ApplicationController {
   @Get('reports/equality/active')
   @DoeResponse({
     operationId: 'getApplicationActiveEqualityReport',
+    errors: [400, 401, 403, 404, 500],
     description:
       "Returns the resolved company's currently-APPROVED equality report (if any). The application portal references the returned `id` as `equalityReportId` when submitting a salary report.",
     type: EqualityReportSummaryDto,
@@ -169,6 +170,7 @@ export class ApplicationController {
   @ApiParam({ name: 'reportId', type: String })
   @DoeResponse({
     operationId: 'getApplicationReport',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Returns company-facing report detail with external comments only.',
     type: ApplicationReportDetailDto,

--- a/apps/directorate-of-equality-api/src/modules/authorization/authorization.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/authorization/authorization.core.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { ReportModel } from '../report/models/report.model'
+import { UserModel } from '../user/models/user.model'
+import { AuthorizationService } from './authorization.service'
+import { IAuthorizationService } from './authorization.service.interface'
+
+@Module({
+  imports: [SequelizeModule.forFeature([ReportModel, UserModel])],
+  providers: [
+    {
+      provide: IAuthorizationService,
+      useClass: AuthorizationService,
+    },
+  ],
+  exports: [IAuthorizationService],
+})
+export class AuthorizationCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/authorization/authorization.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/authorization/authorization.service.interface.ts
@@ -1,0 +1,13 @@
+import { ReportResourceContext } from '../report/types/report-resource-context'
+import { UserModel } from '../user/models/user.model'
+
+export interface IAuthorizationService {
+  resolveReportResourceContext(
+    reportId: string,
+    nationalId: string,
+  ): Promise<ReportResourceContext>
+
+  resolveAdminUser(nationalId: string): Promise<UserModel>
+}
+
+export const IAuthorizationService = Symbol('IAuthorizationService')

--- a/apps/directorate-of-equality-api/src/modules/authorization/authorization.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/authorization/authorization.service.ts
@@ -1,0 +1,82 @@
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { ReportModel } from '../report/models/report.model'
+import {
+  ReportResourceContext,
+  ReportRoleEnum,
+} from '../report/types/report-resource-context'
+import { UserModel } from '../user/models/user.model'
+import { IAuthorizationService } from './authorization.service.interface'
+
+const LOGGING_CONTEXT = 'AuthorizationService'
+
+@Injectable()
+export class AuthorizationService implements IAuthorizationService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(ReportModel)
+    private readonly reportModel: typeof ReportModel,
+    @InjectModel(UserModel)
+    private readonly userModel: typeof UserModel,
+  ) {}
+
+  async resolveReportResourceContext(
+    reportId: string,
+    nationalId: string,
+  ): Promise<ReportResourceContext> {
+    const report = await this.reportModel.findByPkOrThrow(reportId)
+
+    const reviewer = await this.userModel.findOne({
+      where: { nationalId, isActive: true },
+    })
+
+    if (reviewer) {
+      return {
+        reportId: report.id,
+        reportStatus: report.status,
+        actor: { kind: ReportRoleEnum.REVIEWER, userId: reviewer.id },
+      }
+    }
+
+    if (report.companyNationalId === nationalId) {
+      return {
+        reportId: report.id,
+        reportStatus: report.status,
+        actor: { kind: ReportRoleEnum.COMPANY, nationalId },
+      }
+    }
+
+    this.logger.warn('Current user is not allowed to access this report', {
+      context: LOGGING_CONTEXT,
+      reportId: report.id,
+      nationalId,
+      reportCompanyNationalId: report.companyNationalId,
+    })
+
+    throw new ForbiddenException(
+      'Current user is not allowed to access this report',
+    )
+  }
+
+  async resolveAdminUser(nationalId: string): Promise<UserModel> {
+    const adminUser = await this.userModel.findOne({
+      where: { nationalId, isActive: true },
+    })
+
+    if (!adminUser) {
+      this.logger.warn(
+        'Access denied — user not found in doe_user or inactive',
+        {
+          context: LOGGING_CONTEXT,
+          nationalId,
+        },
+      )
+      throw new ForbiddenException('Access restricted to DoE reviewers')
+    }
+
+    return adminUser
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/config/config.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/config/config.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ConfigController } from './config.controller'
 import { ConfigCoreModule } from './config.core.module'
 
 @Module({
-  imports: [ConfigCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [ConfigCoreModule, AuthorizationCoreModule],
   controllers: [ConfigController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
@@ -36,19 +36,19 @@ export class ConfigController {
   }
 
   @Get(':key')
-  @DoeResponse({ operationId: 'getConfigByKey', type: ConfigDto })
+  @DoeResponse({ operationId: 'getConfigByKey', type: ConfigDto, errors: [400, 401, 403, 404, 500] })
   async getByKey(@Param('key') key: string): Promise<ConfigDto> {
     return this.configService.getByKey(key)
   }
 
   @Get(':key/history')
-  @DoeResponse({ operationId: 'getConfigHistoryByKey', type: [ConfigDto] })
+  @DoeResponse({ operationId: 'getConfigHistoryByKey', type: [ConfigDto], errors: [400, 401, 403, 404, 500] })
   async getHistoryByKey(@Param('key') key: string): Promise<ConfigDto[]> {
     return this.configService.getHistoryByKey(key)
   }
 
   @Patch(':key')
-  @DoeResponse({ operationId: 'updateConfigByKey', type: ConfigDto })
+  @DoeResponse({ operationId: 'updateConfigByKey', type: ConfigDto, errors: [400, 401, 403, 404, 500] })
   async updateByKey(
     @Param('key') key: string,
     @Body() dto: UpdateConfigDto,

--- a/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
@@ -36,19 +36,19 @@ export class ConfigController {
   }
 
   @Get(':key')
-  @DoeResponse({ operationId: 'getConfigByKey', type: ConfigDto, errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'getConfigByKey', type: ConfigDto, include404: true })
   async getByKey(@Param('key') key: string): Promise<ConfigDto> {
     return this.configService.getByKey(key)
   }
 
   @Get(':key/history')
-  @DoeResponse({ operationId: 'getConfigHistoryByKey', type: [ConfigDto], errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'getConfigHistoryByKey', type: [ConfigDto], include404: true })
   async getHistoryByKey(@Param('key') key: string): Promise<ConfigDto[]> {
     return this.configService.getHistoryByKey(key)
   }
 
   @Patch(':key')
-  @DoeResponse({ operationId: 'updateConfigByKey', type: ConfigDto, errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'updateConfigByKey', type: ConfigDto, include404: true })
   async updateByKey(
     @Param('key') key: string,
     @Body() dto: UpdateConfigDto,

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.api.module.ts
@@ -1,17 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { ReportResourceGuard } from '../../core/guards/report-resource/report-resource.guard'
-import { ReportModel } from '../report/models/report.model'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportCommentController } from './report-comment.controller'
 import { ReportCommentCoreModule } from './report-comment.core.module'
 
 @Module({
-  imports: [
-    ReportCommentCoreModule,
-    SequelizeModule.forFeature([UserModel, ReportModel]),
-  ],
+  imports: [ReportCommentCoreModule, AuthorizationCoreModule],
   controllers: [ReportCommentController],
   providers: [ReportResourceGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
@@ -36,7 +36,11 @@ export class ReportCommentController {
   ) {}
 
   @Get()
-  @DoeResponse({ operationId: 'getReportComments', type: [ReportCommentDto] })
+  @DoeResponse({
+    operationId: 'getReportComments',
+    type: [ReportCommentDto],
+    errors: [400, 401, 403, 404, 500],
+  })
   async getByReportId(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<ReportCommentDto[]> {
@@ -48,6 +52,7 @@ export class ReportCommentController {
     operationId: 'createReportComment',
     status: 201,
     type: ReportCommentDto,
+    errors: [400, 401, 403, 404, 500],
   })
   async create(
     @CurrentReportResourceContext() context: ReportResourceContext,
@@ -59,7 +64,7 @@ export class ReportCommentController {
   @Delete(':commentId')
   @HttpCode(204)
   @ApiParam({ name: 'commentId', type: String })
-  @DoeResponse({ operationId: 'deleteReportComment' })
+  @DoeResponse({ operationId: 'deleteReportComment', errors: [400, 401, 403, 404, 500] })
   async delete(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Param('commentId') commentId: string,

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.controller.ts
@@ -39,7 +39,7 @@ export class ReportCommentController {
   @DoeResponse({
     operationId: 'getReportComments',
     type: [ReportCommentDto],
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
   })
   async getByReportId(
     @CurrentReportResourceContext() context: ReportResourceContext,
@@ -52,7 +52,7 @@ export class ReportCommentController {
     operationId: 'createReportComment',
     status: 201,
     type: ReportCommentDto,
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
   })
   async create(
     @CurrentReportResourceContext() context: ReportResourceContext,
@@ -64,7 +64,7 @@ export class ReportCommentController {
   @Delete(':commentId')
   @HttpCode(204)
   @ApiParam({ name: 'commentId', type: String })
-  @DoeResponse({ operationId: 'deleteReportComment', errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'deleteReportComment', include404: true })
   async delete(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Param('commentId') commentId: string,

--- a/apps/directorate-of-equality-api/src/modules/report-excel/report-excel.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/report-excel.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportExcelController } from './report-excel.controller'
 import { ReportExcelCoreModule } from './report-excel.core.module'
 
 @Module({
-  imports: [ReportExcelCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [ReportExcelCoreModule, AuthorizationCoreModule],
   controllers: [ReportExcelController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportResultController } from './report-result.controller'
 import { ReportResultCoreModule } from './report-result.core.module'
 
 @Module({
-  imports: [ReportResultCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [ReportResultCoreModule, AuthorizationCoreModule],
   controllers: [ReportResultController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.ts
@@ -24,6 +24,7 @@ export class ReportResultController {
   @Get()
   @DoeResponse({
     operationId: 'getReportResultByReportId',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Returns the persisted report result snapshot for a salary report, including report-level and role-level base/full compensation aggregates.',
     type: ReportResultDto,

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.ts
@@ -24,7 +24,7 @@ export class ReportResultController {
   @Get()
   @DoeResponse({
     operationId: 'getReportResultByReportId',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Returns the persisted report result snapshot for a salary report, including report-level and role-level base/full compensation aggregates.',
     type: ReportResultDto,

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.api.module.ts
@@ -1,16 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportStatisticsController } from './report-statistics.controller'
 import { ReportStatisticsCoreModule } from './report-statistics.core.module'
 
 @Module({
-  imports: [
-    ReportStatisticsCoreModule,
-    SequelizeModule.forFeature([UserModel]),
-  ],
+  imports: [ReportStatisticsCoreModule, AuthorizationCoreModule],
   controllers: [ReportStatisticsController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
@@ -26,6 +26,7 @@ export class ReportStatisticsController {
   @Get('base-salary-by-gender-and-score-all')
   @DoeResponse({
     operationId: 'getBaseSalaryByGenderAndScoreAll',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Adjusted base salary (baseSalary / workRatio) by gender and total score (all criteria). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -42,6 +43,7 @@ export class ReportStatisticsController {
   @Get('base-salary-by-gender-and-score-work')
   @DoeResponse({
     operationId: 'getBaseSalaryByGenderAndScoreWork',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Adjusted base salary (baseSalary / workRatio) by gender and work score (mandatory criteria only, excludes PERSONAL). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -58,6 +60,7 @@ export class ReportStatisticsController {
   @Get('full-salary-by-gender-and-score-all')
   @DoeResponse({
     operationId: 'getFullSalaryByGenderAndScoreAll',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Adjusted full salary ((baseSalary + additionalSalary + bonusSalary) / workRatio) by gender and total score (all criteria). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -74,6 +77,7 @@ export class ReportStatisticsController {
   @Get('base-salary-gender-wage-gap')
   @DoeResponse({
     operationId: 'getBaseSalaryGenderWageGap',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Gender wage gap for adjusted base salary (baseSalary / workRatio). ' +
       'Returns average and median salaries per gender with both average-based and median-based wage gap percentages.',
@@ -88,6 +92,7 @@ export class ReportStatisticsController {
   @Get('full-salary-gender-wage-gap')
   @DoeResponse({
     operationId: 'getFullSalaryGenderWageGap',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Gender wage gap for adjusted full salary ((baseSalary + additionalSalary + bonusSalary) / workRatio). ' +
       'Returns average and median salaries per gender with both average-based and median-based wage gap percentages.',
@@ -102,6 +107,7 @@ export class ReportStatisticsController {
   @Get('benefits-breakdown')
   @DoeResponse({
     operationId: 'getBenefitsBreakdown',
+    errors: [400, 401, 403, 404, 500],
     description:
       'Average bonus salary (viðbótarlaun) and additional salary (aukagreiðslur) by gender. ' +
       'Raw values, not adjusted for work ratio. Returns per-gender breakdown with wage gap for each component and total.',

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.controller.ts
@@ -26,7 +26,7 @@ export class ReportStatisticsController {
   @Get('base-salary-by-gender-and-score-all')
   @DoeResponse({
     operationId: 'getBaseSalaryByGenderAndScoreAll',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Adjusted base salary (baseSalary / workRatio) by gender and total score (all criteria). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -43,7 +43,7 @@ export class ReportStatisticsController {
   @Get('base-salary-by-gender-and-score-work')
   @DoeResponse({
     operationId: 'getBaseSalaryByGenderAndScoreWork',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Adjusted base salary (baseSalary / workRatio) by gender and work score (mandatory criteria only, excludes PERSONAL). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -60,7 +60,7 @@ export class ReportStatisticsController {
   @Get('full-salary-by-gender-and-score-all')
   @DoeResponse({
     operationId: 'getFullSalaryByGenderAndScoreAll',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Adjusted full salary ((baseSalary + additionalSalary + bonusSalary) / workRatio) by gender and total score (all criteria). ' +
       'Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.',
@@ -77,7 +77,7 @@ export class ReportStatisticsController {
   @Get('base-salary-gender-wage-gap')
   @DoeResponse({
     operationId: 'getBaseSalaryGenderWageGap',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Gender wage gap for adjusted base salary (baseSalary / workRatio). ' +
       'Returns average and median salaries per gender with both average-based and median-based wage gap percentages.',
@@ -92,7 +92,7 @@ export class ReportStatisticsController {
   @Get('full-salary-gender-wage-gap')
   @DoeResponse({
     operationId: 'getFullSalaryGenderWageGap',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Gender wage gap for adjusted full salary ((baseSalary + additionalSalary + bonusSalary) / workRatio). ' +
       'Returns average and median salaries per gender with both average-based and median-based wage gap percentages.',
@@ -107,7 +107,7 @@ export class ReportStatisticsController {
   @Get('benefits-breakdown')
   @DoeResponse({
     operationId: 'getBenefitsBreakdown',
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
     description:
       'Average bonus salary (viðbótarlaun) and additional salary (aukagreiðslur) by gender. ' +
       'Raw values, not adjusted for work ratio. Returns per-gender breakdown with wage gap for each component and total.',

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportWorkflowController } from './report-workflow.controller'
 import { ReportWorkflowCoreModule } from './report-workflow.core.module'
 
 @Module({
-  imports: [ReportWorkflowCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [ReportWorkflowCoreModule, AuthorizationCoreModule],
   controllers: [ReportWorkflowController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
@@ -33,7 +33,7 @@ export class ReportWorkflowController {
 
   @Post('assign')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'assignReport', errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'assignReport', include404: true })
   async assign(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -42,7 +42,7 @@ export class ReportWorkflowController {
 
   @Post('deny')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'denyReport', errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'denyReport', include404: true })
   async deny(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Body() dto: DenyReportDto,
@@ -52,7 +52,7 @@ export class ReportWorkflowController {
 
   @Post('approve')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'approveReport', errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'approveReport', include404: true })
   async approve(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -61,7 +61,7 @@ export class ReportWorkflowController {
 
   @Post('start-fines')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'startReportFines', errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'startReportFines', include404: true })
   async startFines(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
@@ -33,7 +33,7 @@ export class ReportWorkflowController {
 
   @Post('assign')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'assignReport' })
+  @DoeResponse({ operationId: 'assignReport', errors: [400, 401, 403, 404, 500] })
   async assign(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -42,7 +42,7 @@ export class ReportWorkflowController {
 
   @Post('deny')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'denyReport' })
+  @DoeResponse({ operationId: 'denyReport', errors: [400, 401, 403, 404, 500] })
   async deny(
     @CurrentReportResourceContext() context: ReportResourceContext,
     @Body() dto: DenyReportDto,
@@ -52,7 +52,7 @@ export class ReportWorkflowController {
 
   @Post('approve')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'approveReport' })
+  @DoeResponse({ operationId: 'approveReport', errors: [400, 401, 403, 404, 500] })
   async approve(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
@@ -61,7 +61,7 @@ export class ReportWorkflowController {
 
   @Post('start-fines')
   @HttpCode(204)
-  @DoeResponse({ operationId: 'startReportFines' })
+  @DoeResponse({ operationId: 'startReportFines', errors: [400, 401, 403, 404, 500] })
   async startFines(
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {

--- a/apps/directorate-of-equality-api/src/modules/report/report.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from '../user/models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { ReportController } from './report.controller'
 import { ReportCoreModule } from './report.core.module'
 
 @Module({
-  imports: [ReportCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [ReportCoreModule, AuthorizationCoreModule],
   controllers: [ReportController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -36,7 +36,11 @@ export class ReportController {
   }
 
   @Get(':id')
-  @DoeResponse({ operationId: 'getReportById', type: ReportDetailDto })
+  @DoeResponse({
+    operationId: 'getReportById',
+    type: ReportDetailDto,
+    errors: [400, 401, 403, 404, 500],
+  })
   async getById(
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<ReportDetailDto> {

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -39,7 +39,7 @@ export class ReportController {
   @DoeResponse({
     operationId: 'getReportById',
     type: ReportDetailDto,
-    errors: [400, 401, 403, 404, 500],
+    include404: true,
   })
   async getById(
     @Param('id', ParseUUIDPipe) id: string,

--- a/apps/directorate-of-equality-api/src/modules/user/user.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.api.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common'
-import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { UserModel } from './models/user.model'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
 import { UserController } from './user.controller'
 import { UserCoreModule } from './user.core.module'
 
 @Module({
-  imports: [UserCoreModule, SequelizeModule.forFeature([UserModel])],
+  imports: [UserCoreModule, AuthorizationCoreModule],
   controllers: [UserController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
@@ -23,7 +23,7 @@ export class UserController {
   ) {}
 
   @Get('me')
-  @DoeResponse({ operationId: 'getMyUser', type: UserDto })
+  @DoeResponse({ operationId: 'getMyUser', type: UserDto, errors: [400, 401, 403, 404, 500] })
   async getMyUser(@CurrentUser() user: DMRUser): Promise<UserDto> {
     return this.userService.getMyUser(user.nationalId)
   }

--- a/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/user/user.controller.ts
@@ -23,7 +23,7 @@ export class UserController {
   ) {}
 
   @Get('me')
-  @DoeResponse({ operationId: 'getMyUser', type: UserDto, errors: [400, 401, 403, 404, 500] })
+  @DoeResponse({ operationId: 'getMyUser', type: UserDto, include404: true })
   async getMyUser(@CurrentUser() user: DMRUser): Promise<UserDto> {
     return this.userService.getMyUser(user.nationalId)
   }

--- a/apps/directorate-of-equality-api/src/openApi.ts
+++ b/apps/directorate-of-equality-api/src/openApi.ts
@@ -1,8 +1,0 @@
-import { DocumentBuilder } from '@nestjs/swagger'
-
-export const openApi = new DocumentBuilder()
-  .setTitle('Directorate of Equality API')
-  .setDescription('The API for the Directorate of Equality')
-  .setVersion('1.0')
-  .addBearerAuth()
-  .build()

--- a/apps/directorate-of-equality-api/src/setupSwaggerDocument.ts
+++ b/apps/directorate-of-equality-api/src/setupSwaggerDocument.ts
@@ -1,13 +1,12 @@
 import { INestApplication } from '@nestjs/common'
-import { SwaggerModule } from '@nestjs/swagger'
-
-import { openApi } from './openApi'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 
 export type SetupSwaggerOptions = {
   // eslint-disable-next-line @typescript-eslint/ban-types
   modules: Function[]
   tag: string
   swaggerTitle: string
+  swaggerDescription: string
   swaggerPath: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filterPaths?: (path: Record<string, any>) => Record<string, any>
@@ -18,6 +17,13 @@ export const setupSwaggerDocument = (
   app: INestApplication,
   options: SetupSwaggerOptions,
 ) => {
+  const openApi = new DocumentBuilder()
+    .setTitle(options.swaggerTitle)
+    .setDescription(options.swaggerDescription)
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build()
+
   const document = SwaggerModule.createDocument(app, openApi, {
     deepScanRoutes: true,
     include: options.modules,

--- a/apps/directorate-of-equality-api/src/swagger.config.ts
+++ b/apps/directorate-of-equality-api/src/swagger.config.ts
@@ -4,10 +4,27 @@ import { SetupSwaggerOptions } from './setupSwaggerDocument'
 
 export const SWAGGER_CONFIG: SetupSwaggerOptions[] = [
   {
-    swaggerPath: 'swagger',
-    swaggerTitle: 'Directorate of Equality API - DoE Web',
-    tag: 'Directorate of Equality API',
-    modules: [DoeWebSwaggerModule, ApplicationApiModule],
+    swaggerPath: 'swagger/internal',
+    swaggerTitle: 'Directorate of Equality — Internal API',
+    swaggerDescription:
+      'Internal API for direct communication between the DoE web application (doe-web) and the DoE API. ' +
+      'Covers report management, workflow transitions (assign, deny, approve, start fines), ' +
+      'comments, statistics, and user administration. ' +
+      'Not intended for external consumers.',
+    tag: 'Internal API',
+    modules: [DoeWebSwaggerModule],
+    autoTagControllers: true,
+  },
+  {
+    swaggerPath: 'swagger/application',
+    swaggerTitle: 'Directorate of Equality — Application API',
+    swaggerDescription:
+      'Public-facing API for equality report submissions through island.is. ' +
+      'Covers company information lookup, Excel template download, workbook import, ' +
+      'salary analysis, and equality report submission. ' +
+      'Consumed by the island.is application system on behalf of employers.',
+    tag: 'Application API',
+    modules: [ApplicationApiModule],
     autoTagControllers: true,
   },
 ]

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -100,14 +100,6 @@
               }
             }
           },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
           "500": {
             "description": "",
             "content": {
@@ -507,14 +499,6 @@
             }
           },
           "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
             "description": "",
             "content": {
               "application/json": {

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -1,532 +1,6 @@
 {
   "openapi": "3.0.0",
   "paths": {
-    "/api/v1/application/company": {
-      "get": {
-        "operationId": "getApplicationCompany",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/CompanyDto" }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/excel/template": {
-      "get": {
-        "operationId": "getApplicationBlankExcelTemplate",
-        "parameters": [],
-        "responses": {
-          "200": { "description": "Blank salary report template" },
-          "400": {
-            "description": "",
-            "content": {
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/excel/import": {
-      "post": {
-        "operationId": "importApplicationSalaryReportWorkbook",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "file": { "type": "string", "format": "binary" }
-                },
-                "required": ["file"]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ParsedReportDto" }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/salary-analysis": {
-      "post": {
-        "operationId": "analyzeApplicationSalaryReport",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SalaryAnalysisRequestDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SalaryAnalysisResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/equality/active": {
-      "get": {
-        "description": "Returns the resolved company's currently-APPROVED equality report (if any). The application portal references the returned `id` as `equalityReportId` when submitting a salary report.",
-        "operationId": "getApplicationActiveEqualityReport",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EqualityReportSummaryDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/salary": {
-      "post": {
-        "operationId": "submitApplicationSalaryReport",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateReportDto" }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateReportResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/equality": {
-      "post": {
-        "operationId": "submitApplicationEqualityReport",
-        "parameters": [],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CreateEqualityReportDto"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateReportResponseDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
-    "/api/v1/application/reports/{reportId}": {
-      "get": {
-        "description": "Returns company-facing report detail with external comments only.",
-        "operationId": "getApplicationReport",
-        "parameters": [
-          {
-            "name": "reportId",
-            "required": true,
-            "in": "path",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApplicationReportDetailDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "401": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "403": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "404": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          },
-          "500": {
-            "description": "",
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
-              }
-            }
-          }
-        },
-        "security": [{ "bearer": [] }],
-        "summary": "",
-        "tags": ["Application"]
-      }
-    },
     "/api/v1/users/me": {
       "get": {
         "operationId": "getMyUser",
@@ -1582,8 +1056,8 @@
     }
   },
   "info": {
-    "title": "Directorate of Equality API",
-    "description": "The API for the Directorate of Equality",
+    "title": "Directorate of Equality — Internal API",
+    "description": "Internal API for direct communication between the DoE web application (doe-web) and the DoE API. Covers report management, workflow transitions (assign, deny, approve, start fines), comments, statistics, and user administration. Not intended for external consumers.",
     "version": "1.0",
     "contact": {}
   },
@@ -1594,31 +1068,24 @@
       "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
     },
     "schemas": {
-      "CompanyDto": {
+      "UserDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "format": "uuid" },
-          "name": { "type": "string" },
-          "address": { "type": "string" },
-          "city": { "type": "string" },
-          "postcode": { "type": "string" },
-          "averageEmployeeCountFromRsk": { "type": "number" },
           "nationalId": { "type": "string" },
-          "isatCategory": { "type": "string" },
-          "salaryReportRequired": { "type": "boolean" },
-          "salaryReportRequiredOverride": { "type": "boolean" }
+          "firstName": { "type": "string" },
+          "lastName": { "type": "string" },
+          "email": { "type": "string" },
+          "phone": { "type": "string", "nullable": true },
+          "isActive": { "type": "boolean" }
         },
         "required": [
           "id",
-          "name",
-          "address",
-          "city",
-          "postcode",
-          "averageEmployeeCountFromRsk",
           "nationalId",
-          "isatCategory",
-          "salaryReportRequired",
-          "salaryReportRequiredOverride"
+          "firstName",
+          "lastName",
+          "email",
+          "isActive"
         ]
       },
       "ApiErrorDto": {
@@ -1660,464 +1127,29 @@
         },
         "required": ["statusCode", "timestamp"]
       },
-      "ParsedSubCriterionStepDto": {
-        "type": "object",
-        "properties": {
-          "order": { "type": "number" },
-          "description": { "type": "string" },
-          "score": { "type": "number" }
-        },
-        "required": ["order", "description", "score"]
-      },
-      "ParsedSubCriterionDto": {
-        "type": "object",
-        "properties": {
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "weight": { "type": "number" },
-          "steps": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ParsedSubCriterionStepDto"
-            }
-          }
-        },
-        "required": ["title", "description", "weight", "steps"]
-      },
-      "ParsedCriterionDto": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "RESPONSIBILITY",
-              "STRAIN",
-              "CONDITION",
-              "COMPETENCE",
-              "PERSONAL"
-            ]
-          },
-          "title": { "type": "string" },
-          "description": { "type": "string" },
-          "weight": { "type": "number" },
-          "subCriteria": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedSubCriterionDto" }
-          }
-        },
-        "required": ["type", "title", "description", "weight", "subCriteria"]
-      },
-      "ParsedStepAssignmentDto": {
-        "type": "object",
-        "properties": {
-          "criterionTitle": { "type": "string" },
-          "subTitle": { "type": "string" },
-          "stepOrder": { "type": "number" }
-        },
-        "required": ["criterionTitle", "subTitle", "stepOrder"]
-      },
-      "ParsedRoleDto": {
-        "type": "object",
-        "properties": {
-          "title": { "type": "string" },
-          "stepAssignments": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedStepAssignmentDto" }
-          }
-        },
-        "required": ["title", "stepAssignments"]
-      },
-      "ParsedEmployeeDto": {
-        "type": "object",
-        "properties": {
-          "ordinal": { "type": "number" },
-          "identifier": { "type": "string" },
-          "roleTitle": { "type": "string" },
-          "education": {
-            "type": "string",
-            "enum": [
-              "COMPULSORY",
-              "UPPER_SECONDARY",
-              "VOCATIONAL",
-              "BACHELOR",
-              "MASTER",
-              "DOCTORATE",
-              "PROFESSIONAL"
-            ]
-          },
-          "gender": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
-          "field": { "type": "string" },
-          "department": { "type": "string" },
-          "startDate": { "type": "string" },
-          "workRatio": { "type": "number" },
-          "baseSalary": { "type": "number" },
-          "additionalSalary": { "type": "number" },
-          "bonusSalary": { "type": "number", "nullable": true },
-          "personalStepAssignments": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedStepAssignmentDto" }
-          }
-        },
-        "required": [
-          "ordinal",
-          "identifier",
-          "roleTitle",
-          "education",
-          "gender",
-          "field",
-          "department",
-          "startDate",
-          "workRatio",
-          "baseSalary",
-          "additionalSalary",
-          "personalStepAssignments"
-        ]
-      },
-      "ParsedReportDto": {
-        "type": "object",
-        "properties": {
-          "criteria": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedCriterionDto" }
-          },
-          "roles": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedRoleDto" }
-          },
-          "employees": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ParsedEmployeeDto" }
-          }
-        },
-        "required": ["criteria", "roles", "employees"]
-      },
-      "SalaryAnalysisRequestDto": {
-        "type": "object",
-        "properties": {
-          "parsed": {
-            "description": "Parsed workbook payload from `POST /application/reports/excel/import`.",
-            "allOf": [{ "$ref": "#/components/schemas/ParsedReportDto" }]
-          }
-        },
-        "required": ["parsed"]
-      },
-      "SalaryAnalysisOutlierDto": {
-        "type": "object",
-        "properties": {
-          "employeeOrdinal": { "type": "number" },
-          "adjustedBaseSalary": { "type": "number" },
-          "direction": {
-            "type": "string",
-            "enum": ["ABOVE", "BELOW", "EQUAL"]
-          },
-          "differencePercent": { "type": "number" },
-          "allowedDifferencePercent": { "type": "number" },
-          "referenceSalary": { "type": "number", "nullable": true },
-          "scoreBucketRangeFrom": { "type": "number" },
-          "scoreBucketRangeTo": { "type": "number" }
-        },
-        "required": [
-          "employeeOrdinal",
-          "adjustedBaseSalary",
-          "direction",
-          "differencePercent",
-          "allowedDifferencePercent",
-          "scoreBucketRangeFrom",
-          "scoreBucketRangeTo"
-        ]
-      },
-      "ScatterDataPointDto": {
-        "type": "object",
-        "properties": {
-          "score": { "type": "number" },
-          "adjustedSalary": { "type": "number" },
-          "gender": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] }
-        },
-        "required": ["score", "adjustedSalary", "gender"]
-      },
-      "RegressionLineDto": {
-        "type": "object",
-        "properties": {
-          "slope": { "type": "number" },
-          "intercept": { "type": "number" }
-        },
-        "required": ["slope", "intercept"]
-      },
-      "ScoreBucketDto": {
-        "type": "object",
-        "properties": {
-          "rangeFrom": { "type": "number" },
-          "rangeTo": { "type": "number" },
-          "maleAverageSalary": { "type": "number", "nullable": true },
-          "femaleAverageSalary": { "type": "number", "nullable": true },
-          "overallAverageSalary": { "type": "number" },
-          "maleMedianSalary": { "type": "number", "nullable": true },
-          "femaleMedianSalary": { "type": "number", "nullable": true },
-          "overallMedianSalary": { "type": "number" },
-          "wageGapPercent": { "type": "number", "nullable": true },
-          "maleCount": { "type": "number" },
-          "femaleCount": { "type": "number" }
-        },
-        "required": [
-          "rangeFrom",
-          "rangeTo",
-          "overallAverageSalary",
-          "overallMedianSalary",
-          "maleCount",
-          "femaleCount"
-        ]
-      },
-      "SalaryTotalsDto": {
-        "type": "object",
-        "properties": {
-          "maleAverageSalary": { "type": "number" },
-          "femaleAverageSalary": { "type": "number" },
-          "overallAverageSalary": { "type": "number" },
-          "maleMedianSalary": { "type": "number" },
-          "femaleMedianSalary": { "type": "number" },
-          "overallMedianSalary": { "type": "number" },
-          "wageGapPercent": { "type": "number", "nullable": true },
-          "maleCount": { "type": "number" },
-          "femaleCount": { "type": "number" }
-        },
-        "required": [
-          "maleAverageSalary",
-          "femaleAverageSalary",
-          "overallAverageSalary",
-          "maleMedianSalary",
-          "femaleMedianSalary",
-          "overallMedianSalary",
-          "maleCount",
-          "femaleCount"
-        ]
-      },
-      "SalaryByGenderAndScoreDto": {
-        "type": "object",
-        "properties": {
-          "dataPoints": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ScatterDataPointDto" }
-          },
-          "regressionLine": {
-            "$ref": "#/components/schemas/RegressionLineDto"
-          },
-          "scoreBuckets": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ScoreBucketDto" }
-          },
-          "totals": { "$ref": "#/components/schemas/SalaryTotalsDto" }
-        },
-        "required": ["dataPoints", "regressionLine", "scoreBuckets", "totals"]
-      },
-      "SalaryAnalysisResponseDto": {
-        "type": "object",
-        "properties": {
-          "outliers": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/SalaryAnalysisOutlierDto" }
-          },
-          "baseSalaryByGenderAndScoreAll": {
-            "$ref": "#/components/schemas/SalaryByGenderAndScoreDto"
-          }
-        },
-        "required": ["outliers", "baseSalaryByGenderAndScoreAll"]
-      },
-      "EqualityReportSummaryDto": {
+      "ConfigDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "format": "uuid" },
-          "identifier": { "type": "string", "nullable": true },
-          "approvedAt": {
+          "key": { "type": "string" },
+          "value": { "type": "string" },
+          "description": { "type": "string", "nullable": true },
+          "supersededAt": {
             "type": "string",
             "format": "date-time",
             "example": "2026-02-19T10:30:00.000Z",
             "nullable": true
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
           }
         },
-        "required": ["id"]
+        "required": ["id", "key", "value"]
       },
-      "CreateReportCompanySnapshotDto": {
+      "UpdateConfigDto": {
         "type": "object",
         "properties": {
-          "companyId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "FK to the live company row"
-          },
-          "parentCompanyId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true,
-            "description": "Parent company FK (nullable). Null on the top-level reporting company; set on each subsidiary."
-          },
-          "name": { "type": "string" },
-          "nationalId": { "type": "string" },
-          "address": { "type": "string" },
-          "city": { "type": "string" },
-          "postcode": { "type": "string" },
-          "averageEmployeeCountFromRsk": { "type": "number" },
-          "isatCategory": { "type": "string" }
+          "value": { "type": "string" },
+          "description": { "type": "string", "nullable": true }
         },
-        "required": [
-          "companyId",
-          "name",
-          "nationalId",
-          "address",
-          "city",
-          "postcode",
-          "averageEmployeeCountFromRsk",
-          "isatCategory"
-        ]
-      },
-      "CreateReportOutlierDto": {
-        "type": "object",
-        "properties": {
-          "employeeOrdinal": {
-            "type": "number",
-            "description": "Ordinal of the employee in `parsed.employees[]` this outlier justification applies to."
-          },
-          "postponed": {
-            "type": "boolean",
-            "description": "When true, defers the explanation. Other fields may be omitted. Defaults to false."
-          },
-          "reason": {
-            "type": "string",
-            "description": "Required when `postponed` is false."
-          },
-          "action": {
-            "type": "string",
-            "description": "Required when `postponed` is false."
-          },
-          "signatureName": {
-            "type": "string",
-            "description": "Required when `postponed` is false."
-          },
-          "signatureRole": {
-            "type": "string",
-            "description": "Required when `postponed` is false."
-          }
-        },
-        "required": ["employeeOrdinal"]
-      },
-      "CreateReportDto": {
-        "type": "object",
-        "properties": {
-          "equalityReportId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "FK to the approved EQUALITY report this salary was audited against."
-          },
-          "identifier": { "type": "string" },
-          "importedFromExcel": { "type": "boolean" },
-          "providerType": {
-            "type": "string",
-            "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
-          },
-          "providerId": { "type": "string", "nullable": true },
-          "companyAdminName": { "type": "string" },
-          "companyAdminEmail": { "type": "string" },
-          "companyAdminGender": {
-            "type": "string",
-            "enum": ["MALE", "FEMALE", "NEUTRAL"]
-          },
-          "contactName": { "type": "string" },
-          "contactEmail": { "type": "string" },
-          "contactPhone": { "type": "string" },
-          "averageEmployeeMaleCount": { "type": "number" },
-          "averageEmployeeFemaleCount": { "type": "number" },
-          "averageEmployeeNeutralCount": { "type": "number" },
-          "parsed": {
-            "description": "Parsed workbook payload from `POST /reports/excel/import`. Contains the criteria tree, role list, and employee rows.",
-            "allOf": [{ "$ref": "#/components/schemas/ParsedReportDto" }]
-          },
-          "companies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CreateReportCompanySnapshotDto"
-            }
-          },
-          "outliers": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/CreateReportOutlierDto" }
-          }
-        },
-        "required": [
-          "equalityReportId",
-          "identifier",
-          "importedFromExcel",
-          "providerType",
-          "companyAdminName",
-          "companyAdminEmail",
-          "companyAdminGender",
-          "contactName",
-          "contactEmail",
-          "contactPhone",
-          "averageEmployeeMaleCount",
-          "averageEmployeeFemaleCount",
-          "averageEmployeeNeutralCount",
-          "parsed",
-          "companies"
-        ]
-      },
-      "CreateReportResponseDto": {
-        "type": "object",
-        "properties": {
-          "reportId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "Identifier of the newly created report row."
-          }
-        },
-        "required": ["reportId"]
-      },
-      "CreateEqualityReportDto": {
-        "type": "object",
-        "properties": {
-          "identifier": { "type": "string" },
-          "providerType": {
-            "type": "string",
-            "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
-          },
-          "providerId": { "type": "string", "nullable": true },
-          "companyAdminName": { "type": "string" },
-          "companyAdminEmail": { "type": "string" },
-          "companyAdminGender": {
-            "type": "string",
-            "enum": ["MALE", "FEMALE", "NEUTRAL"]
-          },
-          "contactName": { "type": "string" },
-          "contactEmail": { "type": "string" },
-          "contactPhone": { "type": "string" },
-          "equalityReportContent": {
-            "type": "string",
-            "minLength": 1,
-            "description": "Narrative gender-equality plan. Persisted as `report.equality_report_content`."
-          },
-          "companies": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CreateReportCompanySnapshotDto"
-            }
-          }
-        },
-        "required": [
-          "identifier",
-          "providerType",
-          "companyAdminName",
-          "companyAdminEmail",
-          "companyAdminGender",
-          "contactName",
-          "contactEmail",
-          "contactPhone",
-          "equalityReportContent",
-          "companies"
-        ]
+        "required": ["value"]
       },
       "ReportTypeEnum": { "type": "string", "enum": ["SALARY", "EQUALITY"] },
       "ReportStatusEnum": {
@@ -2130,6 +1162,100 @@
           "APPROVED",
           "SUPERSEDED"
         ]
+      },
+      "ReportSortByEnum": {
+        "type": "string",
+        "enum": [
+          "createdAt",
+          "updatedAt",
+          "approvedAt",
+          "validUntil",
+          "correctionDeadline",
+          "identifier"
+        ]
+      },
+      "SortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
+      "ReportListItemDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "identifier": { "type": "string", "nullable": true },
+          "type": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportTypeEnum" }]
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "companyName": { "type": "string", "nullable": true },
+          "companyNationalId": { "type": "string", "nullable": true },
+          "reviewer": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/UserDto" }]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          },
+          "correctionDeadline": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          }
+        },
+        "required": ["id", "type", "status"]
+      },
+      "Paging": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "number", "example": 1 },
+          "totalPages": { "type": "number", "example": 10 },
+          "totalItems": { "type": "number", "example": 1000 },
+          "nextPage": { "type": "number", "example": 2, "nullable": true },
+          "previousPage": { "type": "number", "example": 1, "nullable": true },
+          "pageSize": {
+            "type": "number",
+            "example": 10,
+            "minimum": 1,
+            "maximum": 100
+          },
+          "hasNextPage": { "type": "boolean", "example": true },
+          "hasPreviousPage": { "type": "boolean", "example": false }
+        },
+        "required": [
+          "page",
+          "totalPages",
+          "totalItems",
+          "nextPage",
+          "previousPage",
+          "pageSize",
+          "hasNextPage",
+          "hasPreviousPage"
+        ]
+      },
+      "GetReportsResponseDto": {
+        "type": "object",
+        "properties": {
+          "reports": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReportListItemDto" }
+          },
+          "paging": { "$ref": "#/components/schemas/Paging" }
+        },
+        "required": ["reports", "paging"]
+      },
+      "GenderEnum": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
+      "ReportProviderEnum": {
+        "type": "string",
+        "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
       },
       "CompanyReportDto": {
         "type": "object",
@@ -2163,21 +1289,152 @@
           "isatCategory"
         ]
       },
-      "ReportEmployeeOutlierDto": {
+      "EqualityReportDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "format": "uuid" },
-          "reportEmployeeId": { "type": "string", "format": "uuid" },
-          "postponed": {
-            "type": "boolean",
-            "description": "When true, the company has acknowledged the outlier but deferred the explanation. Reason/action/signatures may be null."
+          "identifier": { "type": "string", "nullable": true },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "content": { "type": "string", "nullable": true },
+          "approvedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          },
+          "validUntil": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          },
+          "correctionDeadline": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z",
+            "nullable": true
+          }
+        },
+        "required": ["id", "status"]
+      },
+      "ReportTimelineItemKindEnum": {
+        "type": "string",
+        "enum": ["EVENT", "COMMENT"]
+      },
+      "ReportEventTypeEnum": {
+        "type": "string",
+        "enum": ["SUBMITTED", "ASSIGNED", "STATUS_CHANGED", "SUPERSEDED"]
+      },
+      "ReportEventDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "reportId": { "type": "string", "format": "uuid" },
+          "eventType": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportEventTypeEnum" }]
+          },
+          "actorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "reportStatus": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "fromStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "toStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "assignedUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           },
           "reason": { "type": "string", "nullable": true },
-          "action": { "type": "string", "nullable": true },
-          "signatureName": { "type": "string", "nullable": true },
-          "signatureRole": { "type": "string", "nullable": true }
+          "relatedReportId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "companyId": { "type": "string", "format": "uuid", "nullable": true },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
         },
-        "required": ["id", "reportEmployeeId", "postponed"]
+        "required": ["id", "reportId", "eventType", "reportStatus", "createdAt"]
+      },
+      "ReportRoleEnum": { "type": "string", "enum": ["REVIEWER", "COMPANY"] },
+      "CommentVisibilityEnum": {
+        "type": "string",
+        "enum": ["INTERNAL", "EXTERNAL"]
+      },
+      "ReportCommentDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "reportId": { "type": "string", "format": "uuid" },
+          "authorKind": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportRoleEnum" }]
+          },
+          "authorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "visibility": {
+            "allOf": [{ "$ref": "#/components/schemas/CommentVisibilityEnum" }]
+          },
+          "body": { "type": "string" },
+          "reportStatus": {
+            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "reportId",
+          "authorKind",
+          "visibility",
+          "body",
+          "reportStatus",
+          "createdAt"
+        ]
+      },
+      "ReportTimelineItemDto": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "allOf": [
+              { "$ref": "#/components/schemas/ReportTimelineItemKindEnum" }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          },
+          "event": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/ReportEventDto" }]
+          },
+          "comment": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/ReportCommentDto" }]
+          }
+        },
+        "required": ["kind", "createdAt"]
       },
       "SalaryAggregateMetricsDto": {
         "type": "object",
@@ -2274,360 +1531,6 @@
         },
         "required": ["id", "reportId", "calculationVersion", "base", "full"]
       },
-      "ReportRoleEnum": { "type": "string", "enum": ["REVIEWER", "COMPANY"] },
-      "CommentVisibilityEnum": {
-        "type": "string",
-        "enum": ["INTERNAL", "EXTERNAL"]
-      },
-      "ReportCommentDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "reportId": { "type": "string", "format": "uuid" },
-          "authorKind": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportRoleEnum" }]
-          },
-          "authorUserId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "visibility": {
-            "allOf": [{ "$ref": "#/components/schemas/CommentVisibilityEnum" }]
-          },
-          "body": { "type": "string" },
-          "reportStatus": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z"
-          }
-        },
-        "required": [
-          "id",
-          "reportId",
-          "authorKind",
-          "visibility",
-          "body",
-          "reportStatus",
-          "createdAt"
-        ]
-      },
-      "ApplicationReportDetailDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "type": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportTypeEnum" }]
-          },
-          "status": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "identifier": { "type": "string", "nullable": true },
-          "submittedAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "approvedAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "correctionDeadline": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "companies": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/CompanyReportDto" }
-          },
-          "equalityReport": {
-            "nullable": true,
-            "allOf": [
-              { "$ref": "#/components/schemas/EqualityReportSummaryDto" }
-            ]
-          },
-          "equalityReportContent": { "type": "string", "nullable": true },
-          "outliers": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ReportEmployeeOutlierDto" }
-          },
-          "result": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/ReportResultDto" }]
-          },
-          "externalComments": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ReportCommentDto" }
-          },
-          "denialReason": { "type": "string", "nullable": true }
-        },
-        "required": [
-          "id",
-          "type",
-          "status",
-          "companies",
-          "outliers",
-          "externalComments"
-        ]
-      },
-      "UserDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "nationalId": { "type": "string" },
-          "firstName": { "type": "string" },
-          "lastName": { "type": "string" },
-          "email": { "type": "string" },
-          "phone": { "type": "string", "nullable": true },
-          "isActive": { "type": "boolean" }
-        },
-        "required": [
-          "id",
-          "nationalId",
-          "firstName",
-          "lastName",
-          "email",
-          "isActive"
-        ]
-      },
-      "ConfigDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "key": { "type": "string" },
-          "value": { "type": "string" },
-          "description": { "type": "string", "nullable": true },
-          "supersededAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          }
-        },
-        "required": ["id", "key", "value"]
-      },
-      "UpdateConfigDto": {
-        "type": "object",
-        "properties": {
-          "value": { "type": "string" },
-          "description": { "type": "string", "nullable": true }
-        },
-        "required": ["value"]
-      },
-      "ReportSortByEnum": {
-        "type": "string",
-        "enum": [
-          "createdAt",
-          "updatedAt",
-          "approvedAt",
-          "validUntil",
-          "correctionDeadline",
-          "identifier"
-        ]
-      },
-      "SortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
-      "ReportListItemDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "identifier": { "type": "string", "nullable": true },
-          "type": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportTypeEnum" }]
-          },
-          "status": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "companyName": { "type": "string", "nullable": true },
-          "companyNationalId": { "type": "string", "nullable": true },
-          "reviewer": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/UserDto" }]
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "correctionDeadline": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          }
-        },
-        "required": ["id", "type", "status"]
-      },
-      "Paging": {
-        "type": "object",
-        "properties": {
-          "page": { "type": "number", "example": 1 },
-          "totalPages": { "type": "number", "example": 10 },
-          "totalItems": { "type": "number", "example": 1000 },
-          "nextPage": { "type": "number", "example": 2, "nullable": true },
-          "previousPage": { "type": "number", "example": 1, "nullable": true },
-          "pageSize": {
-            "type": "number",
-            "example": 10,
-            "minimum": 1,
-            "maximum": 100
-          },
-          "hasNextPage": { "type": "boolean", "example": true },
-          "hasPreviousPage": { "type": "boolean", "example": false }
-        },
-        "required": [
-          "page",
-          "totalPages",
-          "totalItems",
-          "nextPage",
-          "previousPage",
-          "pageSize",
-          "hasNextPage",
-          "hasPreviousPage"
-        ]
-      },
-      "GetReportsResponseDto": {
-        "type": "object",
-        "properties": {
-          "reports": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ReportListItemDto" }
-          },
-          "paging": { "$ref": "#/components/schemas/Paging" }
-        },
-        "required": ["reports", "paging"]
-      },
-      "GenderEnum": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
-      "ReportProviderEnum": {
-        "type": "string",
-        "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
-      },
-      "EqualityReportDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "identifier": { "type": "string", "nullable": true },
-          "status": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "content": { "type": "string", "nullable": true },
-          "approvedAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "validUntil": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          },
-          "correctionDeadline": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z",
-            "nullable": true
-          }
-        },
-        "required": ["id", "status"]
-      },
-      "ReportTimelineItemKindEnum": {
-        "type": "string",
-        "enum": ["EVENT", "COMMENT"]
-      },
-      "ReportEventTypeEnum": {
-        "type": "string",
-        "enum": ["SUBMITTED", "ASSIGNED", "STATUS_CHANGED", "SUPERSEDED"]
-      },
-      "ReportEventDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "reportId": { "type": "string", "format": "uuid" },
-          "eventType": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportEventTypeEnum" }]
-          },
-          "actorUserId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "reportStatus": {
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "fromStatus": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "toStatus": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
-          },
-          "assignedUserId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "reason": { "type": "string", "nullable": true },
-          "relatedReportId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
-          "companyId": { "type": "string", "format": "uuid", "nullable": true },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z"
-          }
-        },
-        "required": ["id", "reportId", "eventType", "reportStatus", "createdAt"]
-      },
-      "ReportTimelineItemDto": {
-        "type": "object",
-        "properties": {
-          "kind": {
-            "allOf": [
-              { "$ref": "#/components/schemas/ReportTimelineItemKindEnum" }
-            ]
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time",
-            "example": "2026-02-19T10:30:00.000Z"
-          },
-          "event": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/ReportEventDto" }]
-          },
-          "comment": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/ReportCommentDto" }]
-          }
-        },
-        "required": ["kind", "createdAt"]
-      },
       "ReportRoleResultDto": {
         "type": "object",
         "properties": {
@@ -2650,6 +1553,22 @@
           "base",
           "full"
         ]
+      },
+      "ReportEmployeeOutlierDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "reportEmployeeId": { "type": "string", "format": "uuid" },
+          "postponed": {
+            "type": "boolean",
+            "description": "When true, the company has acknowledged the outlier but deferred the explanation. Reason/action/signatures may be null."
+          },
+          "reason": { "type": "string", "nullable": true },
+          "action": { "type": "string", "nullable": true },
+          "signatureName": { "type": "string", "nullable": true },
+          "signatureRole": { "type": "string", "nullable": true }
+        },
+        "required": ["id", "reportEmployeeId", "postponed"]
       },
       "ReportDetailDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/project.json
+++ b/apps/directorate-of-equality-web/project.json
@@ -66,7 +66,7 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "curl http://localhost:5100/swagger/json > clientConfig.json",
+          "curl http://localhost:5100/swagger/internal/json > clientConfig.json",
           "prettier --write clientConfig.json"
         ],
         "parallel": true,


### PR DESCRIPTION
## What                                                                                                                                                         
                                                            
  - Split the single DoE swagger document into two separate documents:
    - /swagger/internal — DoE Web internal API                                                                                                                 
    - /swagger/application — island.is application submission API                                                                                              
  - Added swaggerDescription field to SetupSwaggerOptions; DocumentBuilder is now constructed per-document from config, removing the shared openApi.ts         
  - Updated doe-web schema fetch URL from /swagger/json to /swagger/internal/json                                                                              
                                                                                                                                                               
## Why                                                                                                                                                          
                                                                                                                                                               
  The internal and application APIs serve different consumers with different access models. Separating the swagger docs makes the boundary explicit and gives  
  island.is a clean, isolated spec to consume without internal endpoints leaking into their integration.