### PR TITLE
feat(doe): Admin report creation drawers with service layer

### DIFF
--- a/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
+++ b/apps/directorate-of-equality-api/src/core/decorators/doe-response.decorator.ts
@@ -67,6 +67,8 @@ export function DoeResponse({
   return applyDecorators(
     ApiOperation({ operationId, description }),
     successDecorator,
-    ...effectiveErrors.map((code) => ApiResponse({ status: code, type: ApiErrorDto })),
+    ...effectiveErrors.map((code) =>
+      ApiResponse({ status: code, type: ApiErrorDto }),
+    ),
   )
 }

--- a/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/admin/admin.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common'
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
 
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
 

--- a/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.spec.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.spec.ts
@@ -84,7 +84,9 @@ describe('ReportResourceGuard', () => {
     }
 
     authorizationService.resolveReportResourceContext.mockRejectedValue(
-      new ForbiddenException('Current user is not allowed to access this report'),
+      new ForbiddenException(
+        'Current user is not allowed to access this report',
+      ),
     )
 
     await expect(

--- a/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.ts
+++ b/apps/directorate-of-equality-api/src/core/guards/report-resource/report-resource.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common'
+import {
+  CanActivate,
+  ExecutionContext,
+  Inject,
+  Injectable,
+} from '@nestjs/common'
 
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
 

--- a/apps/directorate-of-equality-api/src/core/pipes/parse-national-id.pipe.ts
+++ b/apps/directorate-of-equality-api/src/core/pipes/parse-national-id.pipe.ts
@@ -1,0 +1,16 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common'
+
+@Injectable()
+export class ParseNationalIdPipe implements PipeTransform<string, string> {
+  transform(value: string): string {
+    const normalized = value.replace(/[- ]/g, '')
+
+    if (!/^\d{10}$/.test(normalized)) {
+      throw new BadRequestException(
+        'nationalId must be 10 digits (accepted formats: XXXXXXXXXX, XXXXXX-XXXX, XXXXXX XXXX)',
+      )
+    }
+
+    return normalized
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
@@ -7,7 +7,11 @@ import { AdminReportController } from './admin-report.controller'
 import { AdminReportCoreModule } from './admin-report.core.module'
 
 @Module({
-  imports: [AuthorizationCoreModule, AdminReportCoreModule, ReportExcelCoreModule],
+  imports: [
+    AuthorizationCoreModule,
+    AdminReportCoreModule,
+    ReportExcelCoreModule,
+  ],
   controllers: [AdminReportController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
@@ -2,18 +2,12 @@ import { Module } from '@nestjs/common'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
-import { CompanyCoreModule } from '../company/company.core.module'
-import { ReportCreateCoreModule } from '../report-create/report-create.core.module'
 import { ReportExcelCoreModule } from '../report-excel/report-excel.core.module'
 import { AdminReportController } from './admin-report.controller'
+import { AdminReportCoreModule } from './admin-report.core.module'
 
 @Module({
-  imports: [
-    AuthorizationCoreModule,
-    CompanyCoreModule,
-    ReportExcelCoreModule,
-    ReportCreateCoreModule,
-  ],
+  imports: [AuthorizationCoreModule, AdminReportCoreModule, ReportExcelCoreModule],
   controllers: [AdminReportController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.api.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common'
+
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
+import { CompanyCoreModule } from '../company/company.core.module'
+import { ReportCreateCoreModule } from '../report-create/report-create.core.module'
+import { ReportExcelCoreModule } from '../report-excel/report-excel.core.module'
+import { AdminReportController } from './admin-report.controller'
+
+@Module({
+  imports: [
+    AuthorizationCoreModule,
+    CompanyCoreModule,
+    ReportExcelCoreModule,
+    ReportCreateCoreModule,
+  ],
+  controllers: [AdminReportController],
+  providers: [AdminGuard],
+})
+export class AdminReportApiModule {}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
@@ -1,0 +1,125 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  MaxFileSizeValidator,
+  Param,
+  ParseFilePipe,
+  ParseUUIDPipe,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common'
+import { FileInterceptor } from '@nestjs/platform-express'
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger'
+
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+
+import { DoeResponse } from '../../core/decorators/doe-response.decorator'
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { ICompanyService } from '../company/company.service.interface'
+import { CompanyModel } from '../company/models/company.model'
+import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
+import { IReportCreateService } from '../report-create/report-create.service.interface'
+import { ParsedReportDto } from '../report-excel/dto/parsed-report.dto'
+import { IReportExcelService } from '../report-excel/report-excel.service.interface'
+import { AdminEqualityReportDto } from './dto/admin-equality-report.dto'
+import { AdminSalaryReportDto } from './dto/admin-salary-report.dto'
+
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+const ONE_MB = 1024 * 1024
+const MAX_UPLOAD_BYTES = ONE_MB * 20
+
+@Controller({
+  path: 'admin-report',
+  version: '1',
+})
+@ApiTags('Admin Report')
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
+export class AdminReportController {
+  constructor(
+    @Inject(ICompanyService)
+    private readonly companyService: ICompanyService,
+    @Inject(IReportExcelService)
+    private readonly reportExcelService: IReportExcelService,
+    @Inject(IReportCreateService)
+    private readonly reportCreateService: IReportCreateService,
+  ) {}
+
+  @Post('companies/:companyId/reports/excel/import')
+  @ApiConsumes('multipart/form-data')
+  @ApiParam({ name: 'companyId', type: String })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: { file: { type: 'string', format: 'binary' } },
+      required: ['file'],
+    },
+  })
+  @DoeResponse({
+    operationId: 'importAdminSalaryReportWorkbook',
+    type: ParsedReportDto,
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async importWorkbook(
+    @Param('companyId', ParseUUIDPipe) _companyId: string,
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [new MaxFileSizeValidator({ maxSize: MAX_UPLOAD_BYTES })],
+      }),
+    )
+    file: Express.Multer.File,
+  ): Promise<ParsedReportDto> {
+    return this.reportExcelService.importWorkbook(file.buffer)
+  }
+
+  @Post('companies/:companyId/reports/salary')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiParam({ name: 'companyId', type: String })
+  @DoeResponse({
+    operationId: 'submitAdminSalaryReport',
+    status: 201,
+    type: CreateReportResponseDto,
+  })
+  async submitSalary(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Body() input: AdminSalaryReportDto,
+  ): Promise<CreateReportResponseDto> {
+    const company = await this.companyService.getById(companyId)
+    return this.reportCreateService.createSalary({
+      ...input,
+      companies: [CompanyModel.toSnapshot(company)],
+    })
+  }
+
+  @Post('companies/:companyId/reports/equality')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiParam({ name: 'companyId', type: String })
+  @DoeResponse({
+    operationId: 'submitAdminEqualityReport',
+    status: 201,
+    type: CreateReportResponseDto,
+  })
+  async submitEquality(
+    @Param('companyId', ParseUUIDPipe) companyId: string,
+    @Body() input: AdminEqualityReportDto,
+  ): Promise<CreateReportResponseDto> {
+    const company = await this.companyService.getById(companyId)
+    return this.reportCreateService.createEquality({
+      ...input,
+      companies: [CompanyModel.toSnapshot(company)],
+    })
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
@@ -1,8 +1,6 @@
 import {
   Body,
   Controller,
-  HttpCode,
-  HttpStatus,
   Inject,
   MaxFileSizeValidator,
   Param,
@@ -26,17 +24,12 @@ import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { ICompanyService } from '../company/company.service.interface'
-import { CompanyModel } from '../company/models/company.model'
 import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
-import { IReportCreateService } from '../report-create/report-create.service.interface'
 import { ParsedReportDto } from '../report-excel/dto/parsed-report.dto'
 import { IReportExcelService } from '../report-excel/report-excel.service.interface'
 import { AdminEqualityReportDto } from './dto/admin-equality-report.dto'
 import { AdminSalaryReportDto } from './dto/admin-salary-report.dto'
-
-const XLSX_MIME =
-  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+import { IAdminReportService } from './admin-report.service.interface'
 
 const ONE_MB = 1024 * 1024
 const MAX_UPLOAD_BYTES = ONE_MB * 20
@@ -50,12 +43,10 @@ const MAX_UPLOAD_BYTES = ONE_MB * 20
 @UseGuards(TokenJwtAuthGuard, AdminGuard)
 export class AdminReportController {
   constructor(
-    @Inject(ICompanyService)
-    private readonly companyService: ICompanyService,
+    @Inject(IAdminReportService)
+    private readonly adminReportService: IAdminReportService,
     @Inject(IReportExcelService)
     private readonly reportExcelService: IReportExcelService,
-    @Inject(IReportCreateService)
-    private readonly reportCreateService: IReportCreateService,
   ) {}
 
   @Post('companies/:companyId/reports/excel/import')
@@ -86,7 +77,6 @@ export class AdminReportController {
   }
 
   @Post('companies/:companyId/reports/salary')
-  @HttpCode(HttpStatus.CREATED)
   @ApiParam({ name: 'companyId', type: String })
   @DoeResponse({
     operationId: 'submitAdminSalaryReport',
@@ -97,15 +87,10 @@ export class AdminReportController {
     @Param('companyId', ParseUUIDPipe) companyId: string,
     @Body() input: AdminSalaryReportDto,
   ): Promise<CreateReportResponseDto> {
-    const company = await this.companyService.getById(companyId)
-    return this.reportCreateService.createSalary({
-      ...input,
-      companies: [CompanyModel.toSnapshot(company)],
-    })
+    return this.adminReportService.submitSalary(companyId, input)
   }
 
   @Post('companies/:companyId/reports/equality')
-  @HttpCode(HttpStatus.CREATED)
   @ApiParam({ name: 'companyId', type: String })
   @DoeResponse({
     operationId: 'submitAdminEqualityReport',
@@ -116,10 +101,6 @@ export class AdminReportController {
     @Param('companyId', ParseUUIDPipe) companyId: string,
     @Body() input: AdminEqualityReportDto,
   ): Promise<CreateReportResponseDto> {
-    const company = await this.companyService.getById(companyId)
-    return this.reportCreateService.createEquality({
-      ...input,
-      companies: [CompanyModel.toSnapshot(company)],
-    })
+    return this.adminReportService.submitEquality(companyId, input)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.core.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common'
+
+import { CompanyCoreModule } from '../company/company.core.module'
+import { ReportCoreModule } from '../report/report.core.module'
+import { ReportCreateCoreModule } from '../report-create/report-create.core.module'
+import { AdminReportService } from './admin-report.service'
+import { IAdminReportService } from './admin-report.service.interface'
+
+@Module({
+  imports: [CompanyCoreModule, ReportCoreModule, ReportCreateCoreModule],
+  providers: [
+    {
+      provide: IAdminReportService,
+      useClass: AdminReportService,
+    },
+  ],
+  exports: [IAdminReportService],
+})
+export class AdminReportCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.interface.ts
@@ -1,0 +1,17 @@
+import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
+import { AdminEqualityReportDto } from './dto/admin-equality-report.dto'
+import { AdminSalaryReportDto } from './dto/admin-salary-report.dto'
+
+export interface IAdminReportService {
+  submitEquality(
+    companyId: string,
+    dto: AdminEqualityReportDto,
+  ): Promise<CreateReportResponseDto>
+
+  submitSalary(
+    companyId: string,
+    dto: AdminSalaryReportDto,
+  ): Promise<CreateReportResponseDto>
+}
+
+export const IAdminReportService = Symbol('IAdminReportService')

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.ts
@@ -5,10 +5,9 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common'
 const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 function randomAlpha(length = 6): string {
-  return Array.from(
-    randomBytes(length),
-    (b) => ALPHA[b % ALPHA.length],
-  ).join('')
+  return Array.from(randomBytes(length), (b) => ALPHA[b % ALPHA.length]).join(
+    '',
+  )
 }
 
 import { ICompanyService } from '../company/company.service.interface'

--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.service.ts
@@ -1,0 +1,69 @@
+import { randomBytes } from 'crypto'
+
+import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+
+const ALPHA = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+function randomAlpha(length = 6): string {
+  return Array.from(
+    randomBytes(length),
+    (b) => ALPHA[b % ALPHA.length],
+  ).join('')
+}
+
+import { ICompanyService } from '../company/company.service.interface'
+import { CompanyModel } from '../company/models/company.model'
+import { IReportService } from '../report/report.service.interface'
+import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
+import { IReportCreateService } from '../report-create/report-create.service.interface'
+import { AdminEqualityReportDto } from './dto/admin-equality-report.dto'
+import { AdminSalaryReportDto } from './dto/admin-salary-report.dto'
+import { IAdminReportService } from './admin-report.service.interface'
+
+@Injectable()
+export class AdminReportService implements IAdminReportService {
+  constructor(
+    @Inject(ICompanyService)
+    private readonly companyService: ICompanyService,
+    @Inject(IReportService)
+    private readonly reportService: IReportService,
+    @Inject(IReportCreateService)
+    private readonly reportCreateService: IReportCreateService,
+  ) {}
+
+  async submitEquality(
+    companyId: string,
+    dto: AdminEqualityReportDto,
+  ): Promise<CreateReportResponseDto> {
+    const company = await this.companyService.getById(companyId)
+
+    return this.reportCreateService.createEquality({
+      ...dto,
+      identifier: randomAlpha(),
+      companies: [CompanyModel.toSnapshot(company)],
+    })
+  }
+
+  async submitSalary(
+    companyId: string,
+    dto: AdminSalaryReportDto,
+  ): Promise<CreateReportResponseDto> {
+    const company = await this.companyService.getById(companyId)
+
+    const equalityReport =
+      await this.reportService.getActiveEqualityForCompany(companyId)
+
+    if (!equalityReport) {
+      throw new NotFoundException(
+        `No approved equality report found for company ${companyId}`,
+      )
+    }
+
+    return this.reportCreateService.createSalary({
+      ...dto,
+      identifier: randomAlpha(),
+      equalityReportId: equalityReport.id,
+      companies: [CompanyModel.toSnapshot(company)],
+    })
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-equality-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-equality-report.dto.ts
@@ -6,9 +6,6 @@ import {
 } from '../../report/models/report.enums'
 
 export class AdminEqualityReportDto {
-  @ApiString()
-  identifier!: string
-
   @ApiEnum(ReportProviderEnum)
   providerType!: ReportProviderEnum
 

--- a/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-equality-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-equality-report.dto.ts
@@ -1,0 +1,42 @@
+import { ApiEnum, ApiOptionalString, ApiString } from '@dmr.is/decorators'
+
+import {
+  GenderEnum,
+  ReportProviderEnum,
+} from '../../report/models/report.enums'
+
+export class AdminEqualityReportDto {
+  @ApiString()
+  identifier!: string
+
+  @ApiEnum(ReportProviderEnum)
+  providerType!: ReportProviderEnum
+
+  @ApiOptionalString({ nullable: true })
+  providerId!: string | null
+
+  @ApiString()
+  companyAdminName!: string
+
+  @ApiString()
+  companyAdminEmail!: string
+
+  @ApiEnum(GenderEnum)
+  companyAdminGender!: GenderEnum
+
+  @ApiString()
+  contactName!: string
+
+  @ApiString()
+  contactEmail!: string
+
+  @ApiString()
+  contactPhone!: string
+
+  @ApiString({
+    minLength: 1,
+    description:
+      'Narrative gender-equality plan. Persisted as `report.equality_report_content`.',
+  })
+  equalityReportContent!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
@@ -6,7 +6,6 @@ import {
   ApiOptionalDtoArray,
   ApiOptionalString,
   ApiString,
-  ApiUUID,
 } from '@dmr.is/decorators'
 
 import {
@@ -17,15 +16,6 @@ import { CreateReportOutlierDto } from '../../report-create/dto/create-report.dt
 import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
 
 export class AdminSalaryReportDto {
-  @ApiUUID({
-    description:
-      'FK to the approved EQUALITY report this salary was audited against.',
-  })
-  equalityReportId!: string
-
-  @ApiString()
-  identifier!: string
-
   @ApiBoolean()
   importedFromExcel!: boolean
 

--- a/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
@@ -1,0 +1,73 @@
+import {
+  ApiBoolean,
+  ApiDto,
+  ApiEnum,
+  ApiNumber,
+  ApiOptionalDtoArray,
+  ApiOptionalString,
+  ApiString,
+  ApiUUID,
+} from '@dmr.is/decorators'
+
+import {
+  GenderEnum,
+  ReportProviderEnum,
+} from '../../report/models/report.enums'
+import { CreateReportOutlierDto } from '../../report-create/dto/create-report.dto'
+import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
+
+export class AdminSalaryReportDto {
+  @ApiUUID({
+    description:
+      'FK to the approved EQUALITY report this salary was audited against.',
+  })
+  equalityReportId!: string
+
+  @ApiString()
+  identifier!: string
+
+  @ApiBoolean()
+  importedFromExcel!: boolean
+
+  @ApiEnum(ReportProviderEnum)
+  providerType!: ReportProviderEnum
+
+  @ApiOptionalString({ nullable: true })
+  providerId!: string | null
+
+  @ApiString()
+  companyAdminName!: string
+
+  @ApiString()
+  companyAdminEmail!: string
+
+  @ApiEnum(GenderEnum)
+  companyAdminGender!: GenderEnum
+
+  @ApiString()
+  contactName!: string
+
+  @ApiString()
+  contactEmail!: string
+
+  @ApiString()
+  contactPhone!: string
+
+  @ApiNumber()
+  averageEmployeeMaleCount!: number
+
+  @ApiNumber()
+  averageEmployeeFemaleCount!: number
+
+  @ApiNumber()
+  averageEmployeeNeutralCount!: number
+
+  @ApiDto(ParsedReportDto, {
+    description:
+      'Parsed workbook payload from the excel import endpoint. Contains the criteria tree, role list, and employee rows.',
+  })
+  parsed!: ParsedReportDto
+
+  @ApiOptionalDtoArray(CreateReportOutlierDto)
+  outliers?: CreateReportOutlierDto[]
+}

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -738,7 +738,9 @@ function makeCompanySnapshot(
 }
 
 function makeCompanySnapshotSource(
-  overrides: Partial<Omit<CreateReportCompanySnapshotDto, 'parentCompanyId'>> = {},
+  overrides: Partial<
+    Omit<CreateReportCompanySnapshotDto, 'parentCompanyId'>
+  > = {},
 ): Omit<CreateReportCompanySnapshotDto, 'parentCompanyId'> {
   return {
     companyId: 'subsidiary-1',

--- a/apps/directorate-of-equality-api/src/modules/company/company.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.api.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
+import { CompanyController } from './company.controller'
+import { CompanyCoreModule } from './company.core.module'
+
+@Module({
+  imports: [CompanyCoreModule, AuthorizationCoreModule],
+  controllers: [CompanyController],
+  providers: [AdminGuard],
+})
+export class CompanyApiModule {}

--- a/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
@@ -7,6 +7,7 @@ import {
   Inject,
   Param,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiParam, ApiTags } from '@nestjs/swagger'
@@ -15,10 +16,13 @@ import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
-import { ICompanyService } from './company.service.interface'
+import { ParseNationalIdPipe } from '../../core/pipes/parse-national-id.pipe'
 import { CompanyDto } from './dto/company.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
 import { CreateCompanyDto } from './dto/create-company.dto'
+import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
+import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { ICompanyService } from './company.service.interface'
 
 @Controller({
   path: 'companies',
@@ -34,9 +38,11 @@ export class CompanyController {
   ) {}
 
   @Get()
-  @DoeResponse({ operationId: 'getCompanies', type: [CompanyDto] })
-  async getCompanies(): Promise<CompanyDto[]> {
-    return this.companyService.getAll()
+  @DoeResponse({ operationId: 'getCompanies', type: GetCompaniesResponseDto })
+  async getCompanies(
+    @Query() query: GetCompaniesQueryDto,
+  ): Promise<GetCompaniesResponseDto> {
+    return this.companyService.getAll(query)
   }
 
   @Get('lookup/:nationalId')
@@ -47,7 +53,7 @@ export class CompanyController {
     include404: true,
   })
   async rskLookup(
-    @Param('nationalId') nationalId: string,
+    @Param('nationalId', ParseNationalIdPipe) nationalId: string,
   ): Promise<CompanyLookupDto> {
     return this.companyService.rskLookup(nationalId)
   }

--- a/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common'
+import { ApiBearerAuth, ApiParam, ApiTags } from '@nestjs/swagger'
+
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+
+import { DoeResponse } from '../../core/decorators/doe-response.decorator'
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { ICompanyService } from './company.service.interface'
+import { CompanyDto } from './dto/company.dto'
+import { CompanyLookupDto } from './dto/company-lookup.dto'
+import { CreateCompanyDto } from './dto/create-company.dto'
+
+@Controller({
+  path: 'companies',
+  version: '1',
+})
+@ApiTags('Companies')
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
+export class CompanyController {
+  constructor(
+    @Inject(ICompanyService)
+    private readonly companyService: ICompanyService,
+  ) {}
+
+  @Get()
+  @DoeResponse({ operationId: 'getCompanies', type: [CompanyDto] })
+  async getCompanies(): Promise<CompanyDto[]> {
+    return this.companyService.getAll()
+  }
+
+  @Get('lookup/:nationalId')
+  @ApiParam({ name: 'nationalId', type: String })
+  @DoeResponse({
+    operationId: 'rskLookupCompany',
+    type: CompanyLookupDto,
+    include404: true,
+  })
+  async rskLookup(
+    @Param('nationalId') nationalId: string,
+  ): Promise<CompanyLookupDto> {
+    return this.companyService.rskLookup(nationalId)
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @DoeResponse({ operationId: 'createCompany', status: 201, type: CompanyDto })
+  async createCompany(@Body() input: CreateCompanyDto): Promise<CompanyDto> {
+    return this.companyService.create(input)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { NationalRegistryModule } from '@dmr.is/clients-national-registry'
+
 import { CompanyModel } from './models/company.model'
 import { CompanyService } from './company.service'
 import { ICompanyService } from './company.service.interface'
 
 @Module({
-  imports: [SequelizeModule.forFeature([CompanyModel])],
+  imports: [SequelizeModule.forFeature([CompanyModel]), NationalRegistryModule],
   providers: [
     {
       provide: ICompanyService,

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
@@ -3,15 +3,19 @@ import { CompanyLookupDto } from './dto/company-lookup.dto'
 import { CompanyReportSnapshotLookup } from './dto/company-report-snapshot-lookup.dto'
 import { CompanyReportSnapshotSourceDto } from './dto/company-report-snapshot-source.dto'
 import { CreateCompanyInput } from './dto/create-company-input.dto'
+import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
+import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
 
 export {
   CompanyReportSnapshotLookup,
   CompanyReportSnapshotSourceDto,
   CreateCompanyInput,
+  GetCompaniesQueryDto,
+  GetCompaniesResponseDto,
 }
 
 export interface ICompanyService {
-  getAll(): Promise<CompanyDto[]>
+  getAll(query: GetCompaniesQueryDto): Promise<GetCompaniesResponseDto>
   getById(id: string): Promise<CompanyDto>
   getByNationalId(nationalId: string): Promise<CompanyDto>
   rskLookup(nationalId: string): Promise<CompanyLookupDto>

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
@@ -1,22 +1,21 @@
 import { CompanyDto } from './dto/company.dto'
+import { CompanyLookupDto } from './dto/company-lookup.dto'
+import { CompanyReportSnapshotLookup } from './dto/company-report-snapshot-lookup.dto'
+import { CompanyReportSnapshotSourceDto } from './dto/company-report-snapshot-source.dto'
+import { CreateCompanyInput } from './dto/create-company-input.dto'
 
-export interface CompanyReportSnapshotLookup {
-  name: string
-  nationalId: string
-}
-
-export interface CompanyReportSnapshotSourceDto {
-  companyId: string
-  name: string
-  nationalId: string
-  address: string
-  city: string
-  postcode: string
-  isatCategory: string
+export {
+  CompanyReportSnapshotLookup,
+  CompanyReportSnapshotSourceDto,
+  CreateCompanyInput,
 }
 
 export interface ICompanyService {
+  getAll(): Promise<CompanyDto[]>
+  getById(id: string): Promise<CompanyDto>
   getByNationalId(nationalId: string): Promise<CompanyDto>
+  rskLookup(nationalId: string): Promise<CompanyLookupDto>
+  create(input: CreateCompanyInput): Promise<CompanyDto>
   getOrCreateReportSnapshotSource(
     input: CompanyReportSnapshotLookup,
   ): Promise<CompanyReportSnapshotSourceDto>

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -134,9 +134,7 @@ describe('CompanyService', () => {
   })
 })
 
-function makeCompanyModel(
-  overrides: Partial<CompanyModel> = {},
-): CompanyModel {
+function makeCompanyModel(overrides: Partial<CompanyModel> = {}): CompanyModel {
   return {
     id: 'company-1',
     name: 'Acme ehf.',

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -2,6 +2,7 @@ import { NotFoundException } from '@nestjs/common'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
+import { INationalRegistryService } from '@dmr.is/clients-national-registry'
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { CompanyModel } from './models/company.model'
@@ -29,6 +30,10 @@ describe('CompanyService', () => {
       providers: [
         CompanyService,
         { provide: LOGGER_PROVIDER, useValue: mockLogger },
+        {
+          provide: INationalRegistryService,
+          useValue: { getEntityByNationalId: jest.fn() },
+        },
         {
           provide: getModelToken(CompanyModel),
           useValue: { findOneOrThrow, findOne, create },

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -17,6 +17,10 @@ import {
 
 import { CompanyDto } from './dto/company.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
+import {
+  CompanySortByEnum,
+  CompanySortDirectionEnum,
+} from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
 import { CompanyModel } from './models/company.model'
 import {
@@ -26,7 +30,6 @@ import {
   GetCompaniesQueryDto,
   ICompanyService,
 } from './company.service.interface'
-import { CompanySortByEnum, CompanySortDirectionEnum } from './dto/get-companies-query.dto'
 
 const LOGGING_CONTEXT = 'CompanyService'
 
@@ -65,7 +68,9 @@ export class CompanyService implements ICompanyService {
       query.sortBy === CompanySortByEnum.EMPLOYEE_COUNT
         ? 'averageEmployeeCountFromRsk'
         : 'name'
-    const sortDir = (query.direction ?? CompanySortDirectionEnum.ASC).toUpperCase()
+    const sortDir = (
+      query.direction ?? CompanySortDirectionEnum.ASC
+    ).toUpperCase()
     const order: Order = [[sortCol, sortDir]]
 
     const { rows, count } = await this.companyModel.findAndCountAll({

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -1,13 +1,21 @@
-import { Inject, Injectable } from '@nestjs/common'
+import {
+  ConflictException,
+  Inject,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
+import { INationalRegistryService } from '@dmr.is/clients-national-registry'
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { CompanyDto } from './dto/company.dto'
+import { CompanyLookupDto } from './dto/company-lookup.dto'
 import { CompanyModel } from './models/company.model'
 import {
   CompanyReportSnapshotLookup,
   CompanyReportSnapshotSourceDto,
+  CreateCompanyInput,
   ICompanyService,
 } from './company.service.interface'
 
@@ -17,9 +25,74 @@ const LOGGING_CONTEXT = 'CompanyService'
 export class CompanyService implements ICompanyService {
   constructor(
     @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @Inject(INationalRegistryService)
+    private readonly nationalRegistryService: INationalRegistryService,
     @InjectModel(CompanyModel)
     private readonly companyModel: typeof CompanyModel,
   ) {}
+
+  async getAll(): Promise<CompanyDto[]> {
+    const companies = await this.companyModel.findAll({
+      order: [['name', 'ASC']],
+    })
+    return companies.map((c) => c.fromModel())
+  }
+
+  async getById(id: string): Promise<CompanyDto> {
+    this.logger.debug(`Looking up company by id "${id}"`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    const company = await this.companyModel.findOneOrThrow(
+      { where: { id } },
+      `Company "${id}" not found`,
+    )
+
+    return company.fromModel()
+  }
+
+  async rskLookup(nationalId: string): Promise<CompanyLookupDto> {
+    this.logger.debug(
+      `Looking up company in national registry by national id "${nationalId}"`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    const result =
+      await this.nationalRegistryService.getEntityByNationalId(nationalId)
+
+    if (!result.entity) {
+      throw new NotFoundException(
+        `No entity found in national registry for "${nationalId}"`,
+      )
+    }
+
+    return { name: result.entity.nafn, nationalId: result.entity.kennitala }
+  }
+
+  async create(input: CreateCompanyInput): Promise<CompanyDto> {
+    this.logger.info(
+      `Creating company with national id "${input.nationalId}"`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    const existing = await this.companyModel.findOne({
+      where: { nationalId: input.nationalId },
+    })
+
+    if (existing) {
+      throw new ConflictException(
+        `Company with national id "${input.nationalId}" already exists`,
+      )
+    }
+
+    const company = await this.companyModel.create({
+      name: input.name,
+      nationalId: input.nationalId,
+      averageEmployeeCountFromRsk: input.averageEmployeeCountFromRsk,
+    })
+
+    return company.fromModel()
+  }
 
   async getByNationalId(nationalId: string): Promise<CompanyDto> {
     this.logger.debug(`Looking up company by national id "${nationalId}"`, {

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -1,3 +1,5 @@
+import { Op, Order, WhereOptions } from 'sequelize'
+
 import {
   ConflictException,
   Inject,
@@ -8,16 +10,23 @@ import { InjectModel } from '@nestjs/sequelize'
 
 import { INationalRegistryService } from '@dmr.is/clients-national-registry'
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import {
+  generatePaging,
+  getLimitAndOffset,
+} from '@dmr.is/utils-server/serverUtils'
 
 import { CompanyDto } from './dto/company.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
+import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
 import { CompanyModel } from './models/company.model'
 import {
   CompanyReportSnapshotLookup,
   CompanyReportSnapshotSourceDto,
   CreateCompanyInput,
+  GetCompaniesQueryDto,
   ICompanyService,
 } from './company.service.interface'
+import { CompanySortByEnum, CompanySortDirectionEnum } from './dto/get-companies-query.dto'
 
 const LOGGING_CONTEXT = 'CompanyService'
 
@@ -31,11 +40,46 @@ export class CompanyService implements ICompanyService {
     private readonly companyModel: typeof CompanyModel,
   ) {}
 
-  async getAll(): Promise<CompanyDto[]> {
-    const companies = await this.companyModel.findAll({
-      order: [['name', 'ASC']],
+  async getAll(query: GetCompaniesQueryDto): Promise<GetCompaniesResponseDto> {
+    const { limit, offset } = getLimitAndOffset(query)
+
+    const where: WhereOptions = {}
+
+    if (query.q) {
+      const pattern = `%${query.q.trim()}%`
+      Object.assign(where, {
+        [Op.or]: [
+          { name: { [Op.iLike]: pattern } },
+          { nationalId: { [Op.iLike]: pattern } },
+        ],
+      })
+    }
+
+    if (query.minEmployeeCount !== undefined) {
+      Object.assign(where, {
+        averageEmployeeCountFromRsk: { [Op.gte]: query.minEmployeeCount },
+      })
+    }
+
+    const sortCol =
+      query.sortBy === CompanySortByEnum.EMPLOYEE_COUNT
+        ? 'averageEmployeeCountFromRsk'
+        : 'name'
+    const sortDir = (query.direction ?? CompanySortDirectionEnum.ASC).toUpperCase()
+    const order: Order = [[sortCol, sortDir]]
+
+    const { rows, count } = await this.companyModel.findAndCountAll({
+      where,
+      order,
+      limit,
+      offset,
+      distinct: true,
+      col: 'id',
     })
-    return companies.map((c) => c.fromModel())
+
+    const companies = rows.map((c) => c.fromModel())
+    const paging = generatePaging(companies, query.page, query.pageSize, count)
+    return { companies, paging }
   }
 
   async getById(id: string): Promise<CompanyDto> {

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-lookup.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-lookup.dto.ts
@@ -1,0 +1,9 @@
+import { ApiString } from '@dmr.is/decorators'
+
+export class CompanyLookupDto {
+  @ApiString()
+  name!: string
+
+  @ApiString()
+  nationalId!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-report-snapshot-lookup.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-report-snapshot-lookup.dto.ts
@@ -1,0 +1,4 @@
+export class CompanyReportSnapshotLookup {
+  name!: string
+  nationalId!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-report-snapshot-source.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-report-snapshot-source.dto.ts
@@ -1,0 +1,9 @@
+export class CompanyReportSnapshotSourceDto {
+  companyId!: string
+  name!: string
+  nationalId!: string
+  address!: string
+  city!: string
+  postcode!: string
+  isatCategory!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/create-company-input.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/create-company-input.dto.ts
@@ -1,0 +1,5 @@
+export class CreateCompanyInput {
+  name!: string
+  nationalId!: string
+  averageEmployeeCountFromRsk!: number
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/create-company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/create-company.dto.ts
@@ -1,0 +1,12 @@
+import { ApiNumber, ApiString } from '@dmr.is/decorators'
+
+export class CreateCompanyDto {
+  @ApiString()
+  nationalId!: string
+
+  @ApiString()
+  name!: string
+
+  @ApiNumber()
+  averageEmployeeCountFromRsk!: number
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
@@ -1,0 +1,43 @@
+import { Transform } from 'class-transformer'
+import { IsEnum, IsNumber, IsOptional, IsString, Min } from 'class-validator'
+
+import { ApiOptionalEnum, ApiOptionalNumber, ApiOptionalString } from '@dmr.is/decorators'
+import { PagingQuery } from '@dmr.is/shared-dto'
+
+export enum CompanySortByEnum {
+  NAME = 'name',
+  EMPLOYEE_COUNT = 'employeeCount',
+}
+
+export enum CompanySortDirectionEnum {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class GetCompaniesQueryDto extends PagingQuery {
+  @ApiOptionalString({ description: 'Free-text search on company name or national ID.' })
+  @IsOptional()
+  @IsString()
+  q?: string
+
+  @ApiOptionalNumber({ description: 'Return only companies with averageEmployeeCountFromRsk >= this value.', minimum: 0 })
+  @Transform(({ value }) => {
+    if (value == null) return undefined
+    const n = parseInt(value, 10)
+    return Number.isNaN(n) ? undefined : n
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  minEmployeeCount?: number
+
+  @ApiOptionalEnum(CompanySortByEnum, { enumName: 'CompanySortByEnum' })
+  @IsOptional()
+  @IsEnum(CompanySortByEnum)
+  sortBy?: CompanySortByEnum
+
+  @ApiOptionalEnum(CompanySortDirectionEnum, { enumName: 'CompanySortDirectionEnum' })
+  @IsOptional()
+  @IsEnum(CompanySortDirectionEnum)
+  direction?: CompanySortDirectionEnum
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
@@ -1,7 +1,11 @@
 import { Transform } from 'class-transformer'
 import { IsEnum, IsNumber, IsOptional, IsString, Min } from 'class-validator'
 
-import { ApiOptionalEnum, ApiOptionalNumber, ApiOptionalString } from '@dmr.is/decorators'
+import {
+  ApiOptionalEnum,
+  ApiOptionalNumber,
+  ApiOptionalString,
+} from '@dmr.is/decorators'
 import { PagingQuery } from '@dmr.is/shared-dto'
 
 export enum CompanySortByEnum {
@@ -15,12 +19,18 @@ export enum CompanySortDirectionEnum {
 }
 
 export class GetCompaniesQueryDto extends PagingQuery {
-  @ApiOptionalString({ description: 'Free-text search on company name or national ID.' })
+  @ApiOptionalString({
+    description: 'Free-text search on company name or national ID.',
+  })
   @IsOptional()
   @IsString()
   q?: string
 
-  @ApiOptionalNumber({ description: 'Return only companies with averageEmployeeCountFromRsk >= this value.', minimum: 0 })
+  @ApiOptionalNumber({
+    description:
+      'Return only companies with averageEmployeeCountFromRsk >= this value.',
+    minimum: 0,
+  })
   @Transform(({ value }) => {
     if (value == null) return undefined
     const n = parseInt(value, 10)
@@ -36,7 +46,9 @@ export class GetCompaniesQueryDto extends PagingQuery {
   @IsEnum(CompanySortByEnum)
   sortBy?: CompanySortByEnum
 
-  @ApiOptionalEnum(CompanySortDirectionEnum, { enumName: 'CompanySortDirectionEnum' })
+  @ApiOptionalEnum(CompanySortDirectionEnum, {
+    enumName: 'CompanySortDirectionEnum',
+  })
   @IsOptional()
   @IsEnum(CompanySortDirectionEnum)
   direction?: CompanySortDirectionEnum

--- a/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-response.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-response.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+import { Paging } from '@dmr.is/shared-dto'
+
+import { CompanyDto } from './company.dto'
+
+export class GetCompaniesResponseDto {
+  @ApiProperty({ type: [CompanyDto] })
+  companies!: CompanyDto[]
+
+  @ApiProperty({ type: Paging })
+  paging!: Paging
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
@@ -3,6 +3,7 @@ import { Column, DataType } from 'sequelize-typescript'
 import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 
 import { DoeModels } from '../../../core/constants'
+import type { CreateReportCompanySnapshotDto } from '../../report-create/dto/create-report.dto'
 import type { CompanyDto } from '../dto/company.dto'
 
 type CompanyAttributes = {
@@ -63,6 +64,19 @@ export class CompanyModel extends MutableModel<
       nationalId: model.nationalId,
       salaryReportRequired: model.salaryReportRequired,
       salaryReportRequiredOverride: model.salaryReportRequiredOverride,
+    }
+  }
+
+  static toSnapshot(dto: CompanyDto): CreateReportCompanySnapshotDto {
+    return {
+      companyId: dto.id,
+      parentCompanyId: null,
+      name: dto.name,
+      nationalId: dto.nationalId,
+      address: '',
+      city: '',
+      postcode: '',
+      isatCategory: '',
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/config/config.controller.ts
@@ -36,19 +36,31 @@ export class ConfigController {
   }
 
   @Get(':key')
-  @DoeResponse({ operationId: 'getConfigByKey', type: ConfigDto, include404: true })
+  @DoeResponse({
+    operationId: 'getConfigByKey',
+    type: ConfigDto,
+    include404: true,
+  })
   async getByKey(@Param('key') key: string): Promise<ConfigDto> {
     return this.configService.getByKey(key)
   }
 
   @Get(':key/history')
-  @DoeResponse({ operationId: 'getConfigHistoryByKey', type: [ConfigDto], include404: true })
+  @DoeResponse({
+    operationId: 'getConfigHistoryByKey',
+    type: [ConfigDto],
+    include404: true,
+  })
   async getHistoryByKey(@Param('key') key: string): Promise<ConfigDto[]> {
     return this.configService.getHistoryByKey(key)
   }
 
   @Patch(':key')
-  @DoeResponse({ operationId: 'updateConfigByKey', type: ConfigDto, include404: true })
+  @DoeResponse({
+    operationId: 'updateConfigByKey',
+    type: ConfigDto,
+    include404: true,
+  })
   async updateByKey(
     @Param('key') key: string,
     @Body() dto: UpdateConfigDto,

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -371,8 +371,8 @@ export class ReportCreateService implements IReportCreateService {
         address: company.address,
         city: company.city,
         postcode: company.postcode,
-        averageEmployeeCountFromRsk:
-          companyById.get(company.companyId)!.averageEmployeeCountFromRsk,
+        averageEmployeeCountFromRsk: companyById.get(company.companyId)!
+          .averageEmployeeCountFromRsk,
         isatCategory: company.isatCategory,
       })),
     )

--- a/apps/directorate-of-equality-api/src/modules/swagger/doe-web.swagger.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/swagger/doe-web.swagger.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common'
 
+import { AdminReportApiModule } from '../admin-report/admin-report.api.module'
+import { CompanyApiModule } from '../company/company.api.module'
 import { ConfigApiModule } from '../config/config.api.module'
 import { ReportApiModule } from '../report/report.api.module'
 import { ReportCommentApiModule } from '../report-comment/report-comment.api.module'
@@ -8,6 +10,8 @@ import { UserApiModule } from '../user/user.api.module'
 
 @Module({
   imports: [
+    AdminReportApiModule,
+    CompanyApiModule,
     UserApiModule,
     ConfigApiModule,
     ReportApiModule,

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -1,6 +1,419 @@
 {
   "openapi": "3.0.0",
   "paths": {
+    "/api/v1/admin-report/companies/{companyId}/reports/excel/import": {
+      "post": {
+        "operationId": "importAdminSalaryReportWorkbook",
+        "parameters": [
+          {
+            "name": "companyId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" }
+                },
+                "required": ["file"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ParsedReportDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Admin Report"]
+      }
+    },
+    "/api/v1/admin-report/companies/{companyId}/reports/salary": {
+      "post": {
+        "operationId": "submitAdminSalaryReport",
+        "parameters": [
+          {
+            "name": "companyId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/AdminSalaryReportDto" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateReportResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Admin Report"]
+      }
+    },
+    "/api/v1/admin-report/companies/{companyId}/reports/equality": {
+      "post": {
+        "operationId": "submitAdminEqualityReport",
+        "parameters": [
+          {
+            "name": "companyId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminEqualityReportDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateReportResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Admin Report"]
+      }
+    },
+    "/api/v1/companies": {
+      "get": {
+        "operationId": "getCompanies",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": { "default": 1, "example": 1, "type": "number" }
+          },
+          {
+            "name": "pageSize",
+            "required": false,
+            "in": "query",
+            "schema": { "default": 10, "example": 10, "type": "number" }
+          },
+          {
+            "name": "q",
+            "required": false,
+            "in": "query",
+            "description": "Free-text search on company name or national ID.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "minEmployeeCount",
+            "required": false,
+            "in": "query",
+            "description": "Return only companies with averageEmployeeCountFromRsk >= this value.",
+            "schema": { "minimum": 0, "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCompaniesResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      },
+      "post": {
+        "operationId": "createCompany",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateCompanyDto" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/lookup/{nationalId}": {
+      "get": {
+        "operationId": "rskLookupCompany",
+        "parameters": [
+          {
+            "name": "nationalId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyLookupDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
     "/api/v1/users/me": {
       "get": {
         "operationId": "getMyUser",
@@ -1052,25 +1465,136 @@
       "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
     },
     "schemas": {
-      "UserDto": {
+      "ParsedSubCriterionStepDto": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "nationalId": { "type": "string" },
-          "firstName": { "type": "string" },
-          "lastName": { "type": "string" },
-          "email": { "type": "string" },
-          "phone": { "type": "string", "nullable": true },
-          "isActive": { "type": "boolean" }
+          "order": { "type": "number" },
+          "description": { "type": "string" },
+          "score": { "type": "number" }
+        },
+        "required": ["order", "description", "score"]
+      },
+      "ParsedSubCriterionDto": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "weight": { "type": "number" },
+          "steps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParsedSubCriterionStepDto"
+            }
+          }
+        },
+        "required": ["title", "description", "weight", "steps"]
+      },
+      "ParsedCriterionDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "RESPONSIBILITY",
+              "STRAIN",
+              "CONDITION",
+              "COMPETENCE",
+              "PERSONAL"
+            ]
+          },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "weight": { "type": "number" },
+          "subCriteria": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedSubCriterionDto" }
+          }
+        },
+        "required": ["type", "title", "description", "weight", "subCriteria"]
+      },
+      "ParsedStepAssignmentDto": {
+        "type": "object",
+        "properties": {
+          "criterionTitle": { "type": "string" },
+          "subTitle": { "type": "string" },
+          "stepOrder": { "type": "number" }
+        },
+        "required": ["criterionTitle", "subTitle", "stepOrder"]
+      },
+      "ParsedRoleDto": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "stepAssignments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedStepAssignmentDto" }
+          }
+        },
+        "required": ["title", "stepAssignments"]
+      },
+      "ParsedEmployeeDto": {
+        "type": "object",
+        "properties": {
+          "ordinal": { "type": "number" },
+          "identifier": { "type": "string" },
+          "roleTitle": { "type": "string" },
+          "education": {
+            "type": "string",
+            "enum": [
+              "COMPULSORY",
+              "UPPER_SECONDARY",
+              "VOCATIONAL",
+              "BACHELOR",
+              "MASTER",
+              "DOCTORATE",
+              "PROFESSIONAL"
+            ]
+          },
+          "gender": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
+          "field": { "type": "string" },
+          "department": { "type": "string" },
+          "startDate": { "type": "string" },
+          "workRatio": { "type": "number" },
+          "baseSalary": { "type": "number" },
+          "additionalSalary": { "type": "number" },
+          "bonusSalary": { "type": "number", "nullable": true },
+          "personalStepAssignments": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedStepAssignmentDto" }
+          }
         },
         "required": [
-          "id",
-          "nationalId",
-          "firstName",
-          "lastName",
-          "email",
-          "isActive"
+          "ordinal",
+          "identifier",
+          "roleTitle",
+          "education",
+          "gender",
+          "field",
+          "department",
+          "startDate",
+          "workRatio",
+          "baseSalary",
+          "additionalSalary",
+          "personalStepAssignments"
         ]
+      },
+      "ParsedReportDto": {
+        "type": "object",
+        "properties": {
+          "criteria": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedCriterionDto" }
+          },
+          "roles": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedRoleDto" }
+          },
+          "employees": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ParsedEmployeeDto" }
+          }
+        },
+        "required": ["criteria", "roles", "employees"]
       },
       "ApiErrorDto": {
         "type": "object",
@@ -1110,6 +1634,231 @@
           "details": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["statusCode", "timestamp"]
+      },
+      "CreateReportOutlierDto": {
+        "type": "object",
+        "properties": {
+          "employeeOrdinal": {
+            "type": "number",
+            "description": "Ordinal of the employee in `parsed.employees[]` this outlier justification applies to."
+          },
+          "postponed": {
+            "type": "boolean",
+            "description": "When true, defers the explanation. Other fields may be omitted. Defaults to false."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Required when `postponed` is false."
+          },
+          "action": {
+            "type": "string",
+            "description": "Required when `postponed` is false."
+          },
+          "signatureName": {
+            "type": "string",
+            "description": "Required when `postponed` is false."
+          },
+          "signatureRole": {
+            "type": "string",
+            "description": "Required when `postponed` is false."
+          }
+        },
+        "required": ["employeeOrdinal"]
+      },
+      "AdminSalaryReportDto": {
+        "type": "object",
+        "properties": {
+          "equalityReportId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "FK to the approved EQUALITY report this salary was audited against."
+          },
+          "identifier": { "type": "string" },
+          "importedFromExcel": { "type": "boolean" },
+          "providerType": {
+            "type": "string",
+            "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
+          },
+          "providerId": { "type": "string", "nullable": true },
+          "companyAdminName": { "type": "string" },
+          "companyAdminEmail": { "type": "string" },
+          "companyAdminGender": {
+            "type": "string",
+            "enum": ["MALE", "FEMALE", "NEUTRAL"]
+          },
+          "contactName": { "type": "string" },
+          "contactEmail": { "type": "string" },
+          "contactPhone": { "type": "string" },
+          "averageEmployeeMaleCount": { "type": "number" },
+          "averageEmployeeFemaleCount": { "type": "number" },
+          "averageEmployeeNeutralCount": { "type": "number" },
+          "parsed": {
+            "description": "Parsed workbook payload from the excel import endpoint. Contains the criteria tree, role list, and employee rows.",
+            "allOf": [{ "$ref": "#/components/schemas/ParsedReportDto" }]
+          },
+          "outliers": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CreateReportOutlierDto" }
+          }
+        },
+        "required": [
+          "equalityReportId",
+          "identifier",
+          "importedFromExcel",
+          "providerType",
+          "companyAdminName",
+          "companyAdminEmail",
+          "companyAdminGender",
+          "contactName",
+          "contactEmail",
+          "contactPhone",
+          "averageEmployeeMaleCount",
+          "averageEmployeeFemaleCount",
+          "averageEmployeeNeutralCount",
+          "parsed"
+        ]
+      },
+      "CreateReportResponseDto": {
+        "type": "object",
+        "properties": {
+          "reportId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Identifier of the newly created report row."
+          }
+        },
+        "required": ["reportId"]
+      },
+      "AdminEqualityReportDto": {
+        "type": "object",
+        "properties": {
+          "identifier": { "type": "string" },
+          "providerType": {
+            "type": "string",
+            "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
+          },
+          "providerId": { "type": "string", "nullable": true },
+          "companyAdminName": { "type": "string" },
+          "companyAdminEmail": { "type": "string" },
+          "companyAdminGender": {
+            "type": "string",
+            "enum": ["MALE", "FEMALE", "NEUTRAL"]
+          },
+          "contactName": { "type": "string" },
+          "contactEmail": { "type": "string" },
+          "contactPhone": { "type": "string" },
+          "equalityReportContent": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Narrative gender-equality plan. Persisted as `report.equality_report_content`."
+          }
+        },
+        "required": [
+          "identifier",
+          "providerType",
+          "companyAdminName",
+          "companyAdminEmail",
+          "companyAdminGender",
+          "contactName",
+          "contactEmail",
+          "contactPhone",
+          "equalityReportContent"
+        ]
+      },
+      "CompanyDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "averageEmployeeCountFromRsk": { "type": "number" },
+          "nationalId": { "type": "string" },
+          "salaryReportRequired": { "type": "boolean" },
+          "salaryReportRequiredOverride": { "type": "boolean" }
+        },
+        "required": [
+          "id",
+          "name",
+          "averageEmployeeCountFromRsk",
+          "nationalId",
+          "salaryReportRequired",
+          "salaryReportRequiredOverride"
+        ]
+      },
+      "Paging": {
+        "type": "object",
+        "properties": {
+          "page": { "type": "number", "example": 1 },
+          "totalPages": { "type": "number", "example": 10 },
+          "totalItems": { "type": "number", "example": 1000 },
+          "nextPage": { "type": "number", "example": 2, "nullable": true },
+          "previousPage": { "type": "number", "example": 1, "nullable": true },
+          "pageSize": {
+            "type": "number",
+            "example": 10,
+            "minimum": 1,
+            "maximum": 100
+          },
+          "hasNextPage": { "type": "boolean", "example": true },
+          "hasPreviousPage": { "type": "boolean", "example": false }
+        },
+        "required": [
+          "page",
+          "totalPages",
+          "totalItems",
+          "nextPage",
+          "previousPage",
+          "pageSize",
+          "hasNextPage",
+          "hasPreviousPage"
+        ]
+      },
+      "GetCompaniesResponseDto": {
+        "type": "object",
+        "properties": {
+          "companies": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CompanyDto" }
+          },
+          "paging": { "$ref": "#/components/schemas/Paging" }
+        },
+        "required": ["companies", "paging"]
+      },
+      "CompanyLookupDto": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "nationalId": { "type": "string" }
+        },
+        "required": ["name", "nationalId"]
+      },
+      "CreateCompanyDto": {
+        "type": "object",
+        "properties": {
+          "nationalId": { "type": "string" },
+          "name": { "type": "string" },
+          "averageEmployeeCountFromRsk": { "type": "number" }
+        },
+        "required": ["nationalId", "name", "averageEmployeeCountFromRsk"]
+      },
+      "UserDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "nationalId": { "type": "string" },
+          "firstName": { "type": "string" },
+          "lastName": { "type": "string" },
+          "email": { "type": "string" },
+          "phone": { "type": "string", "nullable": true },
+          "isActive": { "type": "boolean" }
+        },
+        "required": [
+          "id",
+          "nationalId",
+          "firstName",
+          "lastName",
+          "email",
+          "isActive"
+        ]
       },
       "ConfigDto": {
         "type": "object",
@@ -1196,34 +1945,6 @@
           }
         },
         "required": ["id", "type", "status"]
-      },
-      "Paging": {
-        "type": "object",
-        "properties": {
-          "page": { "type": "number", "example": 1 },
-          "totalPages": { "type": "number", "example": 10 },
-          "totalItems": { "type": "number", "example": 1000 },
-          "nextPage": { "type": "number", "example": 2, "nullable": true },
-          "previousPage": { "type": "number", "example": 1, "nullable": true },
-          "pageSize": {
-            "type": "number",
-            "example": 10,
-            "minimum": 1,
-            "maximum": 100
-          },
-          "hasNextPage": { "type": "boolean", "example": true },
-          "hasPreviousPage": { "type": "boolean", "example": false }
-        },
-        "required": [
-          "page",
-          "totalPages",
-          "totalItems",
-          "nextPage",
-          "previousPage",
-          "pageSize",
-          "hasNextPage",
-          "hasPreviousPage"
-        ]
       },
       "GetReportsResponseDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -240,6 +240,20 @@
             "in": "query",
             "description": "Return only companies with averageEmployeeCountFromRsk >= this value.",
             "schema": { "minimum": 0, "type": "number" }
+          },
+          {
+            "name": "sortBy",
+            "required": false,
+            "in": "query",
+            "schema": { "$ref": "#/components/schemas/CompanySortByEnum" }
+          },
+          {
+            "name": "direction",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/CompanySortDirectionEnum"
+            }
           }
         ],
         "responses": {
@@ -1668,12 +1682,6 @@
       "AdminSalaryReportDto": {
         "type": "object",
         "properties": {
-          "equalityReportId": {
-            "type": "string",
-            "format": "uuid",
-            "description": "FK to the approved EQUALITY report this salary was audited against."
-          },
-          "identifier": { "type": "string" },
           "importedFromExcel": { "type": "boolean" },
           "providerType": {
             "type": "string",
@@ -1702,8 +1710,6 @@
           }
         },
         "required": [
-          "equalityReportId",
-          "identifier",
           "importedFromExcel",
           "providerType",
           "companyAdminName",
@@ -1732,7 +1738,6 @@
       "AdminEqualityReportDto": {
         "type": "object",
         "properties": {
-          "identifier": { "type": "string" },
           "providerType": {
             "type": "string",
             "enum": ["SYSTEM", "ISLAND_IS", "OTHER"]
@@ -1754,7 +1759,6 @@
           }
         },
         "required": [
-          "identifier",
           "providerType",
           "companyAdminName",
           "companyAdminEmail",
@@ -1765,6 +1769,11 @@
           "equalityReportContent"
         ]
       },
+      "CompanySortByEnum": {
+        "type": "string",
+        "enum": ["name", "employeeCount"]
+      },
+      "CompanySortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
       "CompanyDto": {
         "type": "object",
         "properties": {

--- a/apps/directorate-of-equality-web/next-env.d.ts
+++ b/apps/directorate-of-equality-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/directorate-of-equality-web/next-env.d.ts
+++ b/apps/directorate-of-equality-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
@@ -1,16 +1,18 @@
 import { Suspense } from 'react'
 
-import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
 import { getQueryClient } from '@dmr.is/trpc/client/server'
-
 import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
 
 import { CompaniesPage } from '../../../components/companies/CompaniesPage'
 import { trpc } from '../../../lib/trpc/client/server'
 
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+
 export default async function FyrirtaekiPage() {
   const queryClient = getQueryClient()
-  await queryClient.prefetchQuery(trpc.company.list.queryOptions({ pageSize: 1000 }))
+  await queryClient.prefetchQuery(
+    trpc.company.list.queryOptions({ pageSize: 1000 }),
+  )
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
@@ -8,35 +8,9 @@ import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
 import { CompaniesPage } from '../../../components/companies/CompaniesPage'
 import { trpc } from '../../../lib/trpc/client/server'
 
-type SearchParams = {
-  q?: string
-  minEmployeeCount?: string
-  page?: string
-  pageSize?: string
-  sortBy?: 'name' | 'employeeCount'
-  direction?: 'asc' | 'desc'
-}
-
-export default async function FyrirtaekiPage({
-  searchParams,
-}: {
-  searchParams: Promise<SearchParams>
-}) {
-  const params = await searchParams
+export default async function FyrirtaekiPage() {
   const queryClient = getQueryClient()
-
-  await queryClient.prefetchQuery(
-    trpc.company.list.queryOptions({
-      q: params.q || undefined,
-      minEmployeeCount: params.minEmployeeCount
-        ? parseInt(params.minEmployeeCount, 10) || undefined
-        : undefined,
-      page: params.page ? parseInt(params.page, 10) || 1 : 1,
-      pageSize: params.pageSize ? parseInt(params.pageSize, 10) || 10 : 10,
-      sortBy: params.sortBy,
-      direction: params.direction,
-    }),
-  )
+  await queryClient.prefetchQuery(trpc.company.list.queryOptions({ pageSize: 1000 }))
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/fyrirtaeki/page.tsx
@@ -1,0 +1,48 @@
+import { Suspense } from 'react'
+
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { getQueryClient } from '@dmr.is/trpc/client/server'
+
+import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
+
+import { CompaniesPage } from '../../../components/companies/CompaniesPage'
+import { trpc } from '../../../lib/trpc/client/server'
+
+type SearchParams = {
+  q?: string
+  minEmployeeCount?: string
+  page?: string
+  pageSize?: string
+  sortBy?: 'name' | 'employeeCount'
+  direction?: 'asc' | 'desc'
+}
+
+export default async function FyrirtaekiPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const params = await searchParams
+  const queryClient = getQueryClient()
+
+  await queryClient.prefetchQuery(
+    trpc.company.list.queryOptions({
+      q: params.q || undefined,
+      minEmployeeCount: params.minEmployeeCount
+        ? parseInt(params.minEmployeeCount, 10) || undefined
+        : undefined,
+      page: params.page ? parseInt(params.page, 10) || 1 : 1,
+      pageSize: params.pageSize ? parseInt(params.pageSize, 10) || 10 : 10,
+      sortBy: params.sortBy,
+      direction: params.direction,
+    }),
+  )
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<SkeletonLoader repeat={5} height={44} space={1} />}>
+        <CompaniesPage />
+      </Suspense>
+    </HydrationBoundary>
+  )
+}

--- a/apps/directorate-of-equality-web/src/app/layout.tsx
+++ b/apps/directorate-of-equality-web/src/app/layout.tsx
@@ -5,8 +5,6 @@ import { globalStyles } from '@dmr.is/ui/globalStyles'
 import { RootProviders } from '../components/providers/RootProviders'
 import { authOptions } from '../lib/auth/authOptions'
 
-import '../styles/global.css'
-
 globalStyles()
 
 export const metadata = {

--- a/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
@@ -2,9 +2,6 @@
 
 import { useMemo, useState } from 'react'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
-import { type ColumnDef } from '@tanstack/react-table'
-
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Filter } from '@dmr.is/ui/components/island-is/Filter'
@@ -19,6 +16,9 @@ import { Table } from '@dmr.is/ui/components/Tables/Table'
 
 import { useTRPC } from '../../lib/trpc/client/trpc'
 import { CreateCompanyModal } from './CreateCompanyModal'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ColumnDef } from '@tanstack/react-table'
 
 type CompanyRow = {
   name: string
@@ -105,7 +105,12 @@ export const CompaniesPage = () => {
       <GridContainer>
         <GridRow>
           <GridColumn span="12/12">
-            <Box display="flex" justifyContent="spaceBetween" alignItems="center" marginBottom={3}>
+            <Box
+              display="flex"
+              justifyContent="spaceBetween"
+              alignItems="center"
+              marginBottom={3}
+            >
               <Text variant="h2">Fyrirtæki</Text>
               <Button
                 icon="add"

--- a/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import {
+  parseAsInteger,
+  parseAsString,
+  parseAsStringEnum,
+  useQueryStates,
+} from 'nuqs'
+import { useState } from 'react'
+
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { Select } from '@dmr.is/ui/components/island-is/Select'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { DataTable } from '@dmr.is/ui/components/Tables/DataTable'
+
+import { useTRPC } from '../../lib/trpc/client/trpc'
+import { CreateCompanyModal } from './CreateCompanyModal'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+const EMPLOYEE_COUNT_OPTIONS = [
+  { label: 'Sýna allt', value: 0 },
+  { label: '50+', value: 50 },
+  { label: '100+', value: 100 },
+  { label: '150+', value: 150 },
+  { label: '200+', value: 200 },
+]
+
+export const CompaniesPage = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [searchInput, setSearchInput] = useState('')
+
+  const [filters, setFilters] = useQueryStates({
+    q: parseAsString.withDefault(''),
+    minEmployeeCount: parseAsInteger.withDefault(0),
+    page: parseAsInteger.withDefault(1),
+    pageSize: parseAsInteger.withDefault(10),
+    sortBy: parseAsStringEnum<'name' | 'employeeCount'>([
+      'name',
+      'employeeCount',
+    ]).withDefault('name'),
+    direction: parseAsStringEnum<'asc' | 'desc'>(['asc', 'desc']).withDefault(
+      'asc',
+    ),
+  })
+
+  const trpc = useTRPC()
+  const { data } = useSuspenseQuery(
+    trpc.company.list.queryOptions({
+      q: filters.q || undefined,
+      minEmployeeCount: filters.minEmployeeCount || undefined,
+      page: filters.page,
+      pageSize: filters.pageSize,
+      sortBy: filters.sortBy,
+      direction: filters.direction,
+    }),
+  )
+
+  const handleSearch = () => {
+    setFilters({ q: searchInput || null, page: 1 })
+  }
+
+  const handleSort = (field: string) => {
+    if (field !== 'name' && field !== 'employeeCount') return
+    const isSameField = filters.sortBy === field
+    setFilters({
+      sortBy: field,
+      direction: isSameField && filters.direction === 'asc' ? 'desc' : 'asc',
+      page: 1,
+    })
+  }
+
+  const columns = [
+    {
+      field: 'name' as const,
+      children: 'Nafn',
+      sortable: true,
+      sortBy: filters.sortBy === 'name' ? filters.sortBy : undefined,
+      direction: filters.sortBy === 'name' ? filters.direction : undefined,
+      onSort: handleSort,
+    },
+    {
+      field: 'nationalId' as const,
+      children: 'Kennitala',
+    },
+    {
+      field: 'employeeCount' as const,
+      children: 'Meðalfjöldi starfsmanna',
+      sortable: true,
+      sortBy: filters.sortBy === 'employeeCount' ? filters.sortBy : undefined,
+      direction:
+        filters.sortBy === 'employeeCount' ? filters.direction : undefined,
+      onSort: handleSort,
+    },
+  ] as const
+
+  const hasActiveFilters = !!filters.q || filters.minEmployeeCount !== 0
+
+  return (
+    <Box marginTop={[3, 4]}>
+      <GridContainer>
+        <GridRow>
+          <GridColumn span="12/12">
+            <Stack space={3}>
+              <Inline justifyContent="spaceBetween" alignY="center">
+                <Text variant="h2">Fyrirtæki</Text>
+                <Button
+                  icon="add"
+                  iconType="outline"
+                  onClick={() => setIsModalOpen(true)}
+                >
+                  Nýtt fyrirtæki
+                </Button>
+              </Inline>
+
+              <Inline space={2} alignY="bottom">
+                <TextInput
+                  name="search"
+                  label="Leita"
+                  placeholder="Nafn eða kennitala..."
+                  value={searchInput}
+                  onChange={(e) => setSearchInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSearch()
+                  }}
+                />
+                <Select
+                  size="sm"
+                  name="minEmployeeCount"
+                  label="Fjöldi starfsfólks"
+                  value={EMPLOYEE_COUNT_OPTIONS.find(
+                    (o) => o.value === filters.minEmployeeCount,
+                  )}
+                  options={EMPLOYEE_COUNT_OPTIONS}
+                  onChange={(opt) =>
+                    setFilters({ minEmployeeCount: opt?.value ?? 0, page: 1 })
+                  }
+                />
+                <Button variant="ghost" size="small" onClick={handleSearch}>
+                  Leita
+                </Button>
+                {hasActiveFilters && (
+                  <Button
+                    variant="ghost"
+                    size="small"
+                    onClick={() => {
+                      setSearchInput('')
+                      setFilters({ q: null, minEmployeeCount: 0, page: 1 })
+                    }}
+                  >
+                    Hreinsa síur
+                  </Button>
+                )}
+              </Inline>
+
+              <DataTable
+                columns={columns}
+                rows={(data?.companies ?? []).map((c) => ({
+                  columns,
+                  name: c.name,
+                  nationalId: c.nationalId,
+                  employeeCount: c.averageEmployeeCountFromRsk,
+                }))}
+                paging={
+                  data?.paging
+                    ? {
+                        page: data.paging.page,
+                        pageSize: data.paging.pageSize,
+                        totalItems: data.paging.totalItems,
+                        totalPages: data.paging.totalPages,
+                      }
+                    : undefined
+                }
+                onPageChange={(page) => setFilters({ page })}
+                onPageSizeChange={(pageSize) =>
+                  setFilters({ pageSize, page: 1 })
+                }
+                noDataMessage="Engin fyrirtæki skráð"
+              />
+            </Stack>
+          </GridColumn>
+        </GridRow>
+      </GridContainer>
+      <CreateCompanyModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+      />
+    </Box>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompaniesPage.tsx
@@ -1,193 +1,198 @@
 'use client'
 
-import {
-  parseAsInteger,
-  parseAsString,
-  parseAsStringEnum,
-  useQueryStates,
-} from 'nuqs'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
-import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+import { useSuspenseQuery } from '@tanstack/react-query'
+import { type ColumnDef } from '@tanstack/react-table'
+
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Filter } from '@dmr.is/ui/components/island-is/Filter'
+import { FilterInput } from '@dmr.is/ui/components/island-is/FilterInput'
+import { FilterMultiChoice } from '@dmr.is/ui/components/island-is/FilterMultiChoice'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
 import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
-import { Inline } from '@dmr.is/ui/components/island-is/Inline'
-import { Select } from '@dmr.is/ui/components/island-is/Select'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
-import { DataTable } from '@dmr.is/ui/components/Tables/DataTable'
+import { Table } from '@dmr.is/ui/components/Tables/Table'
 
 import { useTRPC } from '../../lib/trpc/client/trpc'
 import { CreateCompanyModal } from './CreateCompanyModal'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
+type CompanyRow = {
+  name: string
+  nationalId: string
+  employees: number
+}
 
-const EMPLOYEE_COUNT_OPTIONS = [
-  { label: 'Sýna allt', value: 0 },
-  { label: '50+', value: 50 },
-  { label: '100+', value: 100 },
-  { label: '150+', value: 150 },
-  { label: '200+', value: 200 },
+const COLUMNS: ColumnDef<CompanyRow>[] = [
+  { accessorKey: 'name', header: 'Nafn', enableSorting: true },
+  { accessorKey: 'nationalId', header: 'Kennitala', enableSorting: false },
+  {
+    accessorKey: 'employees',
+    header: 'Meðalfjöldi starfsmanna',
+    enableSorting: true,
+  },
 ]
+
+const EMPLOYEE_RANGES = [
+  { value: '1-50', label: '1–50' },
+  { value: '51-100', label: '51–100' },
+  { value: '101-200', label: '101–200' },
+  { value: '201+', label: '201+' },
+]
+
+const inRange = (count: number, range: string): boolean => {
+  if (range === '1-50') return count >= 1 && count <= 50
+  if (range === '51-100') return count >= 51 && count <= 100
+  if (range === '101-200') return count >= 101 && count <= 200
+  if (range === '201+') return count >= 201
+  return false
+}
+
+const PAGE_SIZE = 10
 
 export const CompaniesPage = () => {
   const [isModalOpen, setIsModalOpen] = useState(false)
-  const [searchInput, setSearchInput] = useState('')
-
-  const [filters, setFilters] = useQueryStates({
-    q: parseAsString.withDefault(''),
-    minEmployeeCount: parseAsInteger.withDefault(0),
-    page: parseAsInteger.withDefault(1),
-    pageSize: parseAsInteger.withDefault(10),
-    sortBy: parseAsStringEnum<'name' | 'employeeCount'>([
-      'name',
-      'employeeCount',
-    ]).withDefault('name'),
-    direction: parseAsStringEnum<'asc' | 'desc'>(['asc', 'desc']).withDefault(
-      'asc',
-    ),
-  })
+  const [query, setQuery] = useState('')
+  const [employeeRanges, setEmployeeRanges] = useState<string[]>([])
+  const [page, setPage] = useState(1)
 
   const trpc = useTRPC()
   const { data } = useSuspenseQuery(
-    trpc.company.list.queryOptions({
-      q: filters.q || undefined,
-      minEmployeeCount: filters.minEmployeeCount || undefined,
-      page: filters.page,
-      pageSize: filters.pageSize,
-      sortBy: filters.sortBy,
-      direction: filters.direction,
-    }),
+    trpc.company.list.queryOptions({ pageSize: 1000 }),
   )
 
-  const handleSearch = () => {
-    setFilters({ q: searchInput || null, page: 1 })
-  }
+  const rows = useMemo<CompanyRow[]>(() => {
+    const all = (data?.companies ?? []).map((c) => ({
+      name: c.name,
+      nationalId: c.nationalId,
+      employees: c.averageEmployeeCountFromRsk,
+    }))
 
-  const handleSort = (field: string) => {
-    if (field !== 'name' && field !== 'employeeCount') return
-    const isSameField = filters.sortBy === field
-    setFilters({
-      sortBy: field,
-      direction: isSameField && filters.direction === 'asc' ? 'desc' : 'asc',
-      page: 1,
+    return all.filter((row) => {
+      if (query) {
+        const q = query.toLowerCase()
+        if (
+          !row.name.toLowerCase().includes(q) &&
+          !row.nationalId.includes(q)
+        ) {
+          return false
+        }
+      }
+      if (
+        employeeRanges.length &&
+        !employeeRanges.some((r) => inRange(row.employees, r))
+      ) {
+        return false
+      }
+      return true
     })
+  }, [data, query, employeeRanges])
+
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE))
+  const pageData = rows.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+
+  const handleReset = () => {
+    setQuery('')
+    setEmployeeRanges([])
+    setPage(1)
   }
-
-  const columns = [
-    {
-      field: 'name' as const,
-      children: 'Nafn',
-      sortable: true,
-      sortBy: filters.sortBy === 'name' ? filters.sortBy : undefined,
-      direction: filters.sortBy === 'name' ? filters.direction : undefined,
-      onSort: handleSort,
-    },
-    {
-      field: 'nationalId' as const,
-      children: 'Kennitala',
-    },
-    {
-      field: 'employeeCount' as const,
-      children: 'Meðalfjöldi starfsmanna',
-      sortable: true,
-      sortBy: filters.sortBy === 'employeeCount' ? filters.sortBy : undefined,
-      direction:
-        filters.sortBy === 'employeeCount' ? filters.direction : undefined,
-      onSort: handleSort,
-    },
-  ] as const
-
-  const hasActiveFilters = !!filters.q || filters.minEmployeeCount !== 0
 
   return (
     <Box marginTop={[3, 4]}>
       <GridContainer>
         <GridRow>
           <GridColumn span="12/12">
-            <Stack space={3}>
-              <Inline justifyContent="spaceBetween" alignY="center">
-                <Text variant="h2">Fyrirtæki</Text>
-                <Button
-                  icon="add"
-                  iconType="outline"
-                  onClick={() => setIsModalOpen(true)}
-                >
-                  Nýtt fyrirtæki
-                </Button>
-              </Inline>
+            <Box display="flex" justifyContent="spaceBetween" alignItems="center" marginBottom={3}>
+              <Text variant="h2">Fyrirtæki</Text>
+              <Button
+                icon="add"
+                iconType="outline"
+                onClick={() => setIsModalOpen(true)}
+              >
+                Nýtt fyrirtæki
+              </Button>
+            </Box>
+          </GridColumn>
 
-              <Inline space={2} alignY="bottom">
-                <TextInput
-                  name="search"
-                  label="Leita"
-                  placeholder="Nafn eða kennitala..."
-                  value={searchInput}
-                  onChange={(e) => setSearchInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') handleSearch()
+          <GridColumn span={['12/12', '3/12']}>
+            <Text variant="h5" fontWeight="semiBold" marginBottom={2}>
+              Leit og síun
+            </Text>
+            <Filter
+              labelClearAll="Hreinsa allar síur"
+              labelOpen="Opna síur"
+              labelClose="Loka síum"
+              labelClear="Hreinsa"
+              labelTitle="Síur"
+              labelResult="Sýna niðurstöður"
+              onFilterClear={handleReset}
+              variant="default"
+              filterInput={
+                <FilterInput
+                  name="query"
+                  placeholder="Leita að fyrirtæki..."
+                  value={query}
+                  onChange={(val) => {
+                    setQuery(val)
+                    setPage(1)
                   }}
+                  backgroundColor="white"
                 />
-                <Select
-                  size="sm"
-                  name="minEmployeeCount"
-                  label="Fjöldi starfsfólks"
-                  value={EMPLOYEE_COUNT_OPTIONS.find(
-                    (o) => o.value === filters.minEmployeeCount,
-                  )}
-                  options={EMPLOYEE_COUNT_OPTIONS}
-                  onChange={(opt) =>
-                    setFilters({ minEmployeeCount: opt?.value ?? 0, page: 1 })
+              }
+            >
+              <FilterMultiChoice
+                labelClear="Hreinsa"
+                onChange={({ categoryId, selected }) => {
+                  if (categoryId === 'employees') {
+                    setEmployeeRanges(selected)
+                    setPage(1)
                   }
-                />
-                <Button variant="ghost" size="small" onClick={handleSearch}>
-                  Leita
-                </Button>
-                {hasActiveFilters && (
-                  <Button
-                    variant="ghost"
-                    size="small"
-                    onClick={() => {
-                      setSearchInput('')
-                      setFilters({ q: null, minEmployeeCount: 0, page: 1 })
-                    }}
-                  >
-                    Hreinsa síur
-                  </Button>
-                )}
-              </Inline>
+                }}
+                onClear={(categoryId) => {
+                  if (categoryId === 'employees') {
+                    setEmployeeRanges([])
+                    setPage(1)
+                  }
+                }}
+                categories={[
+                  {
+                    id: 'employees',
+                    label: 'Starfsmenn',
+                    selected: employeeRanges,
+                    filters: EMPLOYEE_RANGES,
+                  },
+                ]}
+              />
+            </Filter>
+          </GridColumn>
 
-              <DataTable
-                columns={columns}
-                rows={(data?.companies ?? []).map((c) => ({
-                  columns,
-                  name: c.name,
-                  nationalId: c.nationalId,
-                  employeeCount: c.averageEmployeeCountFromRsk,
-                }))}
-                paging={
-                  data?.paging
-                    ? {
-                        page: data.paging.page,
-                        pageSize: data.paging.pageSize,
-                        totalItems: data.paging.totalItems,
-                        totalPages: data.paging.totalPages,
-                      }
-                    : undefined
-                }
-                onPageChange={(page) => setFilters({ page })}
-                onPageSizeChange={(pageSize) =>
-                  setFilters({ pageSize, page: 1 })
-                }
+          <GridColumn span={['12/12', '9/12']}>
+            <Stack space={3}>
+              <Box display="flex" alignItems="center" columnGap={1}>
+                <Text fontWeight="semiBold">{rows.length}</Text>
+                <Text>fyrirtæki fundust</Text>
+              </Box>
+              <Table
+                columns={COLUMNS}
+                data={pageData}
+                paging={{
+                  page,
+                  pageSize: PAGE_SIZE,
+                  totalItems: rows.length,
+                  totalPages,
+                }}
+                onPageChange={setPage}
+                showPageSizeSelect={false}
                 noDataMessage="Engin fyrirtæki skráð"
               />
             </Stack>
           </GridColumn>
         </GridRow>
       </GridContainer>
+
       <CreateCompanyModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+import { Modal } from '@dmr.is/ui/components/Modal/Modal'
+
+import { useTRPC } from '../../lib/trpc/client/trpc'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const CreateCompanyModal = ({ isOpen, onClose }: Props) => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+
+  const [nationalIdInput, setNationalIdInput] = useState('')
+  const [lookupNationalId, setLookupNationalId] = useState<string | null>(null)
+  const [employeeCount, setEmployeeCount] = useState('')
+
+  const lookupQuery = useQuery({
+    ...trpc.company.rskLookup.queryOptions({
+      nationalId: lookupNationalId ?? '',
+    }),
+    enabled: !!lookupNationalId,
+    retry: false,
+  })
+
+  const createMutation = useMutation({
+    ...trpc.company.create.mutationOptions(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: trpc.company.list.queryKey() })
+      toast.success('Fyrirtæki skráð')
+      handleClose()
+    },
+    onError: () => {
+      toast.error('Villa við skráningu fyrirtækis')
+    },
+  })
+
+  const handleClose = () => {
+    setNationalIdInput('')
+    setLookupNationalId(null)
+    setEmployeeCount('')
+    onClose()
+  }
+
+  const handleLookup = () => {
+    if (nationalIdInput.trim()) {
+      setLookupNationalId(nationalIdInput.trim())
+    }
+  }
+
+  const handleCreate = () => {
+    if (!lookupQuery.data || !employeeCount) return
+    createMutation.mutate({
+      nationalId: lookupQuery.data.nationalId,
+      name: lookupQuery.data.name,
+      averageEmployeeCountFromRsk: Number(employeeCount),
+    })
+  }
+
+  const lookedUp = !!lookupQuery.data
+  const canCreate =
+    lookedUp && !!employeeCount && Number(employeeCount) > 0
+
+  return (
+    <Modal
+      baseId="create-company-modal"
+      isVisible={isOpen}
+      title="Skrá nýtt fyrirtæki"
+      onVisibilityChange={(visible) => {
+        if (!visible) handleClose()
+      }}
+      toggleClose={handleClose}
+      width="small"
+    >
+      <Stack space={3}>
+        <Stack space={1}>
+          <Text variant="eyebrow">Kennitala fyrirtækis</Text>
+          <Inline space={2} alignY="center">
+            <Box flexGrow={1}>
+              <TextInput
+                name="nationalId"
+                label="Kennitala"
+                placeholder="000000-0000"
+                value={nationalIdInput}
+                onChange={(e) => {
+                  setNationalIdInput(e.target.value)
+                  if (lookupNationalId) setLookupNationalId(null)
+                }}
+              />
+            </Box>
+            <Button
+              variant="ghost"
+              size="small"
+              loading={lookupQuery.isFetching}
+              disabled={!nationalIdInput.trim()}
+              onClick={handleLookup}
+            >
+              Fletta upp
+            </Button>
+          </Inline>
+          {lookupQuery.isError && (
+            <Text color="red600" variant="small">
+              Fyrirtæki fannst ekki í þjóðskrá
+            </Text>
+          )}
+        </Stack>
+
+        <TextInput
+          name="name"
+          label="Nafn fyrirtækis"
+          value={lookupQuery.data?.name ?? ''}
+          readOnly
+          isLoading={lookupQuery.isFetching}
+          disabled={!lookedUp}
+        />
+
+        <TextInput
+          name="employeeCount"
+          label="Meðalfjöldi starfsmanna"
+          type="number"
+          value={employeeCount}
+          onChange={(e) => setEmployeeCount(e.target.value)}
+          disabled={!lookedUp}
+        />
+
+        <Inline justifyContent="flexEnd" space={2}>
+          <Button variant="ghost" onClick={handleClose}>
+            Hætta við
+          </Button>
+          <Button
+            disabled={!canCreate}
+            loading={createMutation.isPending}
+            onClick={handleCreate}
+          >
+            Skrá fyrirtæki
+          </Button>
+        </Inline>
+      </Stack>
+    </Modal>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
@@ -2,18 +2,18 @@
 
 import { useState } from 'react'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Inline } from '@dmr.is/ui/components/island-is/Inline'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
-import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 import { Modal } from '@dmr.is/ui/components/Modal/Modal'
 
 import { useTRPC } from '../../lib/trpc/client/trpc'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 type Props = {
   isOpen: boolean
@@ -71,8 +71,7 @@ export const CreateCompanyModal = ({ isOpen, onClose }: Props) => {
   }
 
   const lookedUp = !!lookupQuery.data
-  const canCreate =
-    lookedUp && !!employeeCount && Number(employeeCount) > 0
+  const canCreate = lookedUp && !!employeeCount && Number(employeeCount) > 0
 
   return (
     <Modal

--- a/apps/directorate-of-equality-web/src/components/header/ControlPanel.tsx
+++ b/apps/directorate-of-equality-web/src/components/header/ControlPanel.tsx
@@ -16,6 +16,7 @@ const NAV_PATHS = [
   { title: 'Heildarlisti', href: '/mal' },
   { title: 'Jafnréttisáætlanir', href: '/mal?category=jafnrettisaetlun' },
   { title: 'Úrbótaáætlanir', href: '/mal?category=urbotaaaetlun' },
+  { title: 'Fyrirtæki', href: '/fyrirtaeki' },
 ]
 
 export const ControlPanel = () => {

--- a/apps/directorate-of-equality-web/src/components/list-page/CreateEqualityReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/list-page/CreateEqualityReportDrawer.tsx
@@ -2,8 +2,9 @@
 
 import { useRef, useState } from 'react'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-
+import { HTMLEditor } from '@dmr.is/ui/components/Editor/Editor'
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Drawer } from '@dmr.is/ui/components/island-is/Drawer'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
@@ -14,11 +15,10 @@ import { Select } from '@dmr.is/ui/components/island-is/Select'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
-import { HTMLEditor } from '@dmr.is/ui/components/Editor/Editor'
-import { Box } from '@dmr.is/ui/components/island-is/Box'
-import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 
 import { useTRPC } from '../../lib/trpc/client/trpc'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 const GENDER_OPTIONS = [
   { label: 'Karl', value: 'MALE' },
@@ -123,7 +123,9 @@ export const CreateEqualityReportDrawer = () => {
                 name="company"
                 label="Veldu fyrirtæki"
                 options={companyOptions}
-                value={companyOptions.find((o) => o.value === companyId) ?? null}
+                value={
+                  companyOptions.find((o) => o.value === companyId) ?? null
+                }
                 onChange={(opt) => setCompanyId(opt?.value ?? null)}
                 isLoading={companiesQuery.isLoading}
                 backgroundColor="blue"
@@ -162,9 +164,7 @@ export const CreateEqualityReportDrawer = () => {
                 value={GENDER_OPTIONS.find(
                   (o) => o.value === form.companyAdminGender,
                 )}
-                onChange={(opt) =>
-                  opt && set('companyAdminGender')(opt.value)
-                }
+                onChange={(opt) => opt && set('companyAdminGender')(opt.value)}
                 backgroundColor="blue"
               />
             </GridColumn>

--- a/apps/directorate-of-equality-web/src/components/list-page/CreateEqualityReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/list-page/CreateEqualityReportDrawer.tsx
@@ -1,0 +1,252 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Drawer } from '@dmr.is/ui/components/island-is/Drawer'
+import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { Select } from '@dmr.is/ui/components/island-is/Select'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+import { HTMLEditor } from '@dmr.is/ui/components/Editor/Editor'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+
+import { useTRPC } from '../../lib/trpc/client/trpc'
+
+const GENDER_OPTIONS = [
+  { label: 'Karl', value: 'MALE' },
+  { label: 'Kona', value: 'FEMALE' },
+  { label: 'Kynhlutlægt', value: 'NEUTRAL' },
+] as const
+
+const EMPTY_FORM = {
+  companyAdminName: '',
+  companyAdminEmail: '',
+  companyAdminGender: 'MALE' as 'MALE' | 'FEMALE' | 'NEUTRAL',
+  contactName: '',
+  contactEmail: '',
+  contactPhone: '',
+  equalityReportContent: '',
+}
+
+export const CreateEqualityReportDrawer = () => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+
+  const [companyId, setCompanyId] = useState<string | null>(null)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const editorKey = useRef(0)
+
+  const set = (key: keyof typeof EMPTY_FORM) => (value: string) =>
+    setForm((prev) => ({ ...prev, [key]: value }))
+
+  const companiesQuery = useQuery(
+    trpc.company.list.queryOptions({ pageSize: 1000 }),
+  )
+
+  const companyOptions = (companiesQuery.data?.companies ?? []).map((c) => ({
+    label: `${c.name} (${c.nationalId})`,
+    value: c.id,
+  }))
+
+  const submitMutation = useMutation({
+    ...trpc.adminReport.submitEquality.mutationOptions(),
+    onSuccess: () => {
+      toast.success('Skýrsla send inn')
+      queryClient.invalidateQueries({ queryKey: trpc.reports.list.queryKey() })
+      handleReset()
+    },
+    onError: () => toast.error('Villa við innsendingu'),
+  })
+
+  const handleReset = () => {
+    setForm(EMPTY_FORM)
+    setCompanyId(null)
+    editorKey.current += 1
+  }
+
+  const handleSubmit = () => {
+    if (!companyId) return
+    submitMutation.mutate({
+      path: { companyId },
+      body: {
+        providerType: 'SYSTEM',
+        companyAdminName: form.companyAdminName,
+        companyAdminEmail: form.companyAdminEmail,
+        companyAdminGender: form.companyAdminGender,
+        contactName: form.contactName,
+        contactEmail: form.contactEmail,
+        contactPhone: form.contactPhone,
+        equalityReportContent: form.equalityReportContent,
+      },
+    })
+  }
+
+  const canSubmit =
+    !!companyId &&
+    !!form.companyAdminName &&
+    !!form.companyAdminEmail &&
+    !!form.contactName &&
+    !!form.contactEmail &&
+    !!form.contactPhone &&
+    !!form.equalityReportContent
+
+  return (
+    <Drawer
+      ariaLabel="Skrá jafnréttisáætlun"
+      baseId="create-equality-report-drawer"
+      disclosure={
+        <Button variant="utility" icon="add" iconType="outline">
+          Jafnréttisáætlun
+        </Button>
+      }
+    >
+      <GridContainer>
+        <Stack space={4}>
+          <Text variant="h2">Ný jafnréttisáætlun</Text>
+
+          <GridRow rowGap={[2, 3]}>
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Fyrirtæki
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '8/12']}>
+              <Select
+                name="company"
+                label="Veldu fyrirtæki"
+                options={companyOptions}
+                value={companyOptions.find((o) => o.value === companyId) ?? null}
+                onChange={(opt) => setCompanyId(opt?.value ?? null)}
+                isLoading={companiesQuery.isLoading}
+                backgroundColor="blue"
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Æðsti stjórnandi
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="companyAdminName"
+                label="Nafn"
+                value={form.companyAdminName}
+                onChange={(e) => set('companyAdminName')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="companyAdminEmail"
+                label="Netfang"
+                type="email"
+                value={form.companyAdminEmail}
+                onChange={(e) => set('companyAdminEmail')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <Select
+                name="companyAdminGender"
+                label="Kyn"
+                options={GENDER_OPTIONS}
+                value={GENDER_OPTIONS.find(
+                  (o) => o.value === form.companyAdminGender,
+                )}
+                onChange={(opt) =>
+                  opt && set('companyAdminGender')(opt.value)
+                }
+                backgroundColor="blue"
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Tengiliður
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactName"
+                label="Nafn"
+                value={form.contactName}
+                onChange={(e) => set('contactName')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactEmail"
+                label="Netfang"
+                type="email"
+                value={form.contactEmail}
+                onChange={(e) => set('contactEmail')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactPhone"
+                label="Símanúmer"
+                type="tel"
+                value={form.contactPhone}
+                onChange={(e) => set('contactPhone')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Skýrsla
+              </Text>
+            </GridColumn>
+            <GridColumn span="12/12">
+              <Box
+                border="standard"
+                position="relative"
+                zIndex={10}
+                borderRadius="large"
+              >
+                <HTMLEditor
+                  key={editorKey.current}
+                  disabled={!companyId}
+                  defaultValue={form.equalityReportContent}
+                  handleUpload={() => new Error('File upload not supported')}
+                  onChange={(value) => set('equalityReportContent')(value)}
+                  config={{
+                    toolbar:
+                      'bold italic underline | align numlist bullist | link',
+                  }}
+                />
+              </Box>
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Inline justifyContent="flexEnd" space={2}>
+                <Button variant="ghost" onClick={handleReset}>
+                  Hreinsa
+                </Button>
+                <Button
+                  disabled={!canSubmit}
+                  loading={submitMutation.isPending}
+                  onClick={handleSubmit}
+                >
+                  Senda inn
+                </Button>
+              </Inline>
+            </GridColumn>
+          </GridRow>
+        </Stack>
+      </GridContainer>
+    </Drawer>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/list-page/CreateSalaryReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/list-page/CreateSalaryReportDrawer.tsx
@@ -2,8 +2,7 @@
 
 import { useRef, useState } from 'react'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Checkbox } from '@dmr.is/ui/components/island-is/Checkbox'
@@ -16,10 +15,11 @@ import { Select } from '@dmr.is/ui/components/island-is/Select'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
-import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 
 import { type ParsedReportDto } from '../../gen/fetch/types.gen'
 import { useTRPC } from '../../lib/trpc/client/trpc'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
 const GENDER_OPTIONS = [
   { label: 'Karl', value: 'MALE' },
@@ -146,7 +146,7 @@ export const CreateSalaryReportDrawer = () => {
 
       if (!postpone) {
         toast.error(
-          `Útlægar niðurstöður fundust fyrir ${ordinals.length} starfsmenn. Merktu "Fresta útlágum" og gefðu ástæðu til að senda inn.`,
+          `Frávik fundust fyrir ${ordinals.length} starfsmenn. Merktu "Fresta skilum frávika" og gefðu ástæðu til að senda inn.`,
         )
         return
       }
@@ -208,7 +208,9 @@ export const CreateSalaryReportDrawer = () => {
                 name="company"
                 label="Veldu fyrirtæki"
                 options={companyOptions}
-                value={companyOptions.find((o) => o.value === companyId) ?? null}
+                value={
+                  companyOptions.find((o) => o.value === companyId) ?? null
+                }
                 onChange={(opt) => {
                   setCompanyId(opt?.value ?? null)
                   setParsedReport(null)
@@ -262,12 +264,12 @@ export const CreateSalaryReportDrawer = () => {
 
             <GridColumn span="12/12">
               <Text variant="h4" marginBottom={1}>
-                Útlægar niðurstöður
+                Frávik
               </Text>
             </GridColumn>
             <GridColumn span="12/12">
               <Checkbox
-                label="Fresta útlágum"
+                label="Fresta skilum frávika"
                 checked={postpone}
                 onChange={(e) => setPostpone(e.target.checked)}
                 disabled={!companyId}
@@ -318,9 +320,7 @@ export const CreateSalaryReportDrawer = () => {
                 value={GENDER_OPTIONS.find(
                   (o) => o.value === form.companyAdminGender,
                 )}
-                onChange={(opt) =>
-                  opt && set('companyAdminGender')(opt.value)
-                }
+                onChange={(opt) => opt && set('companyAdminGender')(opt.value)}
                 backgroundColor="blue"
               />
             </GridColumn>

--- a/apps/directorate-of-equality-web/src/components/list-page/CreateSalaryReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/list-page/CreateSalaryReportDrawer.tsx
@@ -1,0 +1,424 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Checkbox } from '@dmr.is/ui/components/island-is/Checkbox'
+import { Drawer } from '@dmr.is/ui/components/island-is/Drawer'
+import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { Select } from '@dmr.is/ui/components/island-is/Select'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+
+import { type ParsedReportDto } from '../../gen/fetch/types.gen'
+import { useTRPC } from '../../lib/trpc/client/trpc'
+
+const GENDER_OPTIONS = [
+  { label: 'Karl', value: 'MALE' },
+  { label: 'Kona', value: 'FEMALE' },
+  { label: 'Kynhlutlægt', value: 'NEUTRAL' },
+] as const
+
+const EMPTY_FORM = {
+  companyAdminName: '',
+  companyAdminEmail: '',
+  companyAdminGender: 'MALE' as 'MALE' | 'FEMALE' | 'NEUTRAL',
+  contactName: '',
+  contactEmail: '',
+  contactPhone: '',
+  averageEmployeeMaleCount: '',
+  averageEmployeeFemaleCount: '',
+  averageEmployeeNeutralCount: '',
+}
+
+function parseOutlierOrdinals(message: string): number[] | null {
+  const match = message.match(/employee ordinal\(s\): ([\d,\s]+)/)
+  if (!match) return null
+  return match[1]
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n))
+}
+
+export const CreateSalaryReportDrawer = () => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [companyId, setCompanyId] = useState<string | null>(null)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [parsedReport, setParsedReport] = useState<ParsedReportDto | null>(null)
+  const [postpone, setPostpone] = useState(false)
+  const [postponeReason, setPostponeReason] = useState('')
+
+  const set = (key: keyof typeof EMPTY_FORM) => (value: string) =>
+    setForm((prev) => ({ ...prev, [key]: value }))
+
+  const companiesQuery = useQuery(
+    trpc.company.list.queryOptions({ pageSize: 1000 }),
+  )
+
+  const companyOptions = (companiesQuery.data?.companies ?? []).map((c) => ({
+    label: `${c.name} (${c.nationalId})`,
+    value: c.id,
+  }))
+
+  const importMutation = useMutation({
+    ...trpc.adminReport.importWorkbook.mutationOptions(),
+    onSuccess: (data) => {
+      setParsedReport(data)
+      toast.success('Excel skrá flutt inn')
+    },
+    onError: () => toast.error('Villa við innflutning á Excel skrá'),
+  })
+
+  const submitMutation = useMutation(
+    trpc.adminReport.submitSalary.mutationOptions(),
+  )
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file || !companyId) return
+
+    const reader = new FileReader()
+    reader.onload = () => {
+      const base64 = (reader.result as string).split(',')[1]
+      importMutation.mutate({
+        path: { companyId },
+        body: { file: base64 },
+      })
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const handleReset = () => {
+    setForm(EMPTY_FORM)
+    setCompanyId(null)
+    setParsedReport(null)
+    setPostpone(false)
+    setPostponeReason('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleSubmit = async () => {
+    if (!companyId || !parsedReport) return
+
+    const body = {
+      importedFromExcel: true,
+      providerType: 'SYSTEM' as const,
+      companyAdminName: form.companyAdminName,
+      companyAdminEmail: form.companyAdminEmail,
+      companyAdminGender: form.companyAdminGender,
+      contactName: form.contactName,
+      contactEmail: form.contactEmail,
+      contactPhone: form.contactPhone,
+      averageEmployeeMaleCount: Number(form.averageEmployeeMaleCount),
+      averageEmployeeFemaleCount: Number(form.averageEmployeeFemaleCount),
+      averageEmployeeNeutralCount: Number(form.averageEmployeeNeutralCount),
+      parsed: parsedReport,
+    }
+
+    const onSuccess = () => {
+      toast.success('Launagreining send inn')
+      queryClient.invalidateQueries({ queryKey: trpc.reports.list.queryKey() })
+      handleReset()
+    }
+
+    try {
+      await submitMutation.mutateAsync({ path: { companyId }, body })
+      onSuccess()
+    } catch (firstError) {
+      const message = firstError instanceof Error ? firstError.message : ''
+      const ordinals = parseOutlierOrdinals(message)
+
+      if (!ordinals) {
+        toast.error('Villa við innsendingu')
+        return
+      }
+
+      if (!postpone) {
+        toast.error(
+          `Útlægar niðurstöður fundust fyrir ${ordinals.length} starfsmenn. Merktu "Fresta útlágum" og gefðu ástæðu til að senda inn.`,
+        )
+        return
+      }
+
+      try {
+        await submitMutation.mutateAsync({
+          path: { companyId },
+          body: {
+            ...body,
+            outliers: ordinals.map((employeeOrdinal) => ({
+              employeeOrdinal,
+              postponed: true,
+              reason: postponeReason,
+            })),
+          },
+        })
+        onSuccess()
+      } catch {
+        toast.error('Villa við innsendingu')
+      }
+    }
+  }
+
+  const canSubmit =
+    !!companyId &&
+    !!parsedReport &&
+    !!form.companyAdminName &&
+    !!form.companyAdminEmail &&
+    !!form.contactName &&
+    !!form.contactEmail &&
+    !!form.contactPhone &&
+    !!form.averageEmployeeMaleCount &&
+    !!form.averageEmployeeFemaleCount &&
+    !!form.averageEmployeeNeutralCount &&
+    (!postpone || !!postponeReason)
+
+  return (
+    <Drawer
+      ariaLabel="Skrá launagreiningu"
+      baseId="create-salary-report-drawer"
+      disclosure={
+        <Button variant="utility" icon="add" iconType="outline">
+          Launagreining
+        </Button>
+      }
+    >
+      <GridContainer>
+        <Stack space={4}>
+          <Text variant="h2">Ný launagreining</Text>
+
+          <GridRow rowGap={[2, 3]}>
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Fyrirtæki
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '8/12']}>
+              <Select
+                name="company"
+                label="Veldu fyrirtæki"
+                options={companyOptions}
+                value={companyOptions.find((o) => o.value === companyId) ?? null}
+                onChange={(opt) => {
+                  setCompanyId(opt?.value ?? null)
+                  setParsedReport(null)
+                  if (fileInputRef.current) fileInputRef.current.value = ''
+                }}
+                isLoading={companiesQuery.isLoading}
+                backgroundColor="blue"
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Excel innflutningur
+              </Text>
+            </GridColumn>
+            <GridColumn span="12/12">
+              <Box
+                background={parsedReport ? 'mint100' : 'blue100'}
+                borderRadius="large"
+                padding={3}
+                display="flex"
+                alignItems="center"
+                columnGap={3}
+              >
+                <Box flexGrow={1}>
+                  <Text variant="small">
+                    {parsedReport
+                      ? `Gögn flutt inn: ${parsedReport.employees.length} starfsmenn, ${parsedReport.roles.length} hlutverk, ${parsedReport.criteria.length} viðmið`
+                      : 'Veldu Excel skrá til að flytja inn launagreiningargögn'}
+                  </Text>
+                </Box>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".xlsx,.xls"
+                  style={{ display: 'none' }}
+                  onChange={handleFileChange}
+                  disabled={!companyId}
+                />
+                <Button
+                  variant="ghost"
+                  size="small"
+                  loading={importMutation.isPending}
+                  disabled={!companyId}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {parsedReport ? 'Skipta um skrá' : 'Velja skrá'}
+                </Button>
+              </Box>
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Útlægar niðurstöður
+              </Text>
+            </GridColumn>
+            <GridColumn span="12/12">
+              <Checkbox
+                label="Fresta útlágum"
+                checked={postpone}
+                onChange={(e) => setPostpone(e.target.checked)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            {postpone && (
+              <GridColumn span="12/12">
+                <TextInput
+                  name="postponeReason"
+                  label="Ástæða frestunar"
+                  textarea
+                  rows={3}
+                  value={postponeReason}
+                  onChange={(e) => setPostponeReason(e.target.value)}
+                />
+              </GridColumn>
+            )}
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Æðsti stjórnandi
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="companyAdminName"
+                label="Nafn"
+                value={form.companyAdminName}
+                onChange={(e) => set('companyAdminName')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="companyAdminEmail"
+                label="Netfang"
+                type="email"
+                value={form.companyAdminEmail}
+                onChange={(e) => set('companyAdminEmail')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <Select
+                name="companyAdminGender"
+                label="Kyn"
+                options={GENDER_OPTIONS}
+                value={GENDER_OPTIONS.find(
+                  (o) => o.value === form.companyAdminGender,
+                )}
+                onChange={(opt) =>
+                  opt && set('companyAdminGender')(opt.value)
+                }
+                backgroundColor="blue"
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Tengiliður
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactName"
+                label="Nafn"
+                value={form.contactName}
+                onChange={(e) => set('contactName')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactEmail"
+                label="Netfang"
+                type="email"
+                value={form.contactEmail}
+                onChange={(e) => set('contactEmail')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '6/12']}>
+              <TextInput
+                name="contactPhone"
+                label="Símanúmer"
+                type="tel"
+                value={form.contactPhone}
+                onChange={(e) => set('contactPhone')(e.target.value)}
+                disabled={!companyId}
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Text variant="h4" marginBottom={1}>
+                Starfsmannafjöldi
+              </Text>
+            </GridColumn>
+            <GridColumn span={['12/12', '4/12']}>
+              <TextInput
+                name="averageEmployeeMaleCount"
+                label="Karlar"
+                type="number"
+                value={form.averageEmployeeMaleCount}
+                onChange={(e) =>
+                  set('averageEmployeeMaleCount')(e.target.value)
+                }
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '4/12']}>
+              <TextInput
+                name="averageEmployeeFemaleCount"
+                label="Konur"
+                type="number"
+                value={form.averageEmployeeFemaleCount}
+                onChange={(e) =>
+                  set('averageEmployeeFemaleCount')(e.target.value)
+                }
+                disabled={!companyId}
+              />
+            </GridColumn>
+            <GridColumn span={['12/12', '4/12']}>
+              <TextInput
+                name="averageEmployeeNeutralCount"
+                label="Kynhlutlægt"
+                type="number"
+                value={form.averageEmployeeNeutralCount}
+                onChange={(e) =>
+                  set('averageEmployeeNeutralCount')(e.target.value)
+                }
+                disabled={!companyId}
+              />
+            </GridColumn>
+
+            <GridColumn span="12/12">
+              <Inline justifyContent="flexEnd" space={2}>
+                <Button variant="ghost" onClick={handleReset}>
+                  Hreinsa
+                </Button>
+                <Button
+                  disabled={!canSubmit}
+                  loading={submitMutation.isPending}
+                  onClick={handleSubmit}
+                >
+                  Senda inn
+                </Button>
+              </Inline>
+            </GridColumn>
+          </GridRow>
+        </Stack>
+      </GridContainer>
+    </Drawer>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/list-page/Tabs/TabsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/components/list-page/Tabs/TabsContainer.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
 import { Tabs } from '@dmr.is/ui/components/island-is/Tabs'
 import { type TagVariant } from '@dmr.is/ui/components/island-is/Tag'
 import { TableCell } from '@dmr.is/ui/components/Tables/Table'
@@ -8,6 +10,8 @@ import { TableCell } from '@dmr.is/ui/components/Tables/Table'
 import { ReportStatusEnum } from '../../../gen/fetch/types.gen'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
 import { type Case, COLUMN_STATUS } from '../constants'
+import { CreateEqualityReportDrawer } from '../CreateEqualityReportDrawer'
+import { CreateSalaryReportDrawer } from '../CreateSalaryReportDrawer'
 import { TabContent } from './TabContent'
 
 import { useQuery } from '@tanstack/react-query'
@@ -65,6 +69,12 @@ export const TabsContainer = () => {
 
   return (
     <GridContainer>
+      <Box display="flex" justifyContent="flexEnd" marginBottom={3}>
+        <Inline space={2}>
+          <CreateEqualityReportDrawer />
+          <CreateSalaryReportDrawer />
+        </Inline>
+      </Box>
       <Tabs
         label="Mál"
         selected="innsendingar"

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/_app.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/_app.ts
@@ -1,4 +1,5 @@
 import { router } from '../trpc'
+import { companyRouter } from './companyRouter'
 import { configRouter } from './configRouter'
 import { reportCommentsRouter } from './reportCommentsRouter'
 import { reportsRouter } from './reportsRouter'
@@ -6,6 +7,7 @@ import { reportWorkflowRouter } from './reportWorkflowRouter'
 import { userRouter } from './userRouter'
 
 export const appRouter = router({
+  company: companyRouter,
   user: userRouter,
   config: configRouter,
   reports: reportsRouter,

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/_app.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/_app.ts
@@ -1,4 +1,5 @@
 import { router } from '../trpc'
+import { adminReportRouter } from './adminReportRouter'
 import { companyRouter } from './companyRouter'
 import { configRouter } from './configRouter'
 import { reportCommentsRouter } from './reportCommentsRouter'
@@ -7,6 +8,7 @@ import { reportWorkflowRouter } from './reportWorkflowRouter'
 import { userRouter } from './userRouter'
 
 export const appRouter = router({
+  adminReport: adminReportRouter,
   company: companyRouter,
   user: userRouter,
   config: configRouter,

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/adminReportRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/adminReportRouter.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod'
+
+import {
+  zAdminEqualityReportDto,
+  zAdminSalaryReportDto,
+  zSubmitAdminEqualityReportPath,
+  zSubmitAdminSalaryReportPath,
+} from '../../../../gen/fetch/zod.gen'
+import { protectedProcedure, router } from '../trpc'
+
+export const adminReportRouter = router({
+  submitEquality: protectedProcedure
+    .input(
+      z.object({
+        path: zSubmitAdminEqualityReportPath,
+        body: zAdminEqualityReportDto,
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      ctx.api.submitAdminEqualityReport({ path: input.path, body: input.body }),
+    ),
+
+  submitSalary: protectedProcedure
+    .input(
+      z.object({
+        path: zSubmitAdminSalaryReportPath,
+        body: zAdminSalaryReportDto,
+      }),
+    )
+    .mutation(({ ctx, input }) =>
+      ctx.api.submitAdminSalaryReport({ path: input.path, body: input.body }),
+    ),
+
+  importWorkbook: protectedProcedure
+    .input(
+      z.object({
+        path: z.object({ companyId: z.string() }),
+        body: z.object({ file: z.string() }),
+      }),
+    )
+    .mutation(({ ctx, input }) => {
+      const buffer = Buffer.from(input.body.file, 'base64')
+      const blob = new Blob([buffer], {
+        type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      })
+      return ctx.api.importAdminSalaryReportWorkbook({
+        path: input.path,
+        body: { file: blob },
+      })
+    }),
+})

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+import {
+  zCreateCompanyBody,
+  zRskLookupCompanyPath,
+} from '../../../../gen/fetch/zod.gen'
+import { protectedProcedure, router } from '../trpc'
+
+const zGetCompaniesQuery = z.object({
+  page: z.number().min(1).optional(),
+  pageSize: z.number().min(1).max(100).optional(),
+  q: z.string().optional(),
+  minEmployeeCount: z.number().min(0).optional(),
+  sortBy: z.enum(['name', 'employeeCount']).optional(),
+  direction: z.enum(['asc', 'desc']).optional(),
+})
+
+export const companyRouter = router({
+  list: protectedProcedure
+    .input(zGetCompaniesQuery.optional())
+    .query(({ ctx, input }) =>
+      ctx.api.getCompanies({ query: input as never }),
+    ),
+
+  rskLookup: protectedProcedure
+    .input(zRskLookupCompanyPath)
+    .query(({ ctx, input }) =>
+      ctx.api.rskLookupCompany({ path: { nationalId: input.nationalId } }),
+    ),
+
+  create: protectedProcedure
+    .input(zCreateCompanyBody)
+    .mutation(({ ctx, input }) =>
+      ctx.api.createCompany({ body: input }),
+    ),
+})

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -18,9 +18,7 @@ const zGetCompaniesQuery = z.object({
 export const companyRouter = router({
   list: protectedProcedure
     .input(zGetCompaniesQuery.optional())
-    .query(({ ctx, input }) =>
-      ctx.api.getCompanies({ query: input as never }),
-    ),
+    .query(({ ctx, input }) => ctx.api.getCompanies({ query: input as never })),
 
   rskLookup: protectedProcedure
     .input(zRskLookupCompanyPath)
@@ -30,7 +28,5 @@ export const companyRouter = router({
 
   create: protectedProcedure
     .input(zCreateCompanyBody)
-    .mutation(({ ctx, input }) =>
-      ctx.api.createCompany({ body: input }),
-    ),
+    .mutation(({ ctx, input }) => ctx.api.createCompany({ body: input })),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -8,7 +8,7 @@ import { protectedProcedure, router } from '../trpc'
 
 const zGetCompaniesQuery = z.object({
   page: z.number().min(1).optional(),
-  pageSize: z.number().min(1).max(100).optional(),
+  pageSize: z.number().min(1).optional(),
   q: z.string().optional(),
   minEmployeeCount: z.number().min(0).optional(),
   sortBy: z.enum(['name', 'employeeCount']).optional(),

--- a/apps/directorate-of-equality-web/src/middleware.ts
+++ b/apps/directorate-of-equality-web/src/middleware.ts
@@ -2,7 +2,10 @@ import { NextResponse } from 'next/server'
 import type { NextRequestWithAuth } from 'next-auth/middleware'
 import { withAuth } from 'next-auth/middleware'
 
-import { tryToUpdateCookie, updateCookie } from '@dmr.is/auth/middleware-helpers'
+import {
+  tryToUpdateCookie,
+  updateCookie,
+} from '@dmr.is/auth/middleware-helpers'
 import { isExpired } from '@dmr.is/auth/token-service'
 
 import { identityServerConfig } from './lib/auth/authOptions'
@@ -14,7 +17,10 @@ export default withAuth(
 
     if (!token) return response
 
-    const accessExpired = isExpired(token.accessToken as string, !!token.invalid)
+    const accessExpired = isExpired(
+      token.accessToken as string,
+      !!token.invalid,
+    )
     const idTokenExpired = token.idToken
       ? isExpired(token.idToken as string, !!token.invalid)
       : false

--- a/apps/directorate-of-equality-web/src/middleware.ts
+++ b/apps/directorate-of-equality-web/src/middleware.ts
@@ -1,16 +1,63 @@
-import { createAuthMiddleware } from '@dmr.is/auth/middleware-helpers'
+import { NextResponse } from 'next/server'
+import type { NextRequestWithAuth } from 'next-auth/middleware'
+import { withAuth } from 'next-auth/middleware'
+
+import { tryToUpdateCookie, updateCookie } from '@dmr.is/auth/middleware-helpers'
+import { isExpired } from '@dmr.is/auth/token-service'
 
 import { identityServerConfig } from './lib/auth/authOptions'
 
-export default createAuthMiddleware({
-  clientId: identityServerConfig.clientId,
-  clientSecret: identityServerConfig.clientSecret,
-  redirectUriEnvVar: 'DOE_WEB_URL',
-  fallbackRedirectUri: process.env.IDENTITY_SERVER_LOGOUT_URL as string,
-  signInPath: '/innskraning',
-  checkIsActive: false,
-  skipDefaultUrlCheck: true,
-})
+export default withAuth(
+  async function middleware(req: NextRequestWithAuth) {
+    let response = NextResponse.next()
+    const token = req.nextauth.token
+
+    if (!token) return response
+
+    const accessExpired = isExpired(token.accessToken as string, !!token.invalid)
+    const idTokenExpired = token.idToken
+      ? isExpired(token.idToken as string, !!token.invalid)
+      : false
+
+    if (accessExpired || idTokenExpired) {
+      const redirectUri =
+        process.env.DOE_WEB_URL ??
+        (process.env.IDENTITY_SERVER_LOGOUT_URL as string)
+
+      const result = await tryToUpdateCookie(
+        identityServerConfig.clientId,
+        identityServerConfig.clientSecret,
+        req,
+        token,
+        response,
+        redirectUri,
+      )
+      response = result.response
+
+      if (result.newSessionToken) {
+        return updateCookie(result.newSessionToken, req, response)
+      }
+    }
+
+    return response
+  },
+  {
+    pages: {
+      signIn: '/innskraning',
+    },
+    callbacks: {
+      authorized: ({ token, req }) => {
+        const requestedPath = req.nextUrl.pathname
+
+        if (requestedPath.includes('/api/trpc')) {
+          return true
+        }
+
+        return !!token && !token.invalid
+      },
+    },
+  },
+)
 
 export const config = {
   matcher: [

--- a/libs/shared/decorators/src/lib/api-national-id.decorator.ts
+++ b/libs/shared/decorators/src/lib/api-national-id.decorator.ts
@@ -1,0 +1,26 @@
+import { Transform } from 'class-transformer'
+import { IsString, Matches } from 'class-validator'
+
+import { applyDecorators } from '@nestjs/common'
+import { ApiProperty, ApiPropertyOptions } from '@nestjs/swagger'
+
+export function ApiNationalId(options: ApiPropertyOptions = {}) {
+  return applyDecorators(
+    ApiProperty({
+      type: String,
+      pattern: '^\\d{6}[- ]?\\d{4}$',
+      example: '0101901234',
+      description:
+        'National ID. Accepts XXXXXXXXXX, XXXXXX-XXXX, or XXXXXX XXXX — always normalised to XXXXXXXXXX.',
+      ...options,
+    }),
+    Transform(({ value }) =>
+      typeof value === 'string' ? value.replace(/[- ]/g, '') : value,
+    ),
+    IsString(),
+    Matches(/^\d{10}$/, {
+      message:
+        'nationalId must be 10 digits (accepted formats: XXXXXXXXXX, XXXXXX-XXXX, XXXXXX XXXX)',
+    }),
+  )
+}

--- a/libs/shared/decorators/src/lib/index.ts
+++ b/libs/shared/decorators/src/lib/index.ts
@@ -17,6 +17,7 @@ export * from './transactional.decorator'
 export * from './user-role.decorator'
 
 // api decorators
+export * from './api-national-id.decorator'
 export * from './api-date-time.decorator'
 export * from './api-date-time-array.decorator'
 export * from './api-array.decorator'

--- a/libs/shared/trpc/src/lib/client/query-client.tsx
+++ b/libs/shared/trpc/src/lib/client/query-client.tsx
@@ -10,21 +10,27 @@ export const makeQueryClient = () => {
         staleTime: 30 * 1000,
         retry(failureCount, error) {
           if (error instanceof TRPCClientError) {
-            if (error.data.httpStatus === 404) {
+            if (error.data?.httpStatus === 404) {
+              return false
+            }
+            if (error.data?.httpStatus === 401) {
+              if (typeof window !== 'undefined') {
+                forceLogin(window.location.pathname)
+              }
               return false
             }
           }
 
-          if (error.message === 'UNAUTHORIZED') {
-            return false
-          } else if (error.message === 'No session found') {
-            // Force login when no session is found
+          if (
+            error.message === 'UNAUTHORIZED' ||
+            error.message === 'No session found'
+          ) {
             if (typeof window !== 'undefined') {
               forceLogin(window.location.pathname)
             }
-
             return false
           }
+
           return failureCount < 3
         },
       },


### PR DESCRIPTION
## What
                                                                                                                                                               
  - Split single CreateReportDrawer into CreateEqualityReportDrawer and CreateSalaryReportDrawer, each as a utility disclosure button
  - Company selection replaced national ID lookup — both drawers pick from the companies list                                                                  
  - Equality report uses the HTML editor instead of a plain textarea                                                                                           
  - Created AdminReportService + interface + core module in the API; controller is now a thin adapter                                                          
  - identifier is auto-generated server-side as a random 6-letter uppercase string                                                                             
  - equalityReportId is resolved server-side via IReportService.getActiveEqualityForCompany — callers no longer pass it                                        
  - Salary drawer: first submit attempt detects outlier ordinals from the 400 error; if "Fresta frávikum" is checked with a reason, re-submits automatically    
  with postponed: true per ordinal                                                                                                                             
                                                                                                                                                               
  ## Why                                                                                                                        
                                                            
  The original drawer mixed report types in a single component and pushed business logic (company lookup, equality report resolution, identifier generation)   
  onto the client. Separating the drawers makes each form self-contained and purpose-built. Moving the resolution logic into the service layer keeps the
  controller thin and the frontend ignorant of internal FK relationships.