### PR TITLE
feat(doe): Outlier detection updates

### DIFF
--- a/apps/directorate-of-equality-api/db/DIAGRAM.md
+++ b/apps/directorate-of-equality-api/db/DIAGRAM.md
@@ -98,6 +98,7 @@ erDiagram
         text calculation_version
         jsonb base_snapshot
         jsonb full_snapshot
+        jsonb outlier_analysis_snapshot
     }
     report_role_result {
         uuid id PK

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -167,7 +167,17 @@ The final `score` on `report_employee` is derived from the steps that apply to t
 
 ## Results aggregation
 
-`report_result` holds immutable report-level salary snapshots for both **adjusted base salary** (`baseSalary / workRatio`) and **adjusted full salary** (`(baseSalary + additionalSalary + bonusSalary) / workRatio`). The snapshots are stored as JSONB because the service reads results by `report_id` rather than querying individual metrics in SQL. Each salary family stores report-level totals and score-bucket breakdowns. `report_role_result` is kept as the reserved home for a future role-level breakdown and snapshots the role title used at calculation time. Both tables are write-once at submission — computed in the same transaction that persists the report, so reviewers can read the aggregates as soon as they pick the report up. They are not edited by humans, and the approval transition does not recompute them. (Contrast with `public_report`, which is published only on the `APPROVED` transition.)
+`report_result` holds immutable report-level salary snapshots for both **adjusted base salary** (`baseSalary / workRatio`) and **adjusted full salary** (`(baseSalary + additionalSalary + bonusSalary) / workRatio`). The snapshots are stored as JSONB because the service reads results by `report_id` rather than querying individual metrics in SQL. Each salary family stores report-level totals and score-bucket breakdowns. The same row also snapshots the salary-outlier regression analysis: the fitted base-salary regression lines (gender-blind `regressions.overall`, plus per-cohort `regressions.male/female/neutral` for visualisation), the configured threshold, and each employee's adjusted base salary vs predicted base salary at their exact score. `report_role_result` is kept as the reserved home for a future role-level breakdown and snapshots the role title used at calculation time. Both tables are write-once at submission — computed in the same transaction that persists the report, so reviewers can read the aggregates as soon as they pick the report up. They are not edited by humans, and the approval transition does not recompute them. (Contrast with `public_report`, which is published only on the `APPROVED` transition.)
+
+### Reconstructing the gender-vs-score chart from a stored result
+
+The same chart shape that `buildChartFromEmployeePoints` produces for the application-side preview can be rebuilt from a persisted `report_result` row:
+
+- **Scatter points** — `outlier_analysis_snapshot.employees[*]` carries `score`, `gender`, and `adjustedBaseSalary` per employee.
+- **Regression line(s)** — `outlier_analysis_snapshot.regressions.overall` is the gender-blind line that drives the outlier flag. `regressions.male/female/neutral` are per-cohort lines available for visualisation only.
+- **Score-bucket overlay** — the per-employee `scoreBucketRangeFrom/To` is preserved on each row, but the bucket-level aggregates (median, average, gender breakdowns, counts) live in `base_snapshot.scoreBuckets`. Render the chart by joining on the bucket range when an overlay is needed.
+
+Bucket placement is informational only: the outlier flag is decided against the regression prediction at the employee's exact score, not the bucket median.
 
 ## Enums
 
@@ -376,14 +386,14 @@ One row per outlier the company has acknowledged at submission. Two shapes share
 
 Postponement is all-or-none across the report — the API layer enforces uniformity before persisting. The submit-side outlier guard requires every detected outlier to have a row here; extras (rows for non-outliers) are rejected.
 
-| Column               | Type                                                                   |
-| -------------------- | ---------------------------------------------------------------------- |
-| `id`                 | `uuid` PK                                                              |
-| `report_employee_id` | `fk → report_employee`                                                 |
-| `reason`             | `text` (nullable — null only when parent `outliers_postponed = true`)  |
-| `action`             | `text` (nullable — null only when parent `outliers_postponed = true`)  |
-| `signature_name`     | `text` (nullable — null only when parent `outliers_postponed = true`)  |
-| `signature_role`     | `text` (nullable — null only when parent `outliers_postponed = true`)  |
+| Column               | Type                                                                  |
+| -------------------- | --------------------------------------------------------------------- |
+| `id`                 | `uuid` PK                                                             |
+| `report_employee_id` | `fk → report_employee`                                                |
+| `reason`             | `text` (nullable — null only when parent `outliers_postponed = true`) |
+| `action`             | `text` (nullable — null only when parent `outliers_postponed = true`) |
+| `signature_name`     | `text` (nullable — null only when parent `outliers_postponed = true`) |
+| `signature_role`     | `text` (nullable — null only when parent `outliers_postponed = true`) |
 
 Invariant (enforced via CHECK):
 
@@ -421,6 +431,7 @@ Aggregated per-report salary stats. Stored as an immutable calculation snapshot.
 | `calculation_version`                 | `text` (default `v1`)                                                         |
 | `base_snapshot`                       | `jsonb` adjusted base salary snapshot                                         |
 | `full_snapshot`                       | `jsonb` adjusted full salary snapshot                                         |
+| `outlier_analysis_snapshot`           | `jsonb` regression-based salary outlier analysis snapshot                     |
 
 `base_snapshot` and `full_snapshot` share the same shape:
 
@@ -431,6 +442,13 @@ Aggregated per-report salary stats. Stored as an immutable calculation snapshot.
   - `rangeFrom`, `rangeTo`
   - `totals` with the same aggregate shape as above
   - `counts` for `overall`, `male`, `female`, `neutral`
+
+`outlier_analysis_snapshot` stores:
+
+- `method` — currently `BASE_SALARY_LINEAR_REGRESSION_BY_SCORE`.
+- `thresholdPercent` and `allowedDifferencePercent` — the configured threshold and the half-threshold band used for detection.
+- `regression` — slope/intercept and basic fit metadata for adjusted base salary by score.
+- `employees[]` — per employee ordinal: score, gender, adjusted base salary, predicted base salary at that exact score, score-bucket range, percent difference, direction, and `isOutlier`.
 
 Missing cohorts are represented as `null` in the relevant nested metrics, not `0`.
 
@@ -552,5 +570,5 @@ No FKs, no relationships. Standalone lookup table.
 - **Fines cron.** Daily job: `SELECT * FROM report WHERE fines_started_at IS NOT NULL AND status NOT IN ('APPROVED', 'SUPERSEDED')`. Accrual table (`report_fine` or similar) not yet designed.
 - **Scope.** This schema targets companies with ≥50 employees. Smaller-company flows + edge cases (mergers, liquidation, exemptions) TBD.
 - **Cascade vs soft-delete.** Postgres `ON DELETE CASCADE` only fires on real `DELETE` rows. Lifecycle here is status-based, not soft-delete — do not add `deleted_at` to children expecting cascade propagation.
-- **Outlier-preview endpoint.** Lands as `POST /api/v1/application/reports/salary-analysis` in the `application` module. Takes the unsaved parsed payload, computes employee scores with `report/lib/employee-scores.ts`, runs the canonical `detectOutliers(...)` helper from `report/lib/compensation-aggregates.ts` (half the configured `salary_difference_threshold_percent` around the score-bucket median), and returns the flagged employees plus the gender-vs-score chart so the company can verify before submitting.
+- **Outlier-preview endpoint.** Lands as `POST /api/v1/application/reports/salary-analysis` in the `application` module. Takes the unsaved parsed payload, computes employee scores with `report/lib/employee-scores.ts`, runs the canonical `detectOutliers(...)` helper from `report/lib/compensation-aggregates.ts` (half the configured `salary_difference_threshold_percent` around each employee's predicted adjusted base salary on the score regression line), and returns the flagged employees plus the gender-vs-score chart so the company can verify before submitting.
 - **Submit-side outlier guard.** Wired into `report-create.service.ts.createSalary()` alongside the preview endpoint. Uses the same `detectOutliers(parsed, threshold)` helper as the preview to assert: every detected outlier has an `outliers[]` row, and every `outliers[]` row references a detected outlier (extras are rejected). Threshold is re-read from `config` at submission time, so a small drift between preview and submit is possible — rejection in that case just means "re-run preview". The report-level `outliers_postponed` flag lets a company acknowledge every outlier without filling explanations immediately; postponement applies to the whole report, never to individual rows.

--- a/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
+++ b/apps/directorate-of-equality-api/db/migrations/initial-migration-directorate-of-equality.js
@@ -270,7 +270,8 @@ module.exports = {
       salary_difference_threshold_percent DECIMAL(5, 2) DEFAULT NULL,
       calculation_version TEXT NOT NULL DEFAULT 'v1',
       base_snapshot JSONB NOT NULL,
-      full_snapshot JSONB NOT NULL
+      full_snapshot JSONB NOT NULL,
+      outlier_analysis_snapshot JSONB NOT NULL
     );
 
     CREATE TABLE report_role_result (

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -12,6 +12,7 @@ import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
+import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
 import {
   GenderEnum,
   ReportProviderEnum,
@@ -143,30 +144,29 @@ describe('ApplicationService', () => {
   })
 
   describe('salaryAnalysis', () => {
-    it('returns outliers (with bucket + assessment) and the gender-vs-score chart', async () => {
+    it('returns regression outliers and the gender-vs-score chart', async () => {
       const result = await service.salaryAnalysis(makeRequest(), COMPANY)
 
       expect(configGetByKey).toHaveBeenCalledWith(
         'salary_difference_threshold_percent',
       )
 
-      // Ordinal 1 sits 16.7% below the bucket median (1,200,000), well past the
-      // 1.95% half-threshold band — flagged. Ordinals 2 and 3 fall inside the
-      // band and are not flagged.
+      // Ordinal 1 sits about 3% below its predicted salary on the regression
+      // line, past the 1.95% half-threshold band. The rest stay inside the band.
       expect(result.outliers).toHaveLength(1)
       expect(result.outliers[0]).toMatchObject({
         employeeOrdinal: 1,
-        adjustedBaseSalary: 1000000,
+        adjustedBaseSalary: 850000,
         direction: 'BELOW',
-        referenceSalary: 1200000,
-        scoreBucketRangeFrom: 200,
-        scoreBucketRangeTo: 300,
+        predictedBaseSalary: 876786,
+        scoreBucketRangeFrom: 100,
+        scoreBucketRangeTo: 200,
       })
-      expect(result.outliers[0].differencePercent).toBeCloseTo(-16.6667, 2)
+      expect(result.outliers[0].differencePercent).toBeCloseTo(-3.055, 3)
       expect(result.outliers[0].allowedDifferencePercent).toBeCloseTo(1.95, 4)
 
-      expect(result.baseSalaryByGenderAndScoreAll.dataPoints).toHaveLength(3)
-      expect(result.baseSalaryByGenderAndScoreAll.totals.maleCount).toBe(2)
+      expect(result.baseSalaryByGenderAndScoreAll.dataPoints).toHaveLength(7)
+      expect(result.baseSalaryByGenderAndScoreAll.totals.maleCount).toBe(6)
       expect(result.baseSalaryByGenderAndScoreAll.totals.femaleCount).toBe(1)
     })
 
@@ -655,8 +655,13 @@ function makeRequest(): SalaryAnalysisRequestDto {
               description: 'People responsibility',
               weight: 5,
               steps: [
-                { order: 1, description: 'low', score: 10 },
-                { order: 5, description: 'high', score: 250 },
+                { order: 1, description: 'score 100', score: 100 },
+                { order: 2, description: 'score 200', score: 200 },
+                { order: 3, description: 'score 300', score: 300 },
+                { order: 4, description: 'score 400', score: 400 },
+                { order: 5, description: 'score 500', score: 500 },
+                { order: 6, description: 'score 600', score: 600 },
+                { order: 7, description: 'score 700', score: 700 },
               ],
             },
           ],
@@ -665,30 +670,51 @@ function makeRequest(): SalaryAnalysisRequestDto {
       roles: [
         {
           title: 'Framkvaemdastjori',
-          stepAssignments: [
-            {
-              criterionTitle: 'Abyrgd',
-              subTitle: 'Abyrgd a fólki',
-              stepOrder: 5,
-            },
-          ],
+          stepAssignments: [],
         },
       ],
       employees: [
         makeEmployee({
           ordinal: 1,
           gender: GenderEnum.FEMALE,
-          baseSalary: 1000000,
+          baseSalary: 850000,
+          stepOrder: 1,
         }),
         makeEmployee({
           ordinal: 2,
           gender: GenderEnum.MALE,
-          baseSalary: 1200000,
+          baseSalary: 1000000,
+          stepOrder: 2,
         }),
         makeEmployee({
           ordinal: 3,
           gender: GenderEnum.MALE,
-          baseSalary: 1210000,
+          baseSalary: 1100000,
+          stepOrder: 3,
+        }),
+        makeEmployee({
+          ordinal: 4,
+          gender: GenderEnum.MALE,
+          baseSalary: 1200000,
+          stepOrder: 4,
+        }),
+        makeEmployee({
+          ordinal: 5,
+          gender: GenderEnum.MALE,
+          baseSalary: 1300000,
+          stepOrder: 5,
+        }),
+        makeEmployee({
+          ordinal: 6,
+          gender: GenderEnum.MALE,
+          baseSalary: 1400000,
+          stepOrder: 6,
+        }),
+        makeEmployee({
+          ordinal: 7,
+          gender: GenderEnum.MALE,
+          baseSalary: 1500000,
+          stepOrder: 7,
         }),
       ],
     },
@@ -699,10 +725,12 @@ function makeEmployee({
   ordinal,
   gender,
   baseSalary,
+  stepOrder,
 }: {
   ordinal: number
   gender: GenderEnum
   baseSalary: number
+  stepOrder: number
 }) {
   return {
     ordinal,
@@ -717,7 +745,13 @@ function makeEmployee({
     baseSalary,
     additionalSalary: 100000,
     bonusSalary: null,
-    personalStepAssignments: [],
+    personalStepAssignments: [
+      {
+        criterionTitle: 'Abyrgd',
+        subTitle: 'Abyrgd a fólki',
+        stepOrder,
+      },
+    ],
   }
 }
 
@@ -918,5 +952,30 @@ function makeReportResultDto(reportId: string) {
     calculationVersion: 'v1',
     base: snapshot,
     full: snapshot,
+    outlierAnalysis: {
+      method: SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+      thresholdPercent: 3.9,
+      allowedDifferencePercent: 1.95,
+      regressions: {
+        overall: makeEmptyRegression(),
+        male: makeEmptyRegression(),
+        female: makeEmptyRegression(),
+        neutral: makeEmptyRegression(),
+      },
+      employees: [],
+    },
+  }
+}
+
+function makeEmptyRegression() {
+  return {
+    slope: null,
+    intercept: null,
+    sampleCount: 0,
+    scoreMean: null,
+    adjustedBaseSalaryMean: null,
+    rSquared: null,
+    scoreRangeFrom: null,
+    scoreRangeTo: null,
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -502,18 +502,18 @@ function toOutlierDto(detected: DetectedOutlier): SalaryAnalysisOutlierDto {
   // detectOutliers only emits rows where isOutlier=true, which guarantees
   // a non-null direction and non-null differencePercent (see the assessment
   // in compensation-aggregates.ts).
-  const { assessment, bucket } = detected
+  const { assessment } = detected
 
   return {
     employeeOrdinal: detected.ordinal,
     adjustedBaseSalary: Math.round(detected.adjustedBaseSalary),
+    predictedBaseSalary: Math.round(detected.predictedBaseSalary),
+    scoreBucketRangeFrom: detected.scoreBucketRangeFrom,
+    scoreBucketRangeTo: detected.scoreBucketRangeTo,
     direction:
       (assessment.direction as SalaryAnalysisOutlierDirectionEnum | null) ??
       SalaryAnalysisOutlierDirectionEnum.EQUAL,
     differencePercent: assessment.differencePercent ?? 0,
     allowedDifferencePercent: assessment.allowedDifferencePercent,
-    referenceSalary: assessment.referenceSalary,
-    scoreBucketRangeFrom: bucket.rangeFrom,
-    scoreBucketRangeTo: bucket.rangeTo,
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/application/dto/salary-analysis.response.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/salary-analysis.response.dto.ts
@@ -1,10 +1,4 @@
-import {
-  ApiDto,
-  ApiDtoArray,
-  ApiEnum,
-  ApiNumber,
-  ApiOptionalNumber,
-} from '@dmr.is/decorators'
+import { ApiDto, ApiDtoArray, ApiEnum, ApiNumber } from '@dmr.is/decorators'
 
 import { SalaryByGenderAndScoreDto } from '../../report-statistics/dto/salary-by-gender-and-score.dto'
 
@@ -30,8 +24,8 @@ export class SalaryAnalysisOutlierDto {
   @ApiNumber()
   allowedDifferencePercent!: number
 
-  @ApiOptionalNumber({ nullable: true })
-  referenceSalary!: number | null
+  @ApiNumber()
+  predictedBaseSalary!: number
 
   @ApiNumber()
   scoreBucketRangeFrom!: number

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -674,62 +674,51 @@ function makeInput(): CreateReportDto {
 }
 
 /**
- * Variant of makeInput with three same-bucket employees engineered so that
- * `detectOutliers` flags ordinal 1 as the lone outlier under the default
- * 3.9% threshold (= 1.95% half-band around the bucket median).
- *
- * Bucket overall median = 1,200,000. Ordinal 1 sits 16.7% below it, ordinals
- * 2 and 3 are within 0.83% of the median.
+ * Variant of makeInput engineered so that `detectOutliers` flags ordinal 1 as
+ * the lone outlier under the default 3.9% threshold (= 1.95% half-band around
+ * the regression prediction at that exact score).
  */
 function makeInputWithDetectedOutlier(): CreateReportDto {
   const base = makeInput()
-  base.parsed.employees = [
-    {
-      ordinal: 1,
-      identifier: 'TVE-001',
-      roleTitle: 'Framkvaemdastjori',
-      education: EducationEnum.MASTER,
-      gender: GenderEnum.FEMALE,
-      field: 'Mgmt',
-      department: 'Mgmt',
-      startDate: '2021-01-01',
-      workRatio: 1,
-      baseSalary: 1000000,
-      additionalSalary: 100000,
-      bonusSalary: null,
-      personalStepAssignments: [],
-    },
-    {
-      ordinal: 2,
-      identifier: 'TVE-002',
-      roleTitle: 'Framkvaemdastjori',
-      education: EducationEnum.MASTER,
-      gender: GenderEnum.MALE,
-      field: 'Mgmt',
-      department: 'Mgmt',
-      startDate: '2021-01-01',
-      workRatio: 1,
-      baseSalary: 1200000,
-      additionalSalary: 100000,
-      bonusSalary: null,
-      personalStepAssignments: [],
-    },
-    {
-      ordinal: 3,
-      identifier: 'TVE-003',
-      roleTitle: 'Framkvaemdastjori',
-      education: EducationEnum.MASTER,
-      gender: GenderEnum.MALE,
-      field: 'Mgmt',
-      department: 'Mgmt',
-      startDate: '2021-01-01',
-      workRatio: 1,
-      baseSalary: 1210000,
-      additionalSalary: 100000,
-      bonusSalary: null,
-      personalStepAssignments: [],
-    },
+  base.parsed.criteria[0].subCriteria[0].steps = [
+    { order: 1, description: 'score 100', score: 100 },
+    { order: 2, description: 'score 200', score: 200 },
+    { order: 3, description: 'score 300', score: 300 },
+    { order: 4, description: 'score 400', score: 400 },
+    { order: 5, description: 'score 500', score: 500 },
+    { order: 6, description: 'score 600', score: 600 },
+    { order: 7, description: 'score 700', score: 700 },
   ]
+  base.parsed.roles[0].stepAssignments = []
+  base.parsed.employees = [
+    [1, GenderEnum.FEMALE, 850000],
+    [2, GenderEnum.MALE, 1000000],
+    [3, GenderEnum.MALE, 1100000],
+    [4, GenderEnum.MALE, 1200000],
+    [5, GenderEnum.MALE, 1300000],
+    [6, GenderEnum.MALE, 1400000],
+    [7, GenderEnum.MALE, 1500000],
+  ].map(([ordinal, gender, baseSalary]) => ({
+    ordinal: ordinal as number,
+    identifier: `TVE-00${ordinal}`,
+    roleTitle: 'Framkvaemdastjori',
+    education: EducationEnum.MASTER,
+    gender: gender as GenderEnum,
+    field: 'Mgmt',
+    department: 'Mgmt',
+    startDate: '2021-01-01',
+    workRatio: 1,
+    baseSalary: baseSalary as number,
+    additionalSalary: 100000,
+    bonusSalary: null,
+    personalStepAssignments: [
+      {
+        criterionTitle: 'Abyrgd',
+        subTitle: 'Abyrgd a fólki',
+        stepOrder: ordinal as number,
+      },
+    ],
+  }))
   return base
 }
 

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -380,9 +380,8 @@ export class ReportCreateService implements IReportCreateService {
 
   /**
    * Each `outliers[].employeeOrdinal` must match an `ordinal` in the parsed
-   * employees array. Outlier detection is the application's responsibility
-   * (planned outlier-preview endpoint — see `db/README.md` Notes); this
-   * service trusts the caller's flagging but rejects orphan references.
+   * employees array. The submit-side guard below verifies the submitted set
+   * against the canonical regression-based detection result.
    */
   private assertOutliersReferenceParsedEmployees(input: CreateReportDto) {
     if (!input.outliers || input.outliers.length === 0) {

--- a/apps/directorate-of-equality-api/src/modules/report-result/dto/report-result.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/dto/report-result.dto.ts
@@ -1,11 +1,17 @@
 import {
+  ApiBoolean,
   ApiDto,
   ApiDtoArray,
+  ApiEnum,
   ApiNumber,
   ApiOptionalNumber,
+  ApiOptionalString,
   ApiString,
   ApiUUId,
 } from '@dmr.is/decorators'
+
+import { SalaryOutlierAnalysisMethodEnum } from '../../report/lib/compensation-aggregates'
+import { GenderEnum } from '../../report/models/report.model'
 
 export class SalaryAggregateMetricsDto {
   @ApiOptionalNumber({ nullable: true })
@@ -94,6 +100,98 @@ export class ReportSalaryResultSnapshotDto {
   scoreBuckets!: SalaryScoreBucketDto[]
 }
 
+export class SalaryOutlierRegressionDto {
+  @ApiOptionalNumber({ nullable: true })
+  slope!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  intercept!: number | null
+
+  @ApiNumber()
+  sampleCount!: number
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreMean!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  adjustedBaseSalaryMean!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  rSquared!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreRangeFrom!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreRangeTo!: number | null
+}
+
+export class SalaryOutlierRegressionsDto {
+  @ApiDto(SalaryOutlierRegressionDto)
+  overall!: SalaryOutlierRegressionDto
+
+  @ApiDto(SalaryOutlierRegressionDto)
+  male!: SalaryOutlierRegressionDto
+
+  @ApiDto(SalaryOutlierRegressionDto)
+  female!: SalaryOutlierRegressionDto
+
+  @ApiDto(SalaryOutlierRegressionDto)
+  neutral!: SalaryOutlierRegressionDto
+}
+
+export class SalaryOutlierAnalysisEmployeeDto {
+  @ApiNumber()
+  ordinal!: number
+
+  @ApiNumber()
+  score!: number
+
+  @ApiEnum(GenderEnum)
+  gender!: GenderEnum
+
+  @ApiNumber()
+  adjustedBaseSalary!: number
+
+  @ApiOptionalNumber({ nullable: true })
+  predictedBaseSalary!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreBucketRangeFrom!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreBucketRangeTo!: number | null
+
+  @ApiOptionalString({ nullable: true })
+  direction!: string | null
+
+  @ApiOptionalNumber({ nullable: true })
+  differencePercent!: number | null
+
+  @ApiNumber()
+  allowedDifferencePercent!: number
+
+  @ApiBoolean()
+  isOutlier!: boolean
+}
+
+export class SalaryOutlierAnalysisDto {
+  @ApiEnum(SalaryOutlierAnalysisMethodEnum)
+  method!: SalaryOutlierAnalysisMethodEnum
+
+  @ApiNumber()
+  thresholdPercent!: number
+
+  @ApiNumber()
+  allowedDifferencePercent!: number
+
+  @ApiDto(SalaryOutlierRegressionsDto)
+  regressions!: SalaryOutlierRegressionsDto
+
+  @ApiDtoArray(SalaryOutlierAnalysisEmployeeDto)
+  employees!: SalaryOutlierAnalysisEmployeeDto[]
+}
+
 export class ReportRoleResultDto {
   @ApiUUId()
   id!: string
@@ -132,4 +230,7 @@ export class ReportResultDto {
 
   @ApiDto(ReportSalaryResultSnapshotDto)
   full!: ReportSalaryResultSnapshotDto
+
+  @ApiDto(SalaryOutlierAnalysisDto)
+  outlierAnalysis!: SalaryOutlierAnalysisDto
 }

--- a/apps/directorate-of-equality-api/src/modules/report-result/models/report-result.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/models/report-result.model.ts
@@ -3,7 +3,10 @@ import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
 import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 
 import { DoeModels } from '../../../core/constants'
-import type { SalaryResultSnapshot } from '../../report/lib/compensation-aggregates'
+import type {
+  SalaryOutlierAnalysisSnapshot,
+  SalaryResultSnapshot,
+} from '../../report/lib/compensation-aggregates'
 import { ReportModel } from '../../report/models/report.model'
 import type { ReportResultDto } from '../dto/report-result.dto'
 
@@ -16,6 +19,7 @@ export type ReportResultAttributes = {
   calculationVersion: string
   baseSnapshot: SalaryResultSnapshot
   fullSnapshot: SalaryResultSnapshot
+  outlierAnalysisSnapshot: SalaryOutlierAnalysisSnapshot
 }
 
 export type ReportResultCreateAttributes = Omit<
@@ -71,6 +75,13 @@ export class ReportResultModel extends MutableModel<
   })
   fullSnapshot!: SalaryResultSnapshot
 
+  @Column({
+    type: DataType.JSONB,
+    allowNull: false,
+    field: 'outlier_analysis_snapshot',
+  })
+  outlierAnalysisSnapshot!: SalaryOutlierAnalysisSnapshot
+
   @BelongsTo(() => ReportModel, { foreignKey: 'reportId', as: 'report' })
   report?: ReportModel
 
@@ -82,6 +93,7 @@ export class ReportResultModel extends MutableModel<
       calculationVersion: model.calculationVersion,
       base: model.baseSnapshot,
       full: model.fullSnapshot,
+      outlierAnalysis: model.outlierAnalysisSnapshot,
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.controller.spec.ts
@@ -1,7 +1,18 @@
+import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
 import { ReportResultController } from './report-result.controller'
 
 describe('ReportResultController', () => {
   it('returns the persisted report result from the service', async () => {
+    const emptyRegression = {
+      slope: null,
+      intercept: null,
+      sampleCount: 0,
+      scoreMean: null,
+      adjustedBaseSalaryMean: null,
+      rSquared: null,
+      scoreRangeFrom: null,
+      scoreRangeTo: null,
+    }
     const getByReportId = jest.fn().mockResolvedValue({
       id: 'result-1',
       reportId: 'report-1',
@@ -15,10 +26,24 @@ describe('ReportResultController', () => {
         totals: { overall: { average: 625000 } },
         scoreBuckets: [],
       },
+      outlierAnalysis: {
+        method:
+          SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+        thresholdPercent: 3.9,
+        allowedDifferencePercent: 1.95,
+        regressions: {
+          overall: emptyRegression,
+          male: emptyRegression,
+          female: emptyRegression,
+          neutral: emptyRegression,
+        },
+        employees: [],
+      },
     })
 
     const controller = new ReportResultController({
       getByReportId,
+      createForReport: jest.fn(),
     })
     const result = await controller.getByReportId('report-1')
 

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.spec.ts
@@ -9,6 +9,7 @@ import { Test } from '@nestjs/testing'
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { ConfigModel } from '../config/models/config.model'
+import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
 import {
   GenderEnum,
   ReportModel,
@@ -89,11 +90,21 @@ describe('ReportResultService', () => {
           totals: { overall: { average: 625000 } },
           scoreBuckets: [],
         },
+        outlierAnalysis: makeOutlierAnalysis(),
       }),
     })
     employeeFindAll.mockResolvedValue([
-      makeEmployee('role-b', 120, GenderEnum.MALE, 1, 400000, 100000, 50000),
-      makeEmployee('role-a', 220, GenderEnum.FEMALE, 0.5, 300000, 50000, null),
+      makeEmployee(1, 'role-b', 120, GenderEnum.MALE, 1, 400000, 100000, 50000),
+      makeEmployee(
+        2,
+        'role-a',
+        220,
+        GenderEnum.FEMALE,
+        0.5,
+        300000,
+        50000,
+        null,
+      ),
     ])
     configFindOne.mockResolvedValue({ value: '3.9' })
     resultCreate.mockResolvedValue({ id: 'result-1' })
@@ -128,6 +139,53 @@ describe('ReportResultService', () => {
           totals: expect.objectContaining({
             overall: expect.objectContaining({ average: 625000 }),
           }),
+        }),
+        outlierAnalysisSnapshot: expect.objectContaining({
+          method:
+            SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+          thresholdPercent: 3.9,
+          allowedDifferencePercent: 1.95,
+          regressions: expect.objectContaining({
+            overall: expect.objectContaining({
+              sampleCount: 2,
+              slope: 2000,
+              intercept: 160000,
+            }),
+            male: expect.objectContaining({
+              sampleCount: 1,
+              intercept: 400000,
+            }),
+            female: expect.objectContaining({
+              sampleCount: 1,
+              intercept: 600000,
+            }),
+            neutral: expect.objectContaining({
+              sampleCount: 0,
+              slope: null,
+            }),
+          }),
+          employees: expect.arrayContaining([
+            expect.objectContaining({
+              ordinal: 1,
+              score: 120,
+              gender: GenderEnum.MALE,
+              adjustedBaseSalary: 400000,
+              predictedBaseSalary: 400000,
+              scoreBucketRangeFrom: 100,
+              scoreBucketRangeTo: 200,
+              isOutlier: false,
+            }),
+            expect.objectContaining({
+              ordinal: 2,
+              score: 220,
+              gender: GenderEnum.FEMALE,
+              adjustedBaseSalary: 600000,
+              predictedBaseSalary: 600000,
+              scoreBucketRangeFrom: 200,
+              scoreBucketRangeTo: 300,
+              isOutlier: false,
+            }),
+          ]),
         }),
       }),
     )
@@ -187,6 +245,7 @@ describe('ReportResultService', () => {
           totals: { overall: { average: 625000 } },
           scoreBuckets: [],
         },
+        outlierAnalysis: makeOutlierAnalysis(),
       }),
     })
 
@@ -197,6 +256,7 @@ describe('ReportResultService', () => {
 })
 
 function makeEmployee(
+  ordinal: number,
   reportEmployeeRoleId: string,
   score: number,
   gender: GenderEnum,
@@ -206,6 +266,7 @@ function makeEmployee(
   bonusSalary: number | null,
 ) {
   return {
+    ordinal,
     reportEmployeeRoleId,
     score,
     gender,
@@ -214,4 +275,41 @@ function makeEmployee(
     additionalSalary,
     bonusSalary,
   } as ReportEmployeeModel
+}
+
+function makeOutlierAnalysis() {
+  return {
+    method: SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+    thresholdPercent: 3.9,
+    allowedDifferencePercent: 1.95,
+    regressions: {
+      overall: {
+        slope: 2000,
+        intercept: 160000,
+        sampleCount: 2,
+        scoreMean: 170,
+        adjustedBaseSalaryMean: 500000,
+        rSquared: 1,
+        scoreRangeFrom: 120,
+        scoreRangeTo: 220,
+      },
+      male: makeEmptyRegression(1, 400000),
+      female: makeEmptyRegression(1, 600000),
+      neutral: makeEmptyRegression(0, null),
+    },
+    employees: [],
+  }
+}
+
+function makeEmptyRegression(sampleCount: number, mean: number | null) {
+  return {
+    slope: sampleCount > 0 ? 0 : null,
+    intercept: mean,
+    sampleCount,
+    scoreMean: sampleCount > 0 ? 0 : null,
+    adjustedBaseSalaryMean: mean,
+    rSquared: null,
+    scoreRangeFrom: sampleCount > 0 ? 0 : null,
+    scoreRangeTo: sampleCount > 0 ? 0 : null,
+  }
 }

--- a/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-result/report-result.service.ts
@@ -13,6 +13,8 @@ import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 import { ConfigModel } from '../config/models/config.model'
 import {
   computeCompensationAggregates,
+  computeSalaryOutlierAnalysis,
+  roundSalaryOutlierAnalysisSnapshot,
   roundSalaryResultSnapshot,
 } from '../report/lib/compensation-aggregates'
 import { ReportModel, ReportTypeEnum } from '../report/models/report.model'
@@ -125,6 +127,16 @@ export class ReportResultService implements IReportResultService {
         bonusSalary: employee.bonusSalary,
       })),
     })
+    const outlierAnalysis = computeSalaryOutlierAnalysis({
+      employees: employees.map((employee) => ({
+        ordinal: employee.ordinal,
+        score: employee.score,
+        gender: employee.gender,
+        workRatio: employee.workRatio,
+        baseSalary: employee.baseSalary,
+      })),
+      thresholdPercent: threshold,
+    })
 
     const resultValues = {
       reportId,
@@ -132,6 +144,8 @@ export class ReportResultService implements IReportResultService {
       calculationVersion: REPORT_RESULT_CALCULATION_VERSION,
       baseSnapshot: roundSalaryResultSnapshot(aggregates.report.base, 2),
       fullSnapshot: roundSalaryResultSnapshot(aggregates.report.full, 2),
+      outlierAnalysisSnapshot:
+        roundSalaryOutlierAnalysisSnapshot(outlierAnalysis),
     } satisfies ReportResultCreateAttributes
 
     await this.reportResultModel.create(resultValues)

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/lib/build-chart.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/lib/build-chart.ts
@@ -1,8 +1,10 @@
 import {
   computeSalaryAggregateSnapshot,
+  computeSalaryRegression,
   computeSalaryScoreBucketSnapshots,
   roundNullable,
   type SalaryScorePoint,
+  SCORE_BUCKET_WIDTH,
 } from '../../report/lib/compensation-aggregates'
 import { GenderEnum } from '../../report/models/report.model'
 import {
@@ -18,8 +20,6 @@ export interface EmployeeDataPoint {
   adjustedSalary: number
   gender: GenderEnum
 }
-
-const BUCKET_WIDTH = 100
 
 /**
  * Builds the gender-vs-score scatter response shared by reviewer-side
@@ -48,34 +48,16 @@ export function buildChartFromEmployeePoints(
 function computeLinearRegression(
   points: EmployeeDataPoint[],
 ): RegressionLineDto {
-  const n = points.length
-  if (n < 2) {
-    return { slope: 0, intercept: n === 1 ? points[0].adjustedSalary : 0 }
-  }
-
-  let sumX = 0
-  let sumY = 0
-  let sumXY = 0
-  let sumX2 = 0
-
-  for (const p of points) {
-    sumX += p.score
-    sumY += p.adjustedSalary
-    sumXY += p.score * p.adjustedSalary
-    sumX2 += p.score * p.score
-  }
-
-  const denominator = n * sumX2 - sumX * sumX
-  if (denominator === 0) {
-    return { slope: 0, intercept: sumY / n }
-  }
-
-  const slope = (n * sumXY - sumX * sumY) / denominator
-  const intercept = (sumY - slope * sumX) / n
+  const regression = computeSalaryRegression(
+    points.map((p) => ({
+      score: p.score,
+      adjustedBaseSalary: p.adjustedSalary,
+    })),
+  )
 
   return {
-    slope: Math.round(slope * 100) / 100,
-    intercept: Math.round(intercept * 100) / 100,
+    slope: roundNullable(regression.slope, 2) ?? 0,
+    intercept: roundNullable(regression.intercept, 2) ?? 0,
   }
 }
 
@@ -86,7 +68,7 @@ function computeScoreBuckets(points: EmployeeDataPoint[]): ScoreBucketDto[] {
     salary: point.adjustedSalary,
   }))
 
-  return computeSalaryScoreBucketSnapshots(salaryPoints, BUCKET_WIDTH).map(
+  return computeSalaryScoreBucketSnapshots(salaryPoints, SCORE_BUCKET_WIDTH).map(
     (bucket) => {
       const snapshot = bucket.totals
 

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
@@ -1,9 +1,9 @@
 import { GenderEnum } from '../models/report.model'
 import {
-  assessSalaryOutlierFromReference,
-  assessSalaryOutlierInBucket,
+  assessSalaryOutlierFromPrediction,
   computeCompensationAggregates,
   computeSalaryAggregateSnapshot,
+  computeSalaryOutlierAnalysis,
   detectOutliers,
   type OutlierDetectionEmployee,
   roundSalaryAggregateSnapshot,
@@ -239,25 +239,25 @@ describe('compensation-aggregates', () => {
     })
   })
 
-  it('marks salaries outside half the threshold from a reference as outliers', () => {
+  it('marks salaries outside half the threshold from a prediction as outliers', () => {
     expect(
-      assessSalaryOutlierFromReference({
+      assessSalaryOutlierFromPrediction({
         salary: 102000,
-        referenceSalary: 100000,
-        thresholdPercent: 3.9,
+        predictedSalary: 100000,
+        allowedDifferencePercent: 1.95,
       }),
     ).toMatchObject({
       isOutlier: true,
       direction: 'ABOVE',
       allowedDifferencePercent: 1.95,
-      referenceSalary: 100000,
+      predictedSalary: 100000,
     })
 
     expect(
-      assessSalaryOutlierFromReference({
+      assessSalaryOutlierFromPrediction({
         salary: 98100,
-        referenceSalary: 100000,
-        thresholdPercent: 3.9,
+        predictedSalary: 100000,
+        allowedDifferencePercent: 1.95,
       }),
     ).toMatchObject({
       isOutlier: false,
@@ -266,52 +266,66 @@ describe('compensation-aggregates', () => {
     })
   })
 
-  it('assesses salary outlier against a score bucket median', () => {
-    const aggregates = computeCompensationAggregates({
+  it('computes a regression analysis with predicted base salary per exact score', () => {
+    const analysis = computeSalaryOutlierAnalysis({
+      thresholdPercent: 3.9,
       employees: [
-        {
-          reportEmployeeRoleId: 'role-a',
-          score: 120,
-          gender: GenderEnum.MALE,
-          workRatio: 1,
-          baseSalary: 100000,
-          additionalSalary: 0,
-          bonusSalary: null,
-        },
-        {
-          reportEmployeeRoleId: 'role-b',
-          score: 120,
-          gender: GenderEnum.FEMALE,
-          workRatio: 1,
-          baseSalary: 104000,
-          additionalSalary: 0,
-          bonusSalary: null,
-        },
-        {
-          reportEmployeeRoleId: 'role-c',
-          score: 120,
-          gender: GenderEnum.MALE,
-          workRatio: 1,
-          baseSalary: 500000,
-          additionalSalary: 0,
-          bonusSalary: null,
-        },
+        makeOutlierEmployee({ ordinal: 1, score: 100, baseSalary: 1000000 }),
+        makeOutlierEmployee({ ordinal: 2, score: 200, baseSalary: 1100000 }),
+        makeOutlierEmployee({ ordinal: 3, score: 300, baseSalary: 1200000 }),
       ],
     })
 
-    const bucket = aggregates.report.base.scoreBuckets[0]
-
-    expect(
-      assessSalaryOutlierInBucket({
-        salary: 104000,
-        bucket,
-        thresholdPercent: 3.9,
-      }),
-    ).toMatchObject({
+    expect(analysis.regressions.overall.slope).toBeCloseTo(1000, 4)
+    expect(analysis.regressions.overall.intercept).toBeCloseTo(900000, 4)
+    expect(analysis.employees[1]).toMatchObject({
+      ordinal: 2,
+      score: 200,
+      adjustedBaseSalary: 1100000,
+      predictedBaseSalary: 1100000,
       isOutlier: false,
-      direction: 'EQUAL',
-      referenceSalary: 104000,
     })
+  })
+
+  it('snapshots per-gender regressions for visualisation', () => {
+    const analysis = computeSalaryOutlierAnalysis({
+      thresholdPercent: 3.9,
+      employees: [
+        makeOutlierEmployee({
+          ordinal: 1,
+          score: 100,
+          gender: GenderEnum.FEMALE,
+          baseSalary: 800000,
+        }),
+        makeOutlierEmployee({
+          ordinal: 2,
+          score: 200,
+          gender: GenderEnum.FEMALE,
+          baseSalary: 900000,
+        }),
+        makeOutlierEmployee({
+          ordinal: 3,
+          score: 100,
+          gender: GenderEnum.MALE,
+          baseSalary: 1000000,
+        }),
+        makeOutlierEmployee({
+          ordinal: 4,
+          score: 200,
+          gender: GenderEnum.MALE,
+          baseSalary: 1100000,
+        }),
+      ],
+    })
+
+    expect(analysis.regressions.female.sampleCount).toBe(2)
+    expect(analysis.regressions.female.slope).toBeCloseTo(1000, 4)
+    expect(analysis.regressions.male.sampleCount).toBe(2)
+    expect(analysis.regressions.male.slope).toBeCloseTo(1000, 4)
+    expect(analysis.regressions.male.intercept).toBeCloseTo(900000, 4)
+    expect(analysis.regressions.female.intercept).toBeCloseTo(700000, 4)
+    expect(analysis.regressions.neutral.sampleCount).toBe(0)
+    expect(analysis.regressions.neutral.slope).toBeNull()
   })
 
   describe('detectOutliers', () => {
@@ -326,80 +340,77 @@ describe('compensation-aggregates', () => {
       ...overrides,
     })
 
-    it('returns the employees whose adjusted base salary deviates beyond the half-threshold band around the bucket median', () => {
-      // 3 employees in the same score bucket. Median = 1,200,000.
-      // Ordinal 1 is 16.7% below the median (deviates) — flagged.
-      // Ordinals 2 and 3 land within 0.84% of the median — not flagged.
+    const regressionEmployees = () => [
+      baseEmployee({ ordinal: 1, score: 100, baseSalary: 850000 }),
+      baseEmployee({ ordinal: 2, score: 200, baseSalary: 1000000 }),
+      baseEmployee({ ordinal: 3, score: 300, baseSalary: 1100000 }),
+      baseEmployee({ ordinal: 4, score: 400, baseSalary: 1200000 }),
+      baseEmployee({ ordinal: 5, score: 500, baseSalary: 1300000 }),
+      baseEmployee({ ordinal: 6, score: 600, baseSalary: 1400000 }),
+      baseEmployee({ ordinal: 7, score: 700, baseSalary: 1500000 }),
+    ]
+
+    it('returns employees whose adjusted base salary deviates beyond the half-threshold band around the regression prediction', () => {
       const outliers = detectOutliers({
         thresholdPercent: 3.9,
-        employees: [
-          baseEmployee({ ordinal: 1, score: 250, baseSalary: 1000000 }),
-          baseEmployee({ ordinal: 2, score: 250, baseSalary: 1200000 }),
-          baseEmployee({ ordinal: 3, score: 250, baseSalary: 1210000 }),
-        ],
+        employees: regressionEmployees(),
       })
 
       expect(outliers).toHaveLength(1)
       expect(outliers[0]).toMatchObject({
         ordinal: 1,
-        adjustedBaseSalary: 1000000,
+        score: 100,
+        adjustedBaseSalary: 850000,
         assessment: {
           isOutlier: true,
           direction: 'BELOW',
-          referenceSalary: 1200000,
+          predictedSalary: expect.any(Number),
         },
+        scoreBucketRangeFrom: 100,
+        scoreBucketRangeTo: 200,
       })
+      expect(outliers[0].predictedBaseSalary).toBeCloseTo(876785.71, 2)
+      expect(outliers[0].assessment.differencePercent).toBeCloseTo(-3.055, 3)
     })
 
     it('honours workRatio when adjusting base salary for detection', () => {
-      // Same baseSalary but ordinal 1 is part-time (workRatio 0.5), so
-      // adjusted base salary is 2x ordinal 2's. With 2 samples, the median
-      // is the midpoint and both deviate by 33% — both are flagged.
-      const outliers = detectOutliers({
+      const analysis = computeSalaryOutlierAnalysis({
         thresholdPercent: 3.9,
         employees: [
           baseEmployee({
             ordinal: 1,
             score: 250,
-            workRatio: 0.5,
-            baseSalary: 800000,
+            workRatio: 1,
+            baseSalary: 1000000,
           }),
           baseEmployee({
             ordinal: 2,
             score: 250,
-            workRatio: 1,
-            baseSalary: 800000,
+            workRatio: 0.5,
+            baseSalary: 500000,
           }),
         ],
       })
 
-      expect(outliers.map((o) => o.ordinal).sort()).toEqual([1, 2])
-      const ordinal1 = outliers.find((o) => o.ordinal === 1)!
-      expect(ordinal1.adjustedBaseSalary).toBe(1600000)
-    })
-
-    it('reports the score-bucket each outlier landed in', () => {
-      const outliers = detectOutliers({
-        thresholdPercent: 3.9,
-        employees: [
-          baseEmployee({ ordinal: 1, score: 250, baseSalary: 1000000 }),
-          baseEmployee({ ordinal: 2, score: 250, baseSalary: 1200000 }),
-          baseEmployee({ ordinal: 3, score: 250, baseSalary: 1210000 }),
-        ],
-      })
-
-      // Default bucket width is 100. Score 250 → bucket [200, 300).
-      expect(outliers[0].bucket.rangeFrom).toBe(200)
-      expect(outliers[0].bucket.rangeTo).toBe(300)
+      expect(
+        analysis.employees.map((employee) => employee.adjustedBaseSalary),
+      ).toEqual([1000000, 1000000])
+      expect(
+        analysis.employees.map((employee) => employee.scoreBucketRangeFrom),
+      ).toEqual([200, 200])
+      expect(analysis.employees.map((employee) => employee.isOutlier)).toEqual([
+        false,
+        false,
+      ])
     })
 
     it('returns an empty array when no employees deviate beyond the band', () => {
       const outliers = detectOutliers({
         thresholdPercent: 3.9,
         employees: [
-          baseEmployee({ ordinal: 1, score: 250, baseSalary: 1000000 }),
-          baseEmployee({ ordinal: 2, score: 250, baseSalary: 1010000 }),
-          baseEmployee({ ordinal: 3, score: 250, baseSalary: 1005000 }),
+          baseEmployee({ ordinal: 1, score: 100, baseSalary: 1000000 }),
+          baseEmployee({ ordinal: 2, score: 200, baseSalary: 1100000 }),
+          baseEmployee({ ordinal: 3, score: 300, baseSalary: 1200000 }),
         ],
       })
 
@@ -413,13 +424,10 @@ describe('compensation-aggregates', () => {
     })
 
     it('uses the full threshold when useHalfThreshold is false', () => {
-      // Ordinal 1 deviates by 3% from the median. Half-threshold (1.95%)
+      // Ordinal 1 deviates by about 3% from the regression prediction.
+      // Half-threshold (1.95%)
       // would flag it; full threshold (3.9%) wouldn't.
-      const employees = [
-        baseEmployee({ ordinal: 1, score: 250, baseSalary: 970000 }),
-        baseEmployee({ ordinal: 2, score: 250, baseSalary: 1000000 }),
-        baseEmployee({ ordinal: 3, score: 250, baseSalary: 1003000 }),
-      ]
+      const employees = regressionEmployees()
 
       expect(
         detectOutliers({ thresholdPercent: 3.9, employees }).map(
@@ -437,3 +445,16 @@ describe('compensation-aggregates', () => {
     })
   })
 })
+
+function makeOutlierEmployee(
+  overrides: Partial<OutlierDetectionEmployee>,
+): OutlierDetectionEmployee {
+  return {
+    ordinal: 0,
+    score: 100,
+    gender: GenderEnum.FEMALE,
+    workRatio: 1,
+    baseSalary: 1000000,
+    ...overrides,
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
@@ -69,7 +69,7 @@ export type SalaryOutlierAssessment = {
   direction: SalaryOutlierDirection | null
   differencePercent: number | null
   allowedDifferencePercent: number
-  referenceSalary: number | null
+  predictedSalary: number | null
 }
 
 export type CompensationAggregateResult = {
@@ -77,6 +77,60 @@ export type CompensationAggregateResult = {
     base: SalaryResultSnapshot
     full: SalaryResultSnapshot
   }
+}
+
+export enum SalaryOutlierAnalysisMethodEnum {
+  BASE_SALARY_LINEAR_REGRESSION_BY_SCORE = 'BASE_SALARY_LINEAR_REGRESSION_BY_SCORE',
+}
+
+export const SCORE_BUCKET_WIDTH = 100
+
+export type SalaryRegressionSnapshot = {
+  slope: number | null
+  intercept: number | null
+  sampleCount: number
+  scoreMean: number | null
+  adjustedBaseSalaryMean: number | null
+  rSquared: number | null
+  scoreRangeFrom: number | null
+  scoreRangeTo: number | null
+}
+
+/**
+ * Regressions fitted on adjusted base salary vs score.
+ *
+ * `overall` is gender-blind and is the line that drives the outlier flag.
+ * `male` / `female` / `neutral` are fitted on each cohort separately and are
+ * carried for visualisation/analytics only — the outlier rule does not use
+ * them.
+ */
+export type SalaryRegressionsByGenderSnapshot = {
+  overall: SalaryRegressionSnapshot
+  male: SalaryRegressionSnapshot
+  female: SalaryRegressionSnapshot
+  neutral: SalaryRegressionSnapshot
+}
+
+export type SalaryOutlierAnalysisEmployeeSnapshot = {
+  ordinal: number
+  score: number
+  gender: GenderEnum
+  adjustedBaseSalary: number
+  predictedBaseSalary: number | null
+  scoreBucketRangeFrom: number | null
+  scoreBucketRangeTo: number | null
+  direction: SalaryOutlierDirection | null
+  differencePercent: number | null
+  allowedDifferencePercent: number
+  isOutlier: boolean
+}
+
+export type SalaryOutlierAnalysisSnapshot = {
+  method: SalaryOutlierAnalysisMethodEnum
+  thresholdPercent: number
+  allowedDifferencePercent: number
+  regressions: SalaryRegressionsByGenderSnapshot
+  employees: SalaryOutlierAnalysisEmployeeSnapshot[]
 }
 
 type AggregateGroup = {
@@ -266,62 +320,46 @@ export function roundSalaryResultSnapshot(
   }
 }
 
-export function assessSalaryOutlierFromReference(input: {
+/**
+ * Compares an employee's salary to a predicted salary at their exact score
+ * and flags them as an outlier when the absolute difference is at or above
+ * the supplied band. Caller is responsible for deriving
+ * `allowedDifferencePercent` from the configured threshold (typically half
+ * of `salary_difference_threshold_percent`).
+ */
+export function assessSalaryOutlierFromPrediction(input: {
   salary: number
-  referenceSalary: number | null
-  thresholdPercent: number
-  useHalfThreshold?: boolean
+  predictedSalary: number | null
+  allowedDifferencePercent: number
 }): SalaryOutlierAssessment {
-  const allowedDifferencePercent =
-    input.useHalfThreshold === false
-      ? input.thresholdPercent
-      : input.thresholdPercent / 2
-
-  if (input.referenceSalary === null || input.referenceSalary === 0) {
+  if (input.predictedSalary === null || input.predictedSalary <= 0) {
     return {
       isOutlier: false,
       direction: null,
       differencePercent: null,
-      allowedDifferencePercent,
-      referenceSalary: input.referenceSalary,
+      allowedDifferencePercent: input.allowedDifferencePercent,
+      predictedSalary: input.predictedSalary,
     }
   }
 
   const differencePercent =
-    ((input.salary - input.referenceSalary) / input.referenceSalary) * 100
+    ((input.salary - input.predictedSalary) / input.predictedSalary) * 100
   const absoluteDifferencePercent = Math.abs(differencePercent)
 
   return {
-    isOutlier: absoluteDifferencePercent >= allowedDifferencePercent,
+    isOutlier: absoluteDifferencePercent >= input.allowedDifferencePercent,
     direction: getSalaryOutlierDirection(differencePercent),
     differencePercent,
-    allowedDifferencePercent,
-    referenceSalary: input.referenceSalary,
+    allowedDifferencePercent: input.allowedDifferencePercent,
+    predictedSalary: input.predictedSalary,
   }
 }
 
-/**
- * Salary outlier rule for a score bucket:
- *
- * 1. Place the employee in a score bucket.
- * 2. Use the bucket's overall median salary as the reference salary.
- * 3. Use half of the configured salary-difference threshold by default.
- *    Example: `3.9` becomes an allowed +/- `1.95%` band around the median.
- * 4. Mark the employee as an outlier when their adjusted salary is greater
- *    than or equal to that allowed percentage above or below the bucket median.
- */
-export function assessSalaryOutlierInBucket(input: {
-  salary: number
-  bucket: SalaryScoreBucketSnapshot
-  thresholdPercent: number
-  useHalfThreshold?: boolean
-}): SalaryOutlierAssessment {
-  return assessSalaryOutlierFromReference({
-    salary: input.salary,
-    referenceSalary: input.bucket.totals.overall.median,
-    thresholdPercent: input.thresholdPercent,
-    useHalfThreshold: input.useHalfThreshold,
-  })
+export function resolveAllowedDifferencePercent(
+  thresholdPercent: number,
+  useHalfThreshold = true,
+): number {
+  return useHalfThreshold ? thresholdPercent / 2 : thresholdPercent
 }
 
 export type OutlierDetectionEmployee = {
@@ -334,8 +372,11 @@ export type OutlierDetectionEmployee = {
 
 export type DetectedOutlier = {
   ordinal: number
+  score: number
   adjustedBaseSalary: number
-  bucket: SalaryScoreBucketSnapshot
+  predictedBaseSalary: number
+  scoreBucketRangeFrom: number
+  scoreBucketRangeTo: number
   assessment: SalaryOutlierAssessment
 }
 
@@ -344,53 +385,295 @@ export type DetectedOutlier = {
  * application-side preview endpoint and the submit-side guard:
  *
  * - Adjusts each employee's base salary (`baseSalary / workRatio`).
- * - Buckets employees by score using the standard bucket width.
- * - Runs `assessSalaryOutlierInBucket` on each (half threshold by default).
- * - Returns the outlier rows with the bucket and full assessment, so the
- *   caller can show the calculation that drove the verdict.
+ * - Fits one regression line from score -> adjusted base salary.
+ * - Assesses each employee against the predicted salary at their exact score.
+ * - Returns only the rows where the assessment is an outlier.
  */
 export function detectOutliers(input: {
   employees: OutlierDetectionEmployee[]
   thresholdPercent: number
-  bucketWidth?: number
   useHalfThreshold?: boolean
 }): DetectedOutlier[] {
-  const samples: SalaryScorePoint[] = input.employees.map((employee) => ({
-    score: employee.score,
-    gender: employee.gender,
-    salary: employee.baseSalary / employee.workRatio,
-  }))
-
-  const buckets = computeSalaryScoreBucketSnapshots(samples, input.bucketWidth)
-
+  const analysis = computeSalaryOutlierAnalysis(input)
   const outliers: DetectedOutlier[] = []
 
-  for (let index = 0; index < input.employees.length; index += 1) {
-    const employee = input.employees[index]
-    const sample = samples[index]
-    const bucket = buckets.find(
-      (b) => sample.score >= b.rangeFrom && sample.score < b.rangeTo,
-    )
-    if (!bucket) continue
-
-    const assessment = assessSalaryOutlierInBucket({
-      salary: sample.salary,
-      bucket,
-      thresholdPercent: input.thresholdPercent,
-      useHalfThreshold: input.useHalfThreshold,
-    })
-
-    if (assessment.isOutlier) {
+  for (const employee of analysis.employees) {
+    if (
+      employee.isOutlier &&
+      employee.predictedBaseSalary !== null &&
+      employee.scoreBucketRangeFrom !== null &&
+      employee.scoreBucketRangeTo !== null
+    ) {
       outliers.push({
         ordinal: employee.ordinal,
-        adjustedBaseSalary: sample.salary,
-        bucket,
-        assessment,
+        score: employee.score,
+        adjustedBaseSalary: employee.adjustedBaseSalary,
+        predictedBaseSalary: employee.predictedBaseSalary,
+        scoreBucketRangeFrom: employee.scoreBucketRangeFrom,
+        scoreBucketRangeTo: employee.scoreBucketRangeTo,
+        assessment: {
+          isOutlier: employee.isOutlier,
+          direction: employee.direction,
+          differencePercent: employee.differencePercent,
+          allowedDifferencePercent: employee.allowedDifferencePercent,
+          predictedSalary: employee.predictedBaseSalary,
+        },
       })
     }
   }
 
   return outliers
+}
+
+/**
+ * Salary outlier analysis rule:
+ *
+ * 1. Adjust each employee's base salary to a full-time equivalent.
+ * 2. Fit a gender-blind least-squares regression line from
+ *    score -> adjusted base salary (`regressions.overall`).
+ * 3. Predict the employee's salary at their exact score using that line.
+ * 4. Use half of the configured salary-difference threshold by default.
+ *    Example: `3.9` becomes an allowed +/- `1.95%` band around the line.
+ * 5. Mark the employee as an outlier when their adjusted base salary is
+ *    greater than or equal to that allowed percentage above or below the
+ *    predicted salary.
+ *
+ * Per-cohort regressions (`regressions.male/female/neutral`) are also fitted
+ * and snapshotted for visualisation/analytics. They do not influence the
+ * outlier flag.
+ *
+ * Score-bucket placement (`scoreBucketRangeFrom/To`) is preserved per
+ * employee so reviewers can still cross-reference the bucket-level
+ * aggregates carried in `report_result.base_snapshot.scoreBuckets`. It does
+ * not influence the outlier flag either.
+ */
+export function computeSalaryOutlierAnalysis(input: {
+  employees: OutlierDetectionEmployee[]
+  thresholdPercent: number
+  useHalfThreshold?: boolean
+}): SalaryOutlierAnalysisSnapshot {
+  const adjustedEmployees = input.employees.map((employee) => ({
+    ordinal: employee.ordinal,
+    score: employee.score,
+    gender: employee.gender,
+    adjustedBaseSalary: employee.baseSalary / employee.workRatio,
+  }))
+  const regressions = computeRegressionsByGender(adjustedEmployees)
+  const overallRegression = regressions.overall
+  const allowedDifferencePercent = resolveAllowedDifferencePercent(
+    input.thresholdPercent,
+    input.useHalfThreshold,
+  )
+
+  return {
+    method: SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+    thresholdPercent: input.thresholdPercent,
+    allowedDifferencePercent,
+    regressions,
+    employees: adjustedEmployees.map((employee) => {
+      const predictedBaseSalary = predictFromRegression(
+        overallRegression,
+        employee.score,
+      )
+      const bucketRangeFrom = bucketRangeFromScore(employee.score)
+      const assessment = assessSalaryOutlierFromPrediction({
+        salary: employee.adjustedBaseSalary,
+        predictedSalary: predictedBaseSalary,
+        allowedDifferencePercent,
+      })
+
+      return {
+        ordinal: employee.ordinal,
+        score: employee.score,
+        gender: employee.gender,
+        adjustedBaseSalary: employee.adjustedBaseSalary,
+        predictedBaseSalary,
+        scoreBucketRangeFrom: bucketRangeFrom,
+        scoreBucketRangeTo: bucketRangeFrom + SCORE_BUCKET_WIDTH,
+        direction: assessment.direction,
+        differencePercent: assessment.differencePercent,
+        allowedDifferencePercent: assessment.allowedDifferencePercent,
+        isOutlier: assessment.isOutlier,
+      }
+    }),
+  }
+}
+
+function bucketRangeFromScore(score: number): number {
+  return Math.floor(score / SCORE_BUCKET_WIDTH) * SCORE_BUCKET_WIDTH
+}
+
+function predictFromRegression(
+  regression: SalaryRegressionSnapshot,
+  score: number,
+): number | null {
+  if (regression.slope === null || regression.intercept === null) {
+    return null
+  }
+  return regression.slope * score + regression.intercept
+}
+
+function computeRegressionsByGender(
+  samples: Array<{
+    score: number
+    gender: GenderEnum
+    adjustedBaseSalary: number
+  }>,
+): SalaryRegressionsByGenderSnapshot {
+  return {
+    overall: computeSalaryRegression(samples),
+    male: computeSalaryRegression(
+      samples.filter((sample) => sample.gender === GenderEnum.MALE),
+    ),
+    female: computeSalaryRegression(
+      samples.filter((sample) => sample.gender === GenderEnum.FEMALE),
+    ),
+    neutral: computeSalaryRegression(
+      samples.filter((sample) => sample.gender === GenderEnum.NEUTRAL),
+    ),
+  }
+}
+
+/**
+ * Canonical least-squares regression used everywhere in the app:
+ * outlier detection, the gender-vs-score chart, and any future analytics
+ * that needs to fit a salary-vs-score line. Returns the line plus enough
+ * descriptive stats (means, ranges, r²) to render or interpret it.
+ */
+export function computeSalaryRegression(
+  samples: Array<{ score: number; adjustedBaseSalary: number }>,
+): SalaryRegressionSnapshot {
+  if (samples.length === 0) {
+    return {
+      slope: null,
+      intercept: null,
+      sampleCount: 0,
+      scoreMean: null,
+      adjustedBaseSalaryMean: null,
+      rSquared: null,
+      scoreRangeFrom: null,
+      scoreRangeTo: null,
+    }
+  }
+
+  let sumScore = 0
+  let sumSalary = 0
+  let scoreMin = samples[0].score
+  let scoreMax = samples[0].score
+  for (const sample of samples) {
+    sumScore += sample.score
+    sumSalary += sample.adjustedBaseSalary
+    if (sample.score < scoreMin) scoreMin = sample.score
+    if (sample.score > scoreMax) scoreMax = sample.score
+  }
+
+  const scoreMean = sumScore / samples.length
+  const adjustedBaseSalaryMean = sumSalary / samples.length
+
+  let denominator = 0
+  let numerator = 0
+  let totalSquares = 0
+  for (const sample of samples) {
+    const dx = sample.score - scoreMean
+    const dy = sample.adjustedBaseSalary - adjustedBaseSalaryMean
+    denominator += dx * dx
+    numerator += dx * dy
+    totalSquares += dy * dy
+  }
+
+  if (denominator === 0) {
+    return {
+      slope: 0,
+      intercept: adjustedBaseSalaryMean,
+      sampleCount: samples.length,
+      scoreMean,
+      adjustedBaseSalaryMean,
+      rSquared: null,
+      scoreRangeFrom: scoreMin,
+      scoreRangeTo: scoreMax,
+    }
+  }
+
+  const slope = numerator / denominator
+  const intercept = adjustedBaseSalaryMean - slope * scoreMean
+
+  let residualSquares = 0
+  for (const sample of samples) {
+    const predicted = slope * sample.score + intercept
+    const residual = sample.adjustedBaseSalary - predicted
+    residualSquares += residual * residual
+  }
+
+  return {
+    slope,
+    intercept,
+    sampleCount: samples.length,
+    scoreMean,
+    adjustedBaseSalaryMean,
+    rSquared: totalSquares === 0 ? null : 1 - residualSquares / totalSquares,
+    scoreRangeFrom: scoreMin,
+    scoreRangeTo: scoreMax,
+  }
+}
+
+export function roundSalaryOutlierAnalysisSnapshot(
+  snapshot: SalaryOutlierAnalysisSnapshot,
+  salaryPrecision = 2,
+  percentPrecision = 4,
+): SalaryOutlierAnalysisSnapshot {
+  const roundRegression = (
+    regression: SalaryRegressionSnapshot,
+  ): SalaryRegressionSnapshot => ({
+    slope: roundNullable(regression.slope, salaryPrecision),
+    intercept: roundNullable(regression.intercept, salaryPrecision),
+    sampleCount: regression.sampleCount,
+    scoreMean: roundNullable(regression.scoreMean, salaryPrecision),
+    adjustedBaseSalaryMean: roundNullable(
+      regression.adjustedBaseSalaryMean,
+      salaryPrecision,
+    ),
+    rSquared: roundNullable(regression.rSquared, percentPrecision),
+    scoreRangeFrom: roundNullable(regression.scoreRangeFrom, salaryPrecision),
+    scoreRangeTo: roundNullable(regression.scoreRangeTo, salaryPrecision),
+  })
+
+  return {
+    ...snapshot,
+    thresholdPercent: roundNullable(
+      snapshot.thresholdPercent,
+      percentPrecision,
+    ) as number,
+    allowedDifferencePercent: roundNullable(
+      snapshot.allowedDifferencePercent,
+      percentPrecision,
+    ) as number,
+    regressions: {
+      overall: roundRegression(snapshot.regressions.overall),
+      male: roundRegression(snapshot.regressions.male),
+      female: roundRegression(snapshot.regressions.female),
+      neutral: roundRegression(snapshot.regressions.neutral),
+    },
+    employees: snapshot.employees.map((employee) => ({
+      ...employee,
+      score: roundNullable(employee.score, salaryPrecision) as number,
+      adjustedBaseSalary: roundNullable(
+        employee.adjustedBaseSalary,
+        salaryPrecision,
+      ) as number,
+      predictedBaseSalary: roundNullable(
+        employee.predictedBaseSalary,
+        salaryPrecision,
+      ),
+      differencePercent: roundNullable(
+        employee.differencePercent,
+        percentPrecision,
+      ),
+      allowedDifferencePercent: roundNullable(
+        employee.allowedDifferencePercent,
+        percentPrecision,
+      ) as number,
+    })),
+  }
 }
 
 export function roundNullable(


### PR DESCRIPTION
## Summary

Switch the salary-outlier rule from "deviation from score-bucket median" to
"deviation from the regression-predicted salary at the employee's exact
score." Snapshot the full analysis on `report_result` so the verdict and
the line that drove it are persistent and chart-renderable.

## Why

Even a 100-point score bucket (e.g. 200–300) is too coarse — two
employees at scores 205 and 295 share the same reference median even
though the company's pay-for-score curve says they should not.
Predicting salary at the employee's *exact* score with a least-squares
regression line removes that bucketing artifact. The half-threshold
band (`salary_difference_threshold_percent / 2`) now wraps the line,
not the bucket median.