### PR TITLE
feat(doe): Report overview dashboard — live stats endpoints + frontend wiring

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,18 +43,4 @@
       "mode": "auto"
     }
   ],
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": null,
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[typescript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[javascript]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  },
-  "[scss]": {
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
-  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,4 +43,18 @@
       "mode": "auto"
     }
   ],
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": null,
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-overview-statistics.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-overview-statistics.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+import { ReportStatusEnum } from '../models/report.enums'
+
+export class ReportStatisticsItemDto {
+  @ApiProperty({ enum: ReportStatusEnum })
+  status!: ReportStatusEnum
+
+  @ApiProperty()
+  count!: number
+
+  @ApiProperty()
+  percentage!: number
+}
+
+export class ReportStatisticsWindowDto {
+  @ApiProperty({ type: [ReportStatisticsItemDto] })
+  items!: ReportStatisticsItemDto[]
+
+  @ApiProperty()
+  total!: number
+}
+
+export class ReportOverviewStatisticsDto {
+  @ApiProperty({ type: ReportStatisticsWindowDto })
+  last30Days!: ReportStatisticsWindowDto
+
+  @ApiProperty({ type: ReportStatisticsWindowDto })
+  currentYear!: ReportStatisticsWindowDto
+
+  @ApiProperty({ type: ReportStatisticsWindowDto })
+  allTime!: ReportStatisticsWindowDto
+}

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-overview.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-overview.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class ReportOverviewGeneralDto {
+  @ApiProperty()
+  submittedToday!: number
+
+  @ApiProperty()
+  inProgress!: number
+
+  @ApiProperty()
+  reportsWithComments!: number
+
+  @ApiProperty()
+  reportsWithoutEmployee!: number
+}
+
+export class ReportOverviewAssignedDto {
+  @ApiProperty()
+  totalAssigned!: number
+
+  @ApiProperty()
+  assignedWithComments!: number
+}
+
+export class ReportOverviewDto {
+  @ApiProperty({ type: ReportOverviewGeneralDto })
+  general!: ReportOverviewGeneralDto
+
+  @ApiProperty({ type: ReportOverviewAssignedDto })
+  assigned!: ReportOverviewAssignedDto
+}

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -9,6 +9,8 @@ import {
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 
+import { CurrentUser } from '@dmr.is/decorators'
+import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
@@ -16,6 +18,8 @@ import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
 import { ReportDetailDto } from './dto/report-detail.dto'
+import { ReportOverviewDto } from './dto/report-overview.dto'
+import { ReportOverviewStatisticsDto } from './dto/report-overview-statistics.dto'
 import { IReportService } from './report.service.interface'
 
 @Controller({ path: 'reports', version: '1' })
@@ -26,6 +30,23 @@ export class ReportController {
   constructor(
     @Inject(IReportService) private readonly reportService: IReportService,
   ) {}
+
+  @Get('overview')
+  @DoeResponse({ operationId: 'getReportOverview', type: ReportOverviewDto })
+  async getOverview(
+    @CurrentUser() user: DMRUser,
+  ): Promise<ReportOverviewDto> {
+    return this.reportService.getOverview(user.nationalId)
+  }
+
+  @Get('overview/statistics')
+  @DoeResponse({
+    operationId: 'getReportOverviewStatistics',
+    type: ReportOverviewStatisticsDto,
+  })
+  async getOverviewStatistics(): Promise<ReportOverviewStatisticsDto> {
+    return this.reportService.getOverviewStatistics()
+  }
 
   @Get()
   @DoeResponse({ operationId: 'listReports', type: GetReportsResponseDto })

--- a/apps/directorate-of-equality-api/src/modules/report/report.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.core.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
+import { ReportCommentModel } from '../report-comment/models/report-comment.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { ReportModel } from './models/report.model'
@@ -15,6 +16,7 @@ import { IReportService } from './report.service.interface'
       ReportEventModel,
       ReportRoleResultModel,
       ReportEmployeeOutlierModel,
+      ReportCommentModel,
     ]),
   ],
   providers: [

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
@@ -2,6 +2,8 @@ import { EqualityReportSummaryDto } from './dto/equality-report-summary.dto'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
 import { ReportDetailDto } from './dto/report-detail.dto'
+import { ReportOverviewDto } from './dto/report-overview.dto'
+import { ReportOverviewStatisticsDto } from './dto/report-overview-statistics.dto'
 
 export interface IReportService {
   list(query: GetReportsQueryDto): Promise<GetReportsResponseDto>
@@ -9,6 +11,8 @@ export interface IReportService {
   getActiveEqualityForCompany(
     companyId: string,
   ): Promise<EqualityReportSummaryDto | null>
+  getOverview(nationalId: string): Promise<ReportOverviewDto>
+  getOverviewStatistics(): Promise<ReportOverviewStatisticsDto>
 }
 
 export const IReportService = Symbol('IReportService')

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -12,7 +12,7 @@
  * by other modules. This service never mutates report data.
  */
 
-import { Op, Order, WhereOptions } from 'sequelize'
+import { col, fn, Op, Order, WhereOptions } from 'sequelize'
 
 import {
   Inject,
@@ -29,6 +29,13 @@ import {
 
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportCommentModel } from '../report-comment/models/report-comment.model'
+import { UserModel } from '../user/models/user.model'
+import { ReportOverviewDto } from './dto/report-overview.dto'
+import {
+  ReportOverviewStatisticsDto,
+  ReportStatisticsItemDto,
+  ReportStatisticsWindowDto,
+} from './dto/report-overview-statistics.dto'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
@@ -197,6 +204,144 @@ export class ReportService implements IReportService {
       roleResults,
       employeeOutliers,
     }
+  }
+
+  async getOverview(nationalId: string): Promise<ReportOverviewDto> {
+    this.logger.debug('Fetching report overview', {
+      context: LOGGING_CONTEXT,
+      nationalId,
+    })
+
+    const activeStatuses = [
+      ReportStatusEnum.SUBMITTED,
+      ReportStatusEnum.IN_REVIEW,
+    ]
+
+    const todayStart = new Date()
+    todayStart.setUTCHours(0, 0, 0, 0)
+    const todayEnd = new Date()
+    todayEnd.setUTCHours(23, 59, 59, 999)
+
+    const reviewerInclude = {
+      model: UserModel,
+      as: 'reviewer',
+      required: true,
+      attributes: [],
+      where: { nationalId },
+    }
+
+    const [
+      submittedToday,
+      inProgress,
+      reportsWithComments,
+      reportsWithoutEmployee,
+      totalAssigned,
+      assignedWithComments,
+    ] = await Promise.all([
+      this.reportModel.count({
+        where: {
+          status: ReportStatusEnum.SUBMITTED,
+          createdAt: { [Op.between]: [todayStart, todayEnd] },
+        },
+      }),
+      this.reportModel.count({
+        where: { status: ReportStatusEnum.IN_REVIEW },
+      }),
+      this.reportModel.count({
+        where: { status: { [Op.in]: activeStatuses } },
+        include: [
+          { model: ReportCommentModel, as: 'comments', required: true, attributes: [] },
+        ],
+        distinct: true,
+      }),
+      this.reportModel.count({
+        where: {
+          status: { [Op.in]: activeStatuses },
+          reviewerUserId: { [Op.is]: null },
+        },
+      }),
+      this.reportModel.count({
+        where: { status: { [Op.in]: activeStatuses } },
+        include: [reviewerInclude],
+        distinct: true,
+      }),
+      this.reportModel.count({
+        where: { status: { [Op.in]: activeStatuses } },
+        include: [
+          reviewerInclude,
+          { model: ReportCommentModel, as: 'comments', required: true, attributes: [] },
+        ],
+        distinct: true,
+      }),
+    ])
+
+    return {
+      general: { submittedToday, inProgress, reportsWithComments, reportsWithoutEmployee },
+      assigned: { totalAssigned, assignedWithComments },
+    }
+  }
+
+  async getOverviewStatistics(): Promise<ReportOverviewStatisticsDto> {
+    this.logger.debug('Fetching report overview statistics', {
+      context: LOGGING_CONTEXT,
+    })
+
+    const nonDraftStatuses = [
+      ReportStatusEnum.SUBMITTED,
+      ReportStatusEnum.IN_REVIEW,
+      ReportStatusEnum.APPROVED,
+      ReportStatusEnum.DENIED,
+      ReportStatusEnum.SUPERSEDED,
+    ]
+
+    const now = new Date()
+
+    const last30DaysStart = new Date(now)
+    last30DaysStart.setUTCDate(last30DaysStart.getUTCDate() - 30)
+    last30DaysStart.setUTCHours(0, 0, 0, 0)
+
+    const currentYearStart = new Date(Date.UTC(now.getUTCFullYear(), 0, 1))
+
+    const groupByStatus = async (from?: Date) => {
+      const rows = (await this.reportModel.findAll({
+        attributes: ['status', [fn('COUNT', col(`${ReportModel.name}.id`)), 'count']],
+        where: {
+          status: { [Op.in]: nonDraftStatuses },
+          ...(from ? { createdAt: { [Op.gte]: from } } : {}),
+        },
+        group: ['status'],
+        raw: true,
+      })) as unknown as { status: ReportStatusEnum; count: string }[]
+
+      return this.buildStatisticsWindow(rows)
+    }
+
+    const [last30Days, currentYear, allTime] = await Promise.all([
+      groupByStatus(last30DaysStart),
+      groupByStatus(currentYearStart),
+      groupByStatus(),
+    ])
+
+    return { last30Days, currentYear, allTime }
+  }
+
+  private buildStatisticsWindow(
+    rows: { status: ReportStatusEnum; count: string }[],
+  ): ReportStatisticsWindowDto {
+    const items: ReportStatisticsItemDto[] = rows.map((r) => ({
+      status: r.status,
+      count: parseInt(r.count, 10),
+      percentage: 0,
+    }))
+
+    const total = items.reduce((sum, i) => sum + i.count, 0)
+
+    for (const item of items) {
+      item.percentage =
+        total > 0 ? Math.round((item.count / total) * 100) : 0
+    }
+
+    return { items, total }
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -29,16 +29,10 @@ import {
 
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportCommentModel } from '../report-comment/models/report-comment.model'
-import { UserModel } from '../user/models/user.model'
-import { ReportOverviewDto } from './dto/report-overview.dto'
-import {
-  ReportOverviewStatisticsDto,
-  ReportStatisticsItemDto,
-  ReportStatisticsWindowDto,
-} from './dto/report-overview-statistics.dto'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
+import { UserModel } from '../user/models/user.model'
 import { EqualityReportDto } from './dto/equality-report.dto'
 import { EqualityReportSummaryDto } from './dto/equality-report-summary.dto'
 import {
@@ -50,6 +44,12 @@ import {
   ReportStatusCountsDto,
 } from './dto/get-reports-response.dto'
 import { ReportDetailDto } from './dto/report-detail.dto'
+import { ReportOverviewDto } from './dto/report-overview.dto'
+import {
+  ReportOverviewStatisticsDto,
+  ReportStatisticsItemDto,
+  ReportStatisticsWindowDto,
+} from './dto/report-overview-statistics.dto'
 import {
   ReportTimelineItemDto,
   ReportTimelineItemKindEnum,

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -748,6 +748,110 @@
         "tags": ["Config"]
       }
     },
+    "/api/v1/reports/overview": {
+      "get": {
+        "operationId": "getReportOverview",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ReportOverviewDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Reports"]
+      }
+    },
+    "/api/v1/reports/overview/statistics": {
+      "get": {
+        "operationId": "getReportOverviewStatistics",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReportOverviewStatisticsDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Reports"]
+      }
+    },
     "/api/v1/reports": {
       "get": {
         "operationId": "listReports",
@@ -1889,6 +1993,86 @@
           "description": { "type": "string", "nullable": true }
         },
         "required": ["value"]
+      },
+      "ReportOverviewGeneralDto": {
+        "type": "object",
+        "properties": {
+          "submittedToday": { "type": "number" },
+          "inProgress": { "type": "number" },
+          "reportsWithComments": { "type": "number" },
+          "reportsWithoutEmployee": { "type": "number" }
+        },
+        "required": [
+          "submittedToday",
+          "inProgress",
+          "reportsWithComments",
+          "reportsWithoutEmployee"
+        ]
+      },
+      "ReportOverviewAssignedDto": {
+        "type": "object",
+        "properties": {
+          "totalAssigned": { "type": "number" },
+          "assignedWithComments": { "type": "number" }
+        },
+        "required": ["totalAssigned", "assignedWithComments"]
+      },
+      "ReportOverviewDto": {
+        "type": "object",
+        "properties": {
+          "general": {
+            "$ref": "#/components/schemas/ReportOverviewGeneralDto"
+          },
+          "assigned": {
+            "$ref": "#/components/schemas/ReportOverviewAssignedDto"
+          }
+        },
+        "required": ["general", "assigned"]
+      },
+      "ReportStatisticsItemDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "DRAFT",
+              "SUBMITTED",
+              "IN_REVIEW",
+              "DENIED",
+              "APPROVED",
+              "SUPERSEDED"
+            ]
+          },
+          "count": { "type": "number" },
+          "percentage": { "type": "number" }
+        },
+        "required": ["status", "count", "percentage"]
+      },
+      "ReportStatisticsWindowDto": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReportStatisticsItemDto" }
+          },
+          "total": { "type": "number" }
+        },
+        "required": ["items", "total"]
+      },
+      "ReportOverviewStatisticsDto": {
+        "type": "object",
+        "properties": {
+          "last30Days": {
+            "$ref": "#/components/schemas/ReportStatisticsWindowDto"
+          },
+          "currentYear": {
+            "$ref": "#/components/schemas/ReportStatisticsWindowDto"
+          },
+          "allTime": {
+            "$ref": "#/components/schemas/ReportStatisticsWindowDto"
+          }
+        },
+        "required": ["last30Days", "currentYear", "allTime"]
       },
       "ReportTypeEnum": { "type": "string", "enum": ["SALARY", "EQUALITY"] },
       "ReportStatusEnum": {

--- a/apps/directorate-of-equality-web/src/app/(protected)/page.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/page.tsx
@@ -1,5 +1,7 @@
 import { getServerSession } from 'next-auth'
 
+import { Suspense } from 'react'
+
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 
 import { HeroContainer } from '../../components/front-page/HeroContainer'
@@ -13,7 +15,9 @@ export default async function IndexPage() {
   return (
     <Box marginTop={[2, 4]}>
       <HeroContainer userName={session?.user?.name} />
-      <SectionContainer />
+      <Suspense fallback={null}>
+        <SectionContainer />
+      </Suspense>
       <PanelsContainer />
     </Box>
   )

--- a/apps/directorate-of-equality-web/src/components/front-page/SectionContainer.tsx
+++ b/apps/directorate-of-equality-web/src/components/front-page/SectionContainer.tsx
@@ -5,15 +5,22 @@ import dynamic from 'next/dynamic'
 import { useState } from 'react'
 
 import { theme } from '@dmr.is/island-ui-theme'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
 import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Tabs } from '@dmr.is/ui/components/island-is/Tabs'
+import { Tag } from '@dmr.is/ui/components/island-is/Tag'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { Section } from '@dmr.is/ui/components/Section/Section'
 import { TrackerTable } from '@dmr.is/ui/components/Tables/TrackerTable'
 import { Wrapper } from '@dmr.is/ui/components/Wrapper/Wrapper'
+
+import { ReportStatusEnum } from '../../gen/fetch/types.gen'
+import { useTRPC } from '../../lib/trpc/client/trpc'
+
+import { useSuspenseQuery } from '@tanstack/react-query'
 
 const PieChart = dynamic(
   () =>
@@ -23,8 +30,72 @@ const PieChart = dynamic(
   { ssr: false },
 )
 
+const STATUS_LABELS: Record<ReportStatusEnum, string> = {
+  [ReportStatusEnum.DRAFT]: 'Drög',
+  [ReportStatusEnum.SUBMITTED]: 'Ný mál',
+  [ReportStatusEnum.IN_REVIEW]: 'Í vinnslu',
+  [ReportStatusEnum.APPROVED]: 'Samþykkt',
+  [ReportStatusEnum.DENIED]: 'Hafnað',
+  [ReportStatusEnum.SUPERSEDED]: 'Yfirtekið',
+}
+
+const STATUS_COLORS: Record<ReportStatusEnum, string> = {
+  [ReportStatusEnum.DRAFT]: theme.color.dark200,
+  [ReportStatusEnum.SUBMITTED]: theme.color.yellow600,
+  [ReportStatusEnum.IN_REVIEW]: theme.color.roseTinted400,
+  [ReportStatusEnum.APPROVED]: theme.color.mint600,
+  [ReportStatusEnum.DENIED]: theme.color.red400,
+  [ReportStatusEnum.SUPERSEDED]: theme.color.blueberry400,
+}
+
+type StatisticsWindow = 'last30Days' | 'currentYear' | 'allTime'
+
+const STATS_WINDOWS: {
+  id: StatisticsWindow
+  label: string
+  variant: 'blue' | 'mint' | 'purple'
+}[] = [
+  { id: 'last30Days', label: 'Síðustu 30 dagar', variant: 'blue' },
+  { id: 'currentYear', label: 'Þetta ár', variant: 'mint' },
+  { id: 'allTime', label: 'Allt saman', variant: 'purple' },
+]
+
+const STATS_WINDOW_INTROS: Record<StatisticsWindow, string> = {
+  last30Days: 'Hlutfall mála eftir stöðu síðustu 30 daga.',
+  currentYear: 'Hlutfall mála eftir stöðu á þessu ári.',
+  allTime: 'Hlutfall mála eftir stöðu frá upphafi.',
+}
+
+const CHART_STATUSES = [
+  ReportStatusEnum.SUBMITTED,
+  ReportStatusEnum.IN_REVIEW,
+  ReportStatusEnum.APPROVED,
+  ReportStatusEnum.DENIED,
+  ReportStatusEnum.SUPERSEDED,
+] as const
+
 export const SectionContainer = () => {
   const [selectedTab, setSelectedTab] = useState('almennt')
+  const [statsWindow, setStatsWindow] = useState<StatisticsWindow>('last30Days')
+
+  const trpc = useTRPC()
+  const { data: overview } = useSuspenseQuery(
+    trpc.reports.overview.queryOptions(),
+  )
+  const { data: statistics } = useSuspenseQuery(
+    trpc.reports.overviewStatistics.queryOptions(),
+  )
+
+  const windowItems = statistics[statsWindow].items
+  const pieItems = CHART_STATUSES.map((status) => {
+    const match = windowItems.find((i) => i.status === status)
+    return {
+      color: STATUS_COLORS[status],
+      title: STATUS_LABELS[status],
+      count: match?.count ?? 0,
+      percentage: match?.percentage ?? 0,
+    }
+  })
 
   return (
     <Section bleed variant="blue">
@@ -49,10 +120,18 @@ export const SectionContainer = () => {
                       content: (
                         <TrackerTable
                           rows={[
-                            { text: '5 ný mál skráð í dag' },
-                            { text: '12 mál í vinnslu' },
-                            { text: '3 mál með skráðar athugasemdir' },
-                            { text: '2 mál án skráðs starfsmanns' },
+                            {
+                              text: `${overview.general.submittedToday} ný mál hafa borist í dag`,
+                            },
+                            {
+                              text: `${overview.general.inProgress} mál eru til skoðunar hjá starfsmönnum`,
+                            },
+                            {
+                              text: `${overview.general.reportsWithComments} opin mál eru með skráðar athugasemdir`,
+                            },
+                            {
+                              text: `${overview.general.reportsWithoutEmployee} opin mál eru án úthlutaðs starfsmanns`,
+                            },
                           ]}
                         />
                       ),
@@ -63,8 +142,12 @@ export const SectionContainer = () => {
                       content: (
                         <TrackerTable
                           rows={[
-                            { text: '2 mál í vinnslu' },
-                            { text: '1 mál með skráðar athugasemdir' },
+                            {
+                              text: `${overview.assigned.totalAssigned} opin mál eru úthlutað til mín`,
+                            },
+                            {
+                              text: `${overview.assigned.assignedWithComments} af mínum málum eru með skráðar athugasemdir`,
+                            },
                           ]}
                         />
                       ),
@@ -76,28 +159,21 @@ export const SectionContainer = () => {
           </GridColumn>
           <GridColumn span={['12/12', '5/12']}>
             <Wrapper title="Tölfræði">
+              <Box display="flex" flexWrap="wrap" columnGap={1} rowGap={1} marginBottom={2}>
+                {STATS_WINDOWS.map(({ id, label, variant }) => (
+                  <Tag
+                    key={id}
+                    variant={variant}
+                    outlined={statsWindow !== id}
+                    onClick={() => setStatsWindow(id)}
+                  >
+                    {label}
+                  </Tag>
+                ))}
+              </Box>
               <PieChart
-                intro="Staða ólokaðra mála."
-                items={[
-                  {
-                    color: theme.color.yellow600,
-                    title: 'Ný mál',
-                    count: 5,
-                    percentage: 31,
-                  },
-                  {
-                    color: theme.color.roseTinted400,
-                    title: 'Í vinnslu',
-                    count: 8,
-                    percentage: 50,
-                  },
-                  {
-                    color: theme.color.mint600,
-                    title: 'Til afgreiðslu',
-                    count: 3,
-                    percentage: 19,
-                  },
-                ]}
+                intro={STATS_WINDOW_INTROS[statsWindow]}
+                items={pieItems}
               />
             </Wrapper>
           </GridColumn>

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
@@ -20,4 +20,12 @@ export const reportsRouter = router({
         path: { id: input.id },
       }),
     ),
+
+  overview: protectedProcedure.query(({ ctx }) =>
+    ctx.api.getReportOverview(),
+  ),
+
+  overviewStatistics: protectedProcedure.query(({ ctx }) =>
+    ctx.api.getReportOverviewStatistics(),
+  ),
 })


### PR DESCRIPTION
## What
                                                                                                                                                               
  - `GET /api/v1/reports/overview` — returns counts for the admin dashboard:                                                                                   
    Almennt tab (new today, in-progress, with comments, without assigned employee)
    Mín mál tab (total assigned to current user, assigned with comments)                                                                                       
  - `GET /api/v1/reports/overview/statistics` — returns report status distribution                                                                             
    (count + percentage) across three time windows: last 30 days, current year, all time.                                                                      
    Uses a single `GROUP BY status` query per window (3 parallel queries total).                                                                               
  - Both endpoints added to `reportsRouter` tRPC layer.                                                                                                        
  - `SectionContainer` wired to live data via `useSuspenseQuery`; mock data removed.                                                                           
  - Pie chart shows all 5 non-draft statuses (padded to 0 when absent in window).                                                                              
  - Time window selector uses Tag components (outlined = inactive, filled = active)                                                                            
    with per-variant colors (blue / mint / purple).                                                                                                            
                                                                                                                                                               
  ## Why                                                                                                                                                       
                                                                                                                                                               
  The front-page dashboard was fully hardcoded with mock data. This PR closes that                                                                             
  gap, giving admins real-time visibility into case load without leaving the home screen.
  The statistics endpoint avoids per-status COUNT queries in favour of a single                                                                                
  `GROUP BY`, keeping DB load proportional to the number of statuses rather than                                                                               
  the number of time windows × statuses.