### PR TITLE
feat(doe): Report sidebar — employee assignment, status stepper & timeline

### DIFF
--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -2704,7 +2704,13 @@
       },
       "ReportEventTypeEnum": {
         "type": "string",
-        "enum": ["SUBMITTED", "ASSIGNED", "STATUS_CHANGED", "SUPERSEDED"]
+        "enum": [
+          "SUBMITTED",
+          "ASSIGNED",
+          "UNASSIGNED",
+          "STATUS_CHANGED",
+          "SUPERSEDED"
+        ]
       },
       "ReportEventDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
@@ -2,25 +2,50 @@
 
 import { Select } from '@dmr.is/ui/components/island-is/Select'
 
-// TODO: replace with real admins endpoint once available from API
-const mockUsers = [
-  { id: 'emp-1', name: 'Dís Arnardóttir' },
-  { id: 'emp-2', name: 'Bjarni Sigurðsson' },
-  { id: 'emp-3', name: 'Elín Guðmundsdóttir' },
-  { id: 'emp-4', name: 'Katrín Ólafsdóttir' },
-]
+import { useTRPC } from '../../../lib/trpc/client/trpc'
 
-const options = mockUsers.map((user) => ({ label: user.name, value: user.id }))
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
-export const EmployeeSelect = () => {
+type Props = {
+  reportId: string
+  assignedUserId?: string | null
+}
+
+export const EmployeeSelect = ({ reportId, assignedUserId }: Props) => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+
+  const { data: users, isLoading: isLoadingUsers } = useQuery(
+    trpc.user.listActive.queryOptions(),
+  )
+
+  const assign = useMutation({
+    ...trpc.reportWorkflow.assign.mutationOptions(),
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: trpc.reports.getById.queryKey({ id: reportId }),
+      }),
+  })
+
+  const options = (users ?? []).map((u) => ({
+    label: `${u.firstName} ${u.lastName}`,
+    value: u.id,
+  }))
+
+  const value = options.find((o) => o.value === assignedUserId) ?? null
+
   return (
     <Select
       size="sm"
       label="Starfsmaður"
       options={options}
+      value={value}
+      isClearable
+      isLoading={isLoadingUsers || assign.isPending}
       onChange={(opt) => {
-        // eslint-disable-next-line no-console
-        console.log('Selected employee ID:', opt?.value)
+        if (!opt) assign.mutate({ reportId, userId: null })
+        else
+          assign.mutate({ reportId, userId: (opt as { value: string }).value })
       }}
     />
   )

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Select } from '@dmr.is/ui/components/island-is/Select'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 
 import { useTRPC } from '../../../lib/trpc/client/trpc'
 
@@ -21,10 +22,16 @@ export const EmployeeSelect = ({ reportId, assignedUserId }: Props) => {
 
   const assign = useMutation({
     ...trpc.reportWorkflow.assign.mutationOptions(),
-    onSuccess: () =>
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: trpc.reports.getById.queryKey({ id: reportId }),
-      }),
+      })
+      toast.success('Úthlutun tókst.')
+    },
+
+    onError: () => {
+      toast.error('Villa við að úthluta starfsmanni.')
+    },
   })
 
   const options = (users ?? []).map((u) => ({
@@ -44,8 +51,7 @@ export const EmployeeSelect = ({ reportId, assignedUserId }: Props) => {
       isLoading={isLoadingUsers || assign.isPending}
       onChange={(opt) => {
         if (!opt) assign.mutate({ reportId, userId: null })
-        else
-          assign.mutate({ reportId, userId: (opt as { value: string }).value })
+        else assign.mutate({ reportId, userId: opt.value })
       }}
     />
   )

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.css.ts
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.css.ts
@@ -1,0 +1,35 @@
+import { spacing, theme } from '@dmr.is/island-ui-theme'
+
+import { style } from '@vanilla-extract/css'
+
+// Full-screen layover modal
+export const layoverModal = style({
+  overflow: 'hidden',
+  backgroundColor: 'white',
+  width: 650,
+  height: 'fit-content',
+  overflowY: 'auto',
+  margin: 'auto',
+  borderRadius: theme.border.radius.large,
+})
+
+// Modal content area
+export const modalContent = style({
+  maxWidth: '550px',
+  margin: '0 auto',
+  marginTop: spacing[1],
+  padding: `${spacing[3]}px ${spacing[4]}px`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing[3],
+  rowGap: spacing[2],
+})
+
+// Modal header
+export const modalHeader = style({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: `${spacing[3]}px ${spacing[4]}px`,
+})

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.css.ts
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.css.ts
@@ -10,12 +10,12 @@ export const layoverModal = style({
   height: 'fit-content',
   overflowY: 'auto',
   margin: 'auto',
+  padding: theme.spacing[4],
   borderRadius: theme.border.radius.large,
 })
 
 // Modal content area
 export const modalContent = style({
-  maxWidth: '550px',
   margin: '0 auto',
   marginTop: spacing[1],
   padding: `${spacing[3]}px ${spacing[4]}px`,

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 
 import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
@@ -1,0 +1,85 @@
+import { i } from 'node_modules/next-usequerystate/dist/serializer-DjSGvhZt'
+import React from 'react'
+
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Input } from '@dmr.is/ui/components/island-is/Input'
+import { ModalBase } from '@dmr.is/ui/components/island-is/ModalBase'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+
+import * as styles from './ReportDenialModal.css'
+
+interface ReportDenialModalProps {
+  visible: boolean
+  onClose: () => void
+  onSubmit: (denialReason: string) => void
+}
+export const ReportDenialModal = ({
+  visible,
+  onClose,
+  onSubmit,
+}: ReportDenialModalProps) => {
+  const [denialReason, setDenialReason] = React.useState('')
+  const handleChange = (value: string | null) => {
+    if (value && value.length > 0 && denialReason !== value) {
+      setDenialReason(value)
+    }
+  }
+
+  return (
+    <ModalBase
+      baseId="report-denial-modal"
+      initialVisibility={false}
+      onVisibilityChange={(v) => {
+        if (!v) onClose()
+      }}
+      className={styles.layoverModal}
+      hideOnClickOutside={true}
+      hideOnEsc
+      isVisible={visible}
+    >
+      <div className={styles.modalHeader}>
+        <Text variant="h3">Höfnun skýrslu</Text>
+        <Button
+          variant="primary"
+          colorScheme="light"
+          circle
+          icon="close"
+          onClick={onClose}
+        />
+      </div>
+      <form>
+        <div className={styles.modalContent}>
+          <AlertMessage
+            type="warning"
+            title="Athugið"
+            message="Þessi aðgerð er óaftukræf og mun vísa skýrslunni frá."
+          />
+          <Text>
+            Vinsamlegast gerðu grein fyrir ástæðu höfnunar. Athugið að afrit af
+            þessum texta er sent til innsendanda.
+          </Text>
+          <Input
+            name="denial-reason-input"
+            label="Ástæða höfnunar"
+            size="sm"
+            textarea
+            rows={4}
+            backgroundColor="blue"
+            value={denialReason}
+            onChange={(val) => handleChange(val.target.value)}
+          />
+          <Button
+            fluid
+            size="default"
+            type="submit"
+            onClick={() => onSubmit(denialReason)}
+            disabled={denialReason.length === 0}
+          >
+            Vista
+          </Button>
+        </div>
+      </form>
+    </ModalBase>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportDenialModal.tsx
@@ -1,4 +1,3 @@
-import { i } from 'node_modules/next-usequerystate/dist/serializer-DjSGvhZt'
 import React from 'react'
 
 import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
@@ -11,11 +10,13 @@ import * as styles from './ReportDenialModal.css'
 
 interface ReportDenialModalProps {
   visible: boolean
+  isLoading?: boolean
   onClose: () => void
   onSubmit: (denialReason: string) => void
 }
 export const ReportDenialModal = ({
   visible,
+  isLoading = false,
   onClose,
   onSubmit,
 }: ReportDenialModalProps) => {
@@ -48,7 +49,7 @@ export const ReportDenialModal = ({
           onClick={onClose}
         />
       </div>
-      <form>
+      <form onSubmit={(e) => e.preventDefault()}>
         <div className={styles.modalContent}>
           <AlertMessage
             type="warning"
@@ -67,6 +68,7 @@ export const ReportDenialModal = ({
             rows={4}
             backgroundColor="blue"
             value={denialReason}
+            disabled={isLoading}
             onChange={(val) => handleChange(val.target.value)}
           />
           <Button
@@ -74,7 +76,8 @@ export const ReportDenialModal = ({
             size="default"
             type="submit"
             onClick={() => onSubmit(denialReason)}
-            disabled={denialReason.length === 0}
+            disabled={denialReason.length === 0 || isLoading}
+            loading={isLoading}
           >
             Vista
           </Button>

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.css.ts
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.css.ts
@@ -1,0 +1,76 @@
+import { theme } from '@dmr.is/island-ui-theme'
+
+import { style, styleVariants } from '@vanilla-extract/css'
+
+export const stepRow = style({
+  display: 'flex',
+  flexDirection: 'row',
+})
+
+export const indicatorColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  marginRight: theme.spacing[2],
+})
+
+export const circle = style({
+  width: 32,
+  height: 32,
+  flexShrink: 0,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: theme.color.white,
+  fontSize: 16,
+  fontWeight: theme.typography.semiBold,
+})
+
+export const circleVariants = styleVariants({
+  active: { backgroundColor: theme.color.purple400, cursor: 'default' },
+  complete: { backgroundColor: theme.color.purple400, cursor: 'pointer' },
+  next: { backgroundColor: theme.color.purple200, cursor: 'default' },
+})
+
+export const connectingLine = style({
+  width: 2,
+  flex: 1,
+  minHeight: 16,
+})
+
+export const connectingLineVariants = styleVariants({
+  complete: { backgroundColor: theme.color.purple400 },
+  incomplete: { backgroundColor: theme.color.purple200 },
+})
+
+export const contentColumn = style({
+  flex: 1,
+  minWidth: 0,
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+export const titleRow = style({
+  display: 'flex',
+  alignItems: 'center',
+})
+
+export const titleRowClickable = style({
+  cursor: 'pointer',
+})
+
+export const collapseWrapper = style({
+  display: 'grid',
+  transition: 'grid-template-rows 300ms ease',
+  overflow: 'hidden',
+})
+
+export const collapseWrapperVariants = styleVariants({
+  open: { gridTemplateRows: '1fr' },
+  closed: { gridTemplateRows: '0fr' },
+})
+
+export const collapseInner = style({
+  overflow: 'hidden',
+})

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
@@ -3,11 +3,24 @@
 import { FormStepper } from '@dmr.is/ui/components/island-is/FormStepper'
 import { Section } from '@dmr.is/ui/components/island-is/Section'
 
-import { ReportStatusEnum } from '../../../gen/fetch'
-import { ReportStatusTranslatedEnum } from '../../../lib/constants'
+import {
+  ReportEventTypeEnum,
+  ReportStatusEnum,
+  ReportTimelineItemDto,
+  ReportTimelineItemKindEnum,
+  UserDto,
+} from '../../../gen/fetch'
+import {
+  formatDateIS,
+  ReportStatusTranslatedEnum,
+} from '../../../lib/constants'
+import { useTRPC } from '../../../lib/trpc/client/trpc'
+
+import { useQuery } from '@tanstack/react-query'
 
 type Props = {
   status: ReportStatusEnum
+  timeline?: ReportTimelineItemDto[]
 }
 
 type Step = {
@@ -15,7 +28,58 @@ type Step = {
   matchStatuses: ReportStatusEnum[]
 }
 
-export const ReportFormStepper = ({ status }: Props) => {
+function userName(user: UserDto): string {
+  return `${user.firstName} ${user.lastName}`
+}
+
+function timelineLabel(
+  item: ReportTimelineItemDto,
+  usersById: Map<string, UserDto>,
+): string {
+  if (item.kind === ReportTimelineItemKindEnum.COMMENT && item.comment) {
+    return 'Athugasemd'
+  }
+  if (item.event) {
+    if (
+      item.event.eventType === ReportEventTypeEnum.ASSIGNED &&
+      item.event.assignedUserId
+    ) {
+      const user = usersById.get(item.event.assignedUserId)
+      return user ? `Úthlutað: ${userName(user)}` : 'Úthlutað'
+    }
+    if (item.event.eventType === ReportEventTypeEnum.STATUS_CHANGED) {
+      const statusLabel = item.event.toStatus
+        ? ReportStatusTranslatedEnum[item.event.toStatus]
+        : null
+      const actor = item.event.actorUserId
+        ? usersById.get(item.event.actorUserId)
+        : null
+      const parts = ['Fært í stöðuna']
+      if (statusLabel) parts.push(`"${statusLabel}"`)
+      if (actor) parts.push(`af ${userName(actor)}`)
+      return parts.join(' ')
+    }
+    const EVENT_TYPE_LABEL: Record<ReportEventTypeEnum, string> = {
+      [ReportEventTypeEnum.SUBMITTED]: 'Innsent',
+      [ReportEventTypeEnum.ASSIGNED]: 'Úthlutað',
+      [ReportEventTypeEnum.STATUS_CHANGED]: 'Stöðubreyting',
+      [ReportEventTypeEnum.SUPERSEDED]: 'Úrelt',
+    }
+    return EVENT_TYPE_LABEL[item.event.eventType] ?? item.event.eventType
+  }
+  return ''
+}
+
+function timelineItemStatus(
+  item: ReportTimelineItemDto,
+): ReportStatusEnum | null {
+  return item.event?.reportStatus ?? item.comment?.reportStatus ?? null
+}
+
+export const ReportFormStepper = ({ status, timeline }: Props) => {
+  const trpc = useTRPC()
+  const { data: users } = useQuery(trpc.user.listActive.queryOptions())
+  const usersById = new Map((users ?? []).map((u) => [u.id, u]))
   const decisionLabel =
     status === ReportStatusEnum.DENIED
       ? ReportStatusTranslatedEnum.DENIED
@@ -40,16 +104,34 @@ export const ReportFormStepper = ({ status }: Props) => {
     s.matchStatuses.includes(status),
   )
 
-  const sections = statusSteps.map((step, index) => (
-    <Section
-      key={step.label}
-      section={step.label}
-      sectionIndex={index}
-      isActive={step.matchStatuses.includes(status)}
-      isComplete={index < currentStepIndex}
-      subSections={[]}
-    />
-  ))
+  const sections = statusSteps.map((step, index) => {
+    const stepItems = (timeline ?? []).filter((item) => {
+      const s = timelineItemStatus(item)
+      return s !== null && step.matchStatuses.includes(s)
+    })
+
+    const subSections = stepItems.map((item) => (
+      <span style={{ fontSize: '12px' }}>
+        {timelineLabel(item, usersById)}
+        {' · '}
+        {formatDateIS(item.createdAt)}
+      </span>
+    ))
+
+    const isActive = step.matchStatuses.includes(status)
+    const isComplete = index < currentStepIndex
+
+    return (
+      <Section
+        key={step.label}
+        section={step.label}
+        sectionIndex={index}
+        isActive={isActive || (isComplete && subSections.length > 0)}
+        isComplete={isComplete}
+        subSections={subSections.length > 0 ? subSections : undefined}
+      />
+    )
+  })
 
   return <FormStepper sections={sections} />
 }

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
@@ -1,26 +1,21 @@
 'use client'
 
-import { FormStepper } from '@dmr.is/ui/components/island-is/FormStepper'
-import { Section } from '@dmr.is/ui/components/island-is/Section'
+import { useState } from 'react'
 
-import {
-  ReportEventTypeEnum,
-  ReportStatusEnum,
-  ReportTimelineItemDto,
-  ReportTimelineItemKindEnum,
-  UserDto,
-} from '../../../gen/fetch'
-import {
-  formatDateIS,
-  ReportStatusTranslatedEnum,
-} from '../../../lib/constants'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+
+import { ReportStatusEnum, ReportTimelineItemDto } from '../../../gen/fetch'
+import { ReportStatusTranslatedEnum } from '../../../lib/constants'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
+import { StepRow } from './StepRow'
+import { timelineItemStatus } from './timelineNode'
 
 import { useQuery } from '@tanstack/react-query'
 
 type Props = {
   status: ReportStatusEnum
   timeline?: ReportTimelineItemDto[]
+  companyName?: string | null
 }
 
 type Step = {
@@ -28,58 +23,20 @@ type Step = {
   matchStatuses: ReportStatusEnum[]
 }
 
-function userName(user: UserDto): string {
-  return `${user.firstName} ${user.lastName}`
-}
-
-function timelineLabel(
-  item: ReportTimelineItemDto,
-  usersById: Map<string, UserDto>,
-): string {
-  if (item.kind === ReportTimelineItemKindEnum.COMMENT && item.comment) {
-    return 'Athugasemd'
-  }
-  if (item.event) {
-    if (
-      item.event.eventType === ReportEventTypeEnum.ASSIGNED &&
-      item.event.assignedUserId
-    ) {
-      const user = usersById.get(item.event.assignedUserId)
-      return user ? `Úthlutað: ${userName(user)}` : 'Úthlutað'
-    }
-    if (item.event.eventType === ReportEventTypeEnum.STATUS_CHANGED) {
-      const statusLabel = item.event.toStatus
-        ? ReportStatusTranslatedEnum[item.event.toStatus]
-        : null
-      const actor = item.event.actorUserId
-        ? usersById.get(item.event.actorUserId)
-        : null
-      const parts = ['Fært í stöðuna']
-      if (statusLabel) parts.push(`"${statusLabel}"`)
-      if (actor) parts.push(`af ${userName(actor)}`)
-      return parts.join(' ')
-    }
-    const EVENT_TYPE_LABEL: Record<ReportEventTypeEnum, string> = {
-      [ReportEventTypeEnum.SUBMITTED]: 'Innsent',
-      [ReportEventTypeEnum.ASSIGNED]: 'Úthlutað',
-      [ReportEventTypeEnum.STATUS_CHANGED]: 'Stöðubreyting',
-      [ReportEventTypeEnum.SUPERSEDED]: 'Úrelt',
-    }
-    return EVENT_TYPE_LABEL[item.event.eventType] ?? item.event.eventType
-  }
-  return ''
-}
-
-function timelineItemStatus(
-  item: ReportTimelineItemDto,
-): ReportStatusEnum | null {
-  return item.event?.reportStatus ?? item.comment?.reportStatus ?? null
-}
-
-export const ReportFormStepper = ({ status, timeline }: Props) => {
+export const ReportFormStepper = ({ status, timeline, companyName }: Props) => {
   const trpc = useTRPC()
   const { data: users } = useQuery(trpc.user.listActive.queryOptions())
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set())
+
   const usersById = new Map((users ?? []).map((u) => [u.id, u]))
+
+  const toggleCollapsed = (index: number) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev)
+      next.has(index) ? next.delete(index) : next.add(index)
+      return next
+    })
+
   const decisionLabel =
     status === ReportStatusEnum.DENIED
       ? ReportStatusTranslatedEnum.DENIED
@@ -104,34 +61,30 @@ export const ReportFormStepper = ({ status, timeline }: Props) => {
     s.matchStatuses.includes(status),
   )
 
-  const sections = statusSteps.map((step, index) => {
-    const stepItems = (timeline ?? []).filter((item) => {
-      const s = timelineItemStatus(item)
-      return s !== null && step.matchStatuses.includes(s)
-    })
+  return (
+    <Box>
+      {statusSteps.map((step, index) => {
+        const stepItems = (timeline ?? []).filter((item) => {
+          const s = timelineItemStatus(item)
+          return s !== null && step.matchStatuses.includes(s)
+        })
 
-    const subSections = stepItems.map((item) => (
-      <span style={{ fontSize: '12px' }}>
-        {timelineLabel(item, usersById)}
-        {' · '}
-        {formatDateIS(item.createdAt)}
-      </span>
-    ))
-
-    const isActive = step.matchStatuses.includes(status)
-    const isComplete = index < currentStepIndex
-
-    return (
-      <Section
-        key={step.label}
-        section={step.label}
-        sectionIndex={index}
-        isActive={isActive || (isComplete && subSections.length > 0)}
-        isComplete={isComplete}
-        subSections={subSections.length > 0 ? subSections : undefined}
-      />
-    )
-  })
-
-  return <FormStepper sections={sections} />
+        return (
+          <StepRow
+            key={step.label}
+            label={step.label}
+            index={index}
+            isActive={step.matchStatuses.includes(status)}
+            isComplete={index < currentStepIndex}
+            isLast={index === statusSteps.length - 1}
+            isCollapsed={collapsed.has(index)}
+            stepItems={stepItems}
+            usersById={usersById}
+            companyName={companyName}
+            onToggle={() => toggleCollapsed(index)}
+          />
+        )
+      })}
+    </Box>
+  )
 }

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
@@ -62,7 +62,7 @@ export const ReportFormStepper = ({ status, timeline, companyName }: Props) => {
   )
 
   return (
-    <Box>
+    <Box marginTop={1}>
       {statusSteps.map((step, index) => {
         const stepItems = (timeline ?? []).filter((item) => {
           const s = timelineItemStatus(item)

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportFormStepper.tsx
@@ -62,7 +62,7 @@ export const ReportFormStepper = ({ status, timeline, companyName }: Props) => {
   )
 
   return (
-    <Box marginTop={1}>
+    <Box>
       {statusSteps.map((step, index) => {
         const stepItems = (timeline ?? []).filter((item) => {
           const s = timelineItemStatus(item)

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
@@ -1,10 +1,14 @@
 'use client'
 
+import React from 'react'
+
 import { Select } from '@dmr.is/ui/components/island-is/Select'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 
 import { ReportStatusEnum } from '../../../gen/fetch'
 import { ReportStatusTranslatedEnum } from '../../../lib/constants'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
+import { ReportDenialModal } from './ReportDenialModal'
 
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
@@ -37,23 +41,42 @@ const TRANSITIONS: Partial<Record<ReportStatusEnum, Option[]>> = {
 export const ReportStatusSelect = ({ reportId, status }: Props) => {
   const trpc = useTRPC()
   const queryClient = useQueryClient()
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+  const onSuccess = () => () => toast.success('Uppfærsla á stöðu tókst.')
+
+  const onError = () => () =>
+    toast.error('Villa við að uppfæra stöðu. Vinsamlegast reyndu aftur síðar.')
 
   const invalidate = () =>
-    queryClient.invalidateQueries({ queryKey: trpc.reports.getById.queryKey() })
+    queryClient.invalidateQueries({
+      queryKey: trpc.reports.getById.queryKey({ id: reportId }),
+    })
 
   const assign = useMutation({
     ...trpc.reportWorkflow.assign.mutationOptions(),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+    },
+    onError: onError(),
   })
 
   const approve = useMutation({
     ...trpc.reportWorkflow.approve.mutationOptions(),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+    },
+    onError: onError(),
   })
 
   const deny = useMutation({
     ...trpc.reportWorkflow.deny.mutationOptions(),
-    onSuccess: invalidate,
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+    },
+    onError: onError(),
   })
 
   const isLoading = assign.isPending || approve.isPending || deny.isPending
@@ -71,21 +94,25 @@ export const ReportStatusSelect = ({ reportId, status }: Props) => {
     } else if (opt.value === ReportStatusEnum.APPROVED) {
       approve.mutate({ reportId })
     } else if (opt.value === ReportStatusEnum.DENIED) {
-      // TODO: replace prompt with a proper denial reason dialog
-      const denialReason = window.prompt('Ástæða höfnunar')
-      if (!denialReason) return
-      deny.mutate({ reportId, denialReason })
+      setIsModalOpen(true)
     }
   }
 
   return (
-    <Select
-      size="sm"
-      label="Staða"
-      options={options}
-      value={currentOption}
-      isLoading={isLoading}
-      onChange={(opt) => handleChange(opt as Option | null)}
-    />
+    <>
+      <Select
+        size="sm"
+        label="Staða"
+        options={options}
+        value={currentOption}
+        isLoading={isLoading}
+        onChange={(opt) => handleChange(opt as Option | null)}
+      />
+      <ReportDenialModal
+        visible={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={(denialReason) => deny.mutate({ reportId, denialReason })}
+      />
+    </>
   )
 }

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
@@ -75,6 +75,7 @@ export const ReportStatusSelect = ({ reportId, status }: Props) => {
     onSuccess: () => {
       invalidate()
       onSuccess()
+      setIsModalOpen(false)
     },
     onError: onError(),
   })
@@ -110,6 +111,7 @@ export const ReportStatusSelect = ({ reportId, status }: Props) => {
       />
       <ReportDenialModal
         visible={isModalOpen}
+        isLoading={deny.isPending}
         onClose={() => setIsModalOpen(false)}
         onSubmit={(denialReason) => deny.mutate({ reportId, denialReason })}
       />

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/StepRow.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/StepRow.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import cn from 'classnames'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Icon } from '@dmr.is/ui/components/island-is/Icon'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+
+import { ReportTimelineItemDto, UserDto } from '../../../gen/fetch'
+import * as styles from './ReportFormStepper.css'
+import { TimelineItem } from './TimelineItem'
+
+type Props = {
+  label: string
+  index: number
+  isActive: boolean
+  isComplete: boolean
+  isLast: boolean
+  isCollapsed: boolean
+  stepItems: ReportTimelineItemDto[]
+  usersById: Map<string, UserDto>
+  companyName?: string | null
+  onToggle: () => void
+}
+
+export function StepRow({
+  label,
+  index,
+  isActive,
+  isComplete,
+  isLast,
+  isCollapsed,
+  stepItems,
+  usersById,
+  companyName,
+  onToggle,
+}: Props) {
+  const hasItems = stepItems.length > 0
+  const circleVariant = isActive ? 'active' : isComplete ? 'complete' : 'next'
+
+  return (
+    <div className={styles.stepRow}>
+      <div className={styles.indicatorColumn}>
+        <div
+          className={cn(styles.circle, styles.circleVariants[circleVariant])}
+          onClick={hasItems ? onToggle : undefined}
+        >
+          {isComplete ? (
+            <Icon icon="checkmark" color="white" size="small" />
+          ) : (
+            index + 1
+          )}
+        </div>
+        {!isLast && (
+          <div
+            className={cn(
+              styles.connectingLine,
+              styles.connectingLineVariants[isComplete ? 'complete' : 'incomplete'],
+            )}
+          />
+        )}
+      </div>
+
+      <Box className={styles.contentColumn} paddingBottom={isLast ? 0 : 2}>
+        <div
+          className={cn(styles.titleRow, hasItems && styles.titleRowClickable)}
+          onClick={hasItems ? onToggle : undefined}
+        >
+          <Text fontWeight={isActive ? 'semiBold' : 'light'}>{label}</Text>
+        </div>
+
+        {hasItems && (
+          <div
+            className={cn(
+              styles.collapseWrapper,
+              styles.collapseWrapperVariants[isCollapsed ? 'closed' : 'open'],
+            )}
+          >
+            <div className={styles.collapseInner}>
+              <Box paddingBottom={1} paddingTop={1}>
+                {stepItems.map((item) => (
+                  <TimelineItem
+                    key={item.createdAt}
+                    item={item}
+                    usersById={usersById}
+                    companyName={companyName}
+                  />
+                ))}
+              </Box>
+            </div>
+          </div>
+        )}
+      </Box>
+    </div>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/StepRow.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/StepRow.tsx
@@ -38,12 +38,26 @@ export function StepRow({
   const hasItems = stepItems.length > 0
   const circleVariant = isActive ? 'active' : isComplete ? 'complete' : 'next'
 
+  const toggleProps = hasItems
+    ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        onClick: onToggle,
+        onKeyDown: (e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onToggle()
+          }
+        },
+      }
+    : {}
+
   return (
     <div className={styles.stepRow}>
       <div className={styles.indicatorColumn}>
         <div
           className={cn(styles.circle, styles.circleVariants[circleVariant])}
-          onClick={hasItems ? onToggle : undefined}
+          {...toggleProps}
         >
           {isComplete ? (
             <Icon icon="checkmark" color="white" size="small" />
@@ -55,7 +69,9 @@ export function StepRow({
           <div
             className={cn(
               styles.connectingLine,
-              styles.connectingLineVariants[isComplete ? 'complete' : 'incomplete'],
+              styles.connectingLineVariants[
+                isComplete ? 'complete' : 'incomplete'
+              ],
             )}
           />
         )}
@@ -64,7 +80,7 @@ export function StepRow({
       <Box className={styles.contentColumn} paddingBottom={isLast ? 0 : 2}>
         <div
           className={cn(styles.titleRow, hasItems && styles.titleRowClickable)}
-          onClick={hasItems ? onToggle : undefined}
+          {...toggleProps}
         >
           <Text fontWeight={isActive ? 'semiBold' : 'light'}>{label}</Text>
         </div>
@@ -78,9 +94,9 @@ export function StepRow({
           >
             <div className={styles.collapseInner}>
               <Box paddingBottom={1} paddingTop={1}>
-                {stepItems.map((item) => (
+                {stepItems.map((item, index) => (
                   <TimelineItem
-                    key={item.createdAt}
+                    key={`${item.kind}-${item.createdAt}-${index}`}
                     item={item}
                     usersById={usersById}
                     companyName={companyName}

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/TimelineItem.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/TimelineItem.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import format from 'date-fns/format'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+
+import { ReportTimelineItemDto, UserDto } from '../../../gen/fetch'
+import { timelineNode } from './timelineNode'
+
+type Props = {
+  item: ReportTimelineItemDto
+  usersById: Map<string, UserDto>
+  companyName?: string | null
+}
+
+export function TimelineItem({ item, usersById, companyName }: Props) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      justifyContent="spaceBetween"
+      columnGap={2}
+      marginBottom={1}
+    >
+      <Text variant="medium">{timelineNode(item, usersById, companyName)}</Text>
+      <Text variant="small" color="dark400">
+        {format(new Date(item.createdAt), 'dd.MM.yy')}
+      </Text>
+    </Box>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/timelineNode.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/timelineNode.tsx
@@ -1,7 +1,6 @@
-'use client'
-
 import {
   ReportEventTypeEnum,
+  ReportStatusEnum,
   ReportTimelineItemDto,
   ReportTimelineItemKindEnum,
   UserDto,
@@ -18,7 +17,7 @@ export function userName(user: UserDto): string {
 
 export function timelineItemStatus(
   item: ReportTimelineItemDto,
-): import('../../../gen/fetch').ReportStatusEnum | null {
+): ReportStatusEnum | null {
   return item.event?.reportStatus ?? item.comment?.reportStatus ?? null
 }
 
@@ -29,10 +28,12 @@ export function timelineNode(
 ): React.ReactNode {
   if (item.kind === ReportTimelineItemKindEnum.COMMENT) {
     const user = usersById.get(item.comment?.authorUserId ?? '')
-    const fullName = user
-      ? `${user.firstName === 'Gervimaður' ? 'GM' : user.firstName} ${user.lastName}`
-      : 'Óþekktum notanda'
-    return <>Athugasemd frá: <Bold>{fullName}</Bold></>
+    const fullName = user ? userName(user) : 'Óþekktum notanda'
+    return (
+      <>
+        Athugasemd frá: <Bold>{fullName}</Bold>
+      </>
+    )
   }
 
   if (!item.event) return null
@@ -40,12 +41,24 @@ export function timelineNode(
   const { eventType, assignedUserId, actorUserId, toStatus } = item.event
 
   if (eventType === ReportEventTypeEnum.SUBMITTED) {
-    return companyName ? <>Innsent af: <Bold>{companyName}</Bold></> : 'Innsent'
+    return companyName ? (
+      <>
+        Innsent af: <Bold>{companyName}</Bold>
+      </>
+    ) : (
+      'Innsent'
+    )
   }
 
   if (eventType === ReportEventTypeEnum.ASSIGNED && assignedUserId) {
     const user = usersById.get(assignedUserId)
-    return user ? <><Bold>{userName(user)}</Bold> merkir sér málið</> : 'Úthlutað'
+    return user ? (
+      <>
+        <Bold>{userName(user)}</Bold> merkir sér málið
+      </>
+    ) : (
+      'Úthlutað'
+    )
   }
 
   if (eventType === ReportEventTypeEnum.STATUS_CHANGED) {
@@ -53,7 +66,11 @@ export function timelineNode(
     const actor = actorUserId ? usersById.get(actorUserId) : null
     return (
       <>
-        {actor && <><Bold>{userName(actor)}</Bold>{' '}</>}
+        {actor && (
+          <>
+            <Bold>{userName(actor)}</Bold>{' '}
+          </>
+        )}
         færir mál í stöðuna: {statusLabel ? <Bold>{statusLabel}</Bold> : null}
       </>
     )
@@ -63,7 +80,11 @@ export function timelineNode(
     const actor = actorUserId ? usersById.get(actorUserId) : null
     return (
       <>
-        {actor && <><Bold>{userName(actor)}</Bold>{' '}</>}
+        {actor && (
+          <>
+            <Bold>{userName(actor)}</Bold>{' '}
+          </>
+        )}
         tekur sig af málinu
       </>
     )

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/timelineNode.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/timelineNode.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import {
+  ReportEventTypeEnum,
+  ReportTimelineItemDto,
+  ReportTimelineItemKindEnum,
+  UserDto,
+} from '../../../gen/fetch'
+import { ReportStatusTranslatedEnum } from '../../../lib/constants'
+
+export function Bold({ children }: { children: React.ReactNode }) {
+  return <strong style={{ fontWeight: 600 }}>{children}</strong>
+}
+
+export function userName(user: UserDto): string {
+  return `${user.firstName === 'Gervimaður' ? 'GM' : user.firstName} ${user.lastName}`
+}
+
+export function timelineItemStatus(
+  item: ReportTimelineItemDto,
+): import('../../../gen/fetch').ReportStatusEnum | null {
+  return item.event?.reportStatus ?? item.comment?.reportStatus ?? null
+}
+
+export function timelineNode(
+  item: ReportTimelineItemDto,
+  usersById: Map<string, UserDto>,
+  companyName?: string | null,
+): React.ReactNode {
+  if (item.kind === ReportTimelineItemKindEnum.COMMENT) {
+    const user = usersById.get(item.comment?.authorUserId ?? '')
+    const fullName = user
+      ? `${user.firstName === 'Gervimaður' ? 'GM' : user.firstName} ${user.lastName}`
+      : 'Óþekktum notanda'
+    return <>Athugasemd frá: <Bold>{fullName}</Bold></>
+  }
+
+  if (!item.event) return null
+
+  const { eventType, assignedUserId, actorUserId, toStatus } = item.event
+
+  if (eventType === ReportEventTypeEnum.SUBMITTED) {
+    return companyName ? <>Innsent af: <Bold>{companyName}</Bold></> : 'Innsent'
+  }
+
+  if (eventType === ReportEventTypeEnum.ASSIGNED && assignedUserId) {
+    const user = usersById.get(assignedUserId)
+    return user ? <><Bold>{userName(user)}</Bold> merkir sér málið</> : 'Úthlutað'
+  }
+
+  if (eventType === ReportEventTypeEnum.STATUS_CHANGED) {
+    const statusLabel = toStatus ? ReportStatusTranslatedEnum[toStatus] : null
+    const actor = actorUserId ? usersById.get(actorUserId) : null
+    return (
+      <>
+        {actor && <><Bold>{userName(actor)}</Bold>{' '}</>}
+        færir mál í stöðuna: {statusLabel ? <Bold>{statusLabel}</Bold> : null}
+      </>
+    )
+  }
+
+  if (eventType === ReportEventTypeEnum.UNASSIGNED) {
+    const actor = actorUserId ? usersById.get(actorUserId) : null
+    return (
+      <>
+        {actor && <><Bold>{userName(actor)}</Bold>{' '}</>}
+        tekur sig af málinu
+      </>
+    )
+  }
+
+  const FALLBACK: Partial<Record<ReportEventTypeEnum, string>> = {
+    [ReportEventTypeEnum.SUPERSEDED]: 'Úrelt',
+  }
+  return FALLBACK[eventType] ?? eventType
+}

--- a/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
@@ -30,6 +30,9 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
       queryClient.invalidateQueries({
         queryKey: trpc.reportComments.list.queryKey({ reportId }),
       })
+      queryClient.invalidateQueries({
+        queryKey: trpc.reports.getById.queryKey({ id: reportId }),
+      })
     },
   })
 

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -26,7 +26,11 @@ export function ReportSidebarContainer({
     <ReportSidebar>
       <EmployeeSelect reportId={data.id} assignedUserId={data.reviewer?.id} />
       <ReportStatusSelect reportId={data.id} status={data.status} />
-      <ReportFormStepper status={data.status} timeline={data.timeline} />
+      <ReportFormStepper
+        status={data.status}
+        timeline={data.timeline}
+        companyName={data.company.name}
+      />
     </ReportSidebar>
   )
 }

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -5,6 +5,9 @@ import { ReportFormStepper } from '../../components/report/report-sidebar/Report
 import { ReportSidebar } from '../../components/report/report-sidebar/ReportSidebar'
 import { ReportStatusSelect } from '../../components/report/report-sidebar/ReportStatusSelect'
 import { ReportDetailDto } from '../../gen/fetch'
+import { useTRPC } from '../../lib/trpc/client/trpc'
+
+import { useQuery } from '@tanstack/react-query'
 
 type ReportSidebarContainerProps = {
   report: ReportDetailDto
@@ -13,11 +16,17 @@ type ReportSidebarContainerProps = {
 export function ReportSidebarContainer({
   report,
 }: ReportSidebarContainerProps) {
+  const trpc = useTRPC()
+  const { data } = useQuery({
+    ...trpc.reports.getById.queryOptions({ id: report.id }),
+    initialData: report,
+  })
+
   return (
     <ReportSidebar>
-      <EmployeeSelect />
-      <ReportStatusSelect reportId={report.id} status={report.status} />
-      <ReportFormStepper status={report.status} />
+      <EmployeeSelect reportId={data.id} assignedUserId={data.reviewer?.id} />
+      <ReportStatusSelect reportId={data.id} status={data.status} />
+      <ReportFormStepper status={data.status} timeline={data.timeline} />
     </ReportSidebar>
   )
 }

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { Divider } from '@dmr.is/ui/components/island-is/Divider'
+
 import { EmployeeSelect } from '../../components/report/report-sidebar/EmployeeSelect'
 import { ReportFormStepper } from '../../components/report/report-sidebar/ReportFormStepper'
 import { ReportSidebar } from '../../components/report/report-sidebar/ReportSidebar'
@@ -26,6 +28,7 @@ export function ReportSidebarContainer({
     <ReportSidebar>
       <EmployeeSelect reportId={data.id} assignedUserId={data.reviewer?.id} />
       <ReportStatusSelect reportId={data.id} status={data.status} />
+      <Divider />
       <ReportFormStepper
         status={data.status}
         timeline={data.timeline}

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Divider } from '@dmr.is/ui/components/island-is/Divider'
 
 import { EmployeeSelect } from '../../components/report/report-sidebar/EmployeeSelect'
@@ -28,7 +29,9 @@ export function ReportSidebarContainer({
     <ReportSidebar>
       <EmployeeSelect reportId={data.id} assignedUserId={data.reviewer?.id} />
       <ReportStatusSelect reportId={data.id} status={data.status} />
-      <Divider />
+      <Box paddingY={2}>
+        <Divider />
+      </Box>
       <ReportFormStepper
         status={data.status}
         timeline={data.timeline}

--- a/apps/directorate-of-equality-web/src/lib/constants.ts
+++ b/apps/directorate-of-equality-web/src/lib/constants.ts
@@ -26,7 +26,6 @@ export enum ReportStatusTranslatedEnum {
   APPROVED = 'Afgreitt',
   DENIED = 'Hafnað',
   SUPERSEDED = 'Úrelt',
-  UNASSIGNED = 'Óúthlutað',
 }
 import { type ColumnDef } from '@tanstack/react-table'
 

--- a/apps/directorate-of-equality-web/src/lib/constants.ts
+++ b/apps/directorate-of-equality-web/src/lib/constants.ts
@@ -26,6 +26,7 @@ export enum ReportStatusTranslatedEnum {
   APPROVED = 'Afgreitt',
   DENIED = 'Hafnað',
   SUPERSEDED = 'Úrelt',
+  UNASSIGNED = 'Óúthlutað',
 }
 import { type ColumnDef } from '@tanstack/react-table'
 


### PR DESCRIPTION
## What 
Wires up the report sidebar with live data and interaction:

- Employee select — fetches active users via trpc.user.listActive, calls reportWorkflow.assign on change, clears with null userId; invalidates the report query on success
- Sidebar reactivity — ReportSidebarContainer subscribes to reports.getById with server data as initialData so assignment and status changes reflect immediately
- Timeline stepper — custom stepper (no island-is FormStepper) with connecting lines, checkmarks for completed steps, and collapsible subsections per step with a smooth grid-template-rows animation
- Timeline labels — rich formatted entries: Innsent af: **Company**, **User** merkir sér málið, **User** færir mál í stöðuna: **Status**, **User** tekur sig af málinu, Athugasemd frá: **User**
- Refactored into StepRow, TimelineItem, timelineNode + ReportFormStepper.css.ts (vanilla-extract)

<img width="491" height="998" alt="Screenshot 2026-05-11 at 16 21 15" src="https://github.com/user-attachments/assets/cbc974d2-91b0-4e95-89b7-6bdf4fb8794d" />
-
<img width="452" height="738" alt="Screenshot 2026-05-11 at 16 21 22" src="https://github.com/user-attachments/assets/b7759457-f61a-47c2-895c-1a744720d515" />
