### PR TITLE
feat(doe): Provider id as application handle, supersede by type

### DIFF
--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -64,7 +64,7 @@ State-by-state:
 - **`IN_REVIEW`** — a reviewer has picked up the report. (If you want reviewer-assignment tracking, stamp `reviewer_user_id` on pickup; currently it's stamped on the final decision.)
 - **`DENIED`** — reviewer rejected the submission. `reviewer_user_id` set on the report. Denial reason is stored on the `STATUS_CHANGED` event (`reason` column) rather than the report row — keeps the audit trail self-contained. The company must submit a new report (new row) — this denied row **stays forever** as audit.
 - **`APPROVED`** — reviewer accepted. `approved_at` set, `valid_until = approved_at + 3 years`. A `public_report` row is inserted as part of this transition.
-- **`SUPERSEDED`** — a newer report from the same company has been approved. Old `valid_until` gets stamped to `now()`. Only one `APPROVED` report per company is "current" at any time.
+- **`SUPERSEDED`** — a newer report **of the same `type`** from the same company has been approved. Old `valid_until` gets stamped to `now()`. Only one `APPROVED` report per `(company, type)` pair is "current" at any time — an approved `SALARY` does **not** supersede an approved `EQUALITY` and vice versa, since every company needs both kinds active simultaneously (equality universally, salary for ≥50-employee companies).
 
 ## Resubmission
 
@@ -72,8 +72,19 @@ A resubmission is always a **new row** in `report`. It is never an update of an 
 
 Two resubmission triggers:
 
-1. **Denial** — reviewer denied the current submission. Company edits, re-submits as a new `DRAFT` → `SUBMITTED` row.
+1. **Denial** — reviewer denied the current submission. The denied row stays as audit forever and is never mutated. A redo always comes through as a fresh upstream application — new `provider_id` → new `report` row → fresh review queue entry. A future PUT-edit endpoint is planned to allow targeted in-place edits to a denied row after admin/applicant communication, but that is distinct from resubmission; resubmission is always a new row.
 2. **Three-year expiry** — approved report is aging out. Companies are notified ~3 months before `valid_until`. A new report is drafted and submitted. On approval, the old report transitions to `SUPERSEDED`.
+
+## Provider correlation
+
+Every report row records who submitted it on the upstream side via the pair `(provider_type, provider_id)`:
+
+- **`provider_type`** (`ReportProviderEnum`) — the upstream system that originated the submission. `ISLAND_IS` for reports forwarded from the island.is application portal, `SYSTEM` for DoE-internal/manual creations, `OTHER` as an escape hatch for any future integration that isn't island.is.
+- **`provider_id`** — the upstream system's own ID for this specific submission. For an island.is-originated report this is the application's UUID on their side. Separate from `report.identifier`, which is the DoE-side internal handle and has no relation to the upstream ID.
+
+Each new island.is submission gets its own `provider_id` — the type identifies the channel, the id identifies the individual application on that channel. Once a row exists for a given `(provider_type, provider_id)` tuple, that mapping is permanent: the row is never duplicated, and a future resubmission from the same company comes through as a fresh upstream application with a new `provider_id`. SYSTEM-created rows leave both columns null.
+
+**Uniqueness.** A partial unique index on `(provider_type, provider_id) WHERE provider_id IS NOT NULL` enforces one-row-per-tuple at the DB level. The application layer in `report-create.service.ts` also short-circuits on replay: if a non-null `(provider_type, provider_id)` already exists *and the submitting company matches the existing row's parent*, the create returns the existing `reportId` instead of inserting. That makes upstream network retries transparent — same payload + same key = same response. Cross-company collisions on the same tuple (an unlikely but theoretically possible "a new provider channel emits an id that an existing channel already used" scenario) are rejected with a 409.
 
 ## Audit timeline (events + comments)
 
@@ -306,8 +317,8 @@ Submission-time snapshot of a company participating in a report. `company_id` po
 | `average_employee_male_count`    | `decimal(10, 2)`                                                                                                               |
 | `average_employee_female_count`  | `decimal(10, 2)`                                                                                                               |
 | `average_employee_neutral_count` | `decimal(10, 2)`                                                                                                               |
-| `provider_type`                  | `ReportProviderEnum`                                                                                                           |
-| `provider_id`                    | `text` (nullable)                                                                                                              |
+| `provider_type`                  | `ReportProviderEnum` (upstream channel — see "Provider correlation")                                                           |
+| `provider_id`                    | `text` (nullable; upstream submission ID — see "Provider correlation". Unique with `provider_type` when not null.)              |
 | `imported_from_excel`            | `boolean`                                                                                                                      |
 | `identifier`                     | `text`                                                                                                                         |
 | `outliers_postponed`             | `boolean` (default `false` — when true, the company has deferred every outlier explanation on this report)                     |

--- a/apps/directorate-of-equality-api/db/migrations/m-20260518-add-provider-id-unique-index.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260518-add-provider-id-unique-index.js
@@ -1,0 +1,34 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- Partial unique index on (provider_type, provider_id).
+    -- Enforces one-row-per-tuple for upstream-originated submissions so an
+    -- island.is application UUID (or any non-null upstream id) maps to at most
+    -- one DoE report. SYSTEM-created rows with null provider_id are excluded
+    -- by the WHERE clause and can coexist freely. See db/README.md →
+    -- "Provider correlation" for the full contract and the matching
+    -- application-layer idempotent-create behaviour in
+    -- report-create.service.ts.
+    CREATE UNIQUE INDEX report_provider_type_provider_id_unique_idx
+      ON report (provider_type, provider_id)
+      WHERE provider_id IS NOT NULL;
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    DROP INDEX IF EXISTS report_provider_type_provider_id_unique_idx;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -9,7 +9,6 @@ import {
   MaxFileSizeValidator,
   Param,
   ParseFilePipe,
-  ParseUUIDPipe,
   Post,
   StreamableFile,
   UploadedFile,
@@ -200,38 +199,52 @@ export class ApplicationController {
     return this.applicationService.submitEquality(input, company)
   }
 
-  @Get('reports/:reportId')
-  @ApiParam({ name: 'reportId', type: String })
+  @Get('reports/:providerId')
+  @ApiParam({
+    name: 'providerId',
+    type: String,
+    description:
+      "Upstream submission ID (e.g. the island.is application UUID). Identifies the report by the originator's own handle rather than the DoE-side `report.id`, which the applicant does not see. Resolved against reports whose parent company matches the authenticated company.",
+  })
   @DoeResponse({
     operationId: 'getApplicationReport',
     include404: true,
     description:
-      'Returns company-facing report detail with external comments only.',
+      'Returns company-facing report detail with external comments. Looked up by upstream `providerId`.',
     type: ApplicationReportDetailDto,
   })
   async getReport(
-    @Param('reportId', ParseUUIDPipe) reportId: string,
+    @Param('providerId') providerId: string,
     @CurrentCompany() company: CompanyDto,
   ): Promise<ApplicationReportDetailDto> {
-    return this.applicationService.getReport(reportId, company)
+    return this.applicationService.getReport(providerId, company)
   }
 
-  @Post('reports/:reportId/comments')
+  @Post('reports/:providerId/comments')
   @HttpCode(HttpStatus.CREATED)
-  @ApiParam({ name: 'reportId', type: String })
+  @ApiParam({
+    name: 'providerId',
+    type: String,
+    description:
+      'Upstream submission ID (e.g. the island.is application UUID).',
+  })
   @DoeResponse({
     operationId: 'submitApplicationReportComment',
     status: 201,
     include404: true,
     description:
-      'Submits an external comment on a report owned by the authenticated company.',
+      'Submits an external comment on a report owned by the authenticated company. Report is looked up by upstream `providerId`.',
     type: ApplicationReportCommentDto,
   })
   async submitComment(
-    @Param('reportId', ParseUUIDPipe) reportId: string,
+    @Param('providerId') providerId: string,
     @CurrentCompany() company: CompanyDto,
     @Body() input: SubmitApplicationReportCommentDto,
   ): Promise<ApplicationReportCommentDto> {
-    return this.applicationService.createReportComment(reportId, input, company)
+    return this.applicationService.createReportComment(
+      providerId,
+      input,
+      company,
+    )
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
@@ -26,11 +26,11 @@ export interface IApplicationService {
     company: CompanyDto,
   ): Promise<EqualityReportSummaryDto>
   getReport(
-    reportId: string,
+    providerId: string,
     company: CompanyDto,
   ): Promise<ApplicationReportDetailDto>
   createReportComment(
-    reportId: string,
+    providerId: string,
     input: SubmitApplicationReportCommentDto,
     company: CompanyDto,
   ): Promise<ApplicationReportCommentDto>

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -442,19 +442,25 @@ describe('ApplicationService', () => {
 
   describe('getReport', () => {
     const REPORT_ID = '00000000-0000-0000-0000-0000000000aa'
+    const PROVIDER_ID = 'island-is-application-aa'
     const EQUALITY_REPORT_ID = '00000000-0000-0000-0000-0000000000bb'
 
-    it("throws NotFoundException when the report doesn't exist", async () => {
+    it("throws NotFoundException when no report matches the providerId", async () => {
       reportFindOne.mockResolvedValueOnce(null)
 
-      await expect(service.getReport(REPORT_ID, COMPANY)).rejects.toThrow(
+      await expect(service.getReport(PROVIDER_ID, COMPANY)).rejects.toThrow(
         NotFoundException,
       )
+      expect(reportFindOne).toHaveBeenCalledWith({
+        where: { providerId: PROVIDER_ID },
+      })
       expect(companyReportFindAll).not.toHaveBeenCalled()
     })
 
     it("throws NotFoundException when the resolved company isn't the parent", async () => {
-      reportFindOne.mockResolvedValueOnce(makeReportRow({ id: REPORT_ID }))
+      reportFindOne.mockResolvedValueOnce(
+        makeReportRow({ id: REPORT_ID, providerId: PROVIDER_ID }),
+      )
       companyReportFindAll.mockResolvedValueOnce([
         makeCompanyReportRow({
           reportId: REPORT_ID,
@@ -463,7 +469,7 @@ describe('ApplicationService', () => {
         }),
       ])
 
-      await expect(service.getReport(REPORT_ID, COMPANY)).rejects.toThrow(
+      await expect(service.getReport(PROVIDER_ID, COMPANY)).rejects.toThrow(
         NotFoundException,
       )
       expect(getCommentsByReportId).not.toHaveBeenCalled()
@@ -475,6 +481,7 @@ describe('ApplicationService', () => {
       const validUntil = new Date('2028-06-01T00:00:00.000Z')
       const salaryReport = makeReportRow({
         id: REPORT_ID,
+        providerId: PROVIDER_ID,
         type: ReportTypeEnum.SALARY,
         status: ReportStatusEnum.SUBMITTED,
         identifier: 'SAL-2026-001',
@@ -520,8 +527,14 @@ describe('ApplicationService', () => {
       outlierFindAll.mockResolvedValueOnce([outlier])
       getCommentsByReportId.mockResolvedValueOnce([externalComment])
 
-      const result = await service.getReport(REPORT_ID, COMPANY)
+      const result = await service.getReport(PROVIDER_ID, COMPANY)
 
+      expect(reportFindOne).toHaveBeenCalledWith({
+        where: { providerId: PROVIDER_ID },
+      })
+      expect(companyReportFindAll).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { reportId: REPORT_ID } }),
+      )
       expect(result).toMatchObject({
         id: REPORT_ID,
         type: ReportTypeEnum.SALARY,
@@ -568,6 +581,7 @@ describe('ApplicationService', () => {
     it('returns equality report detail with narrative content and no salary-only data', async () => {
       const equalityReport = makeReportRow({
         id: REPORT_ID,
+        providerId: PROVIDER_ID,
         type: ReportTypeEnum.EQUALITY,
         status: ReportStatusEnum.APPROVED,
         identifier: 'EQ-2026-001',
@@ -580,7 +594,7 @@ describe('ApplicationService', () => {
       ])
       getCommentsByReportId.mockResolvedValueOnce([])
 
-      const result = await service.getReport(REPORT_ID, COMPANY)
+      const result = await service.getReport(PROVIDER_ID, COMPANY)
 
       expect(result.equalityReport).toBeNull()
       expect(result.equalityReportContent).toBe('Equality plan narrative')
@@ -595,6 +609,7 @@ describe('ApplicationService', () => {
       reportFindOne.mockResolvedValueOnce(
         makeReportRow({
           id: REPORT_ID,
+          providerId: PROVIDER_ID,
           status: ReportStatusEnum.DENIED,
           type: ReportTypeEnum.EQUALITY,
         }),
@@ -605,7 +620,7 @@ describe('ApplicationService', () => {
       getCommentsByReportId.mockResolvedValueOnce([])
       eventFindOne.mockResolvedValueOnce({ reason: 'Missing explanation' })
 
-      const result = await service.getReport(REPORT_ID, COMPANY)
+      const result = await service.getReport(PROVIDER_ID, COMPANY)
 
       expect(result.denialReason).toBe('Missing explanation')
       expect(eventFindOne).toHaveBeenCalledWith(
@@ -625,7 +640,9 @@ describe('ApplicationService', () => {
         reportId: REPORT_ID,
         visibility: CommentVisibilityEnum.EXTERNAL,
       })
-      reportFindOne.mockResolvedValueOnce(makeReportRow({ id: REPORT_ID }))
+      reportFindOne.mockResolvedValueOnce(
+        makeReportRow({ id: REPORT_ID, providerId: PROVIDER_ID }),
+      )
       companyReportFindAll.mockResolvedValueOnce([
         makeCompanyReportRow({ reportId: REPORT_ID }),
       ])
@@ -639,7 +656,7 @@ describe('ApplicationService', () => {
         },
       )
 
-      const result = await service.getReport(REPORT_ID, COMPANY)
+      const result = await service.getReport(PROVIDER_ID, COMPANY)
 
       expect(result.externalComments).toEqual([
         {
@@ -665,19 +682,25 @@ describe('ApplicationService', () => {
 
   describe('createReportComment', () => {
     const REPORT_ID = '00000000-0000-0000-0000-0000000000aa'
+    const PROVIDER_ID = 'island-is-application-aa'
 
-    it("throws NotFoundException when the report doesn't exist", async () => {
+    it("throws NotFoundException when no report matches the providerId", async () => {
       reportFindOne.mockResolvedValueOnce(null)
 
       await expect(
-        service.createReportComment(REPORT_ID, { body: 'hi' }, COMPANY),
+        service.createReportComment(PROVIDER_ID, { body: 'hi' }, COMPANY),
       ).rejects.toThrow(NotFoundException)
+      expect(reportFindOne).toHaveBeenCalledWith({
+        where: { providerId: PROVIDER_ID },
+      })
       expect(companyReportFindAll).not.toHaveBeenCalled()
       expect(createComment).not.toHaveBeenCalled()
     })
 
     it("throws NotFoundException when the resolved company isn't the parent", async () => {
-      reportFindOne.mockResolvedValueOnce(makeReportRow({ id: REPORT_ID }))
+      reportFindOne.mockResolvedValueOnce(
+        makeReportRow({ id: REPORT_ID, providerId: PROVIDER_ID }),
+      )
       companyReportFindAll.mockResolvedValueOnce([
         makeCompanyReportRow({
           reportId: REPORT_ID,
@@ -687,7 +710,7 @@ describe('ApplicationService', () => {
       ])
 
       await expect(
-        service.createReportComment(REPORT_ID, { body: 'hi' }, COMPANY),
+        service.createReportComment(PROVIDER_ID, { body: 'hi' }, COMPANY),
       ).rejects.toThrow(NotFoundException)
       expect(createComment).not.toHaveBeenCalled()
     })
@@ -704,6 +727,7 @@ describe('ApplicationService', () => {
       reportFindOne.mockResolvedValueOnce(
         makeReportRow({
           id: REPORT_ID,
+          providerId: PROVIDER_ID,
           status: ReportStatusEnum.SUBMITTED,
         }),
       )
@@ -713,7 +737,7 @@ describe('ApplicationService', () => {
       createComment.mockResolvedValueOnce(createdComment)
 
       const result = await service.createReportComment(
-        REPORT_ID,
+        PROVIDER_ID,
         { body: 'Please review my correction' },
         COMPANY,
       )
@@ -900,7 +924,7 @@ function makeSubmitSalaryInput(): SubmitSalaryReportDto {
     identifier: 'SAL-2026-001',
     importedFromExcel: true,
     providerType: ReportProviderEnum.SYSTEM,
-    providerId: null,
+    providerId: 'salary-provider-1',
     companyAdminName: 'Anna Admin',
     companyAdminEmail: 'admin@example.is',
     companyAdminGender: GenderEnum.FEMALE,
@@ -926,7 +950,7 @@ function makeSubmitEqualityInput(): SubmitEqualityReportDto {
   return {
     identifier: 'EQ-2026-001',
     providerType: ReportProviderEnum.SYSTEM,
-    providerId: null,
+    providerId: 'equality-provider-1',
     companyAdminName: 'Anna Admin',
     companyAdminEmail: 'admin@example.is',
     companyAdminGender: GenderEnum.FEMALE,
@@ -950,6 +974,7 @@ function makeReportRow(
 ): ReportModel {
   return {
     id: 'report-1',
+    providerId: null,
     type: ReportTypeEnum.EQUALITY,
     status: ReportStatusEnum.SUBMITTED,
     identifier: 'REPORT-001',

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -211,17 +211,17 @@ export class ApplicationService implements IApplicationService {
   }
 
   async getReport(
-    reportId: string,
+    providerId: string,
     company: CompanyDto,
   ): Promise<ApplicationReportDetailDto> {
-    const report = await this.reportModel.findOne({ where: { id: reportId } })
+    const report = await this.reportModel.findOne({ where: { providerId } })
 
     if (!report) {
-      throw new NotFoundException(`Report "${reportId}" not found`)
+      throw new NotFoundException(`Report "${providerId}" not found`)
     }
 
     const companyRows = await this.companyReportModel.findAll({
-      where: { reportId },
+      where: { reportId: report.id },
       order: [['createdAt', 'ASC']],
     })
 
@@ -229,7 +229,7 @@ export class ApplicationService implements IApplicationService {
       (row) => row.parentCompanyId === null,
     )
     if (!parentCompany || parentCompany.companyId !== company.id) {
-      throw new NotFoundException(`Report "${reportId}" not found`)
+      throw new NotFoundException(`Report "${providerId}" not found`)
     }
 
     const [equalityReport, salaryData, externalComments, denialReason] =
@@ -269,24 +269,24 @@ export class ApplicationService implements IApplicationService {
   }
 
   async createReportComment(
-    reportId: string,
+    providerId: string,
     input: SubmitApplicationReportCommentDto,
     company: CompanyDto,
   ): Promise<ApplicationReportCommentDto> {
     this.logger.info('Submitting report comment from application portal', {
       context: LOGGING_CONTEXT,
       companyId: company.id,
-      reportId,
+      providerId,
     })
 
-    const report = await this.reportModel.findOne({ where: { id: reportId } })
+    const report = await this.reportModel.findOne({ where: { providerId } })
 
     if (!report) {
-      throw new NotFoundException(`Report "${reportId}" not found`)
+      throw new NotFoundException(`Report "${providerId}" not found`)
     }
 
     const companyRows = await this.companyReportModel.findAll({
-      where: { reportId },
+      where: { reportId: report.id },
       order: [['createdAt', 'ASC']],
     })
 
@@ -294,7 +294,7 @@ export class ApplicationService implements IApplicationService {
       (row) => row.parentCompanyId === null,
     )
     if (!parentCompany || parentCompany.companyId !== company.id) {
-      throw new NotFoundException(`Report "${reportId}" not found`)
+      throw new NotFoundException(`Report "${providerId}" not found`)
     }
 
     const created = await this.reportCommentService.create(

--- a/apps/directorate-of-equality-api/src/modules/application/dto/submit-equality-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/submit-equality-report.dto.ts
@@ -2,7 +2,6 @@ import {
   ApiDto,
   ApiEnum,
   ApiOptionalDtoArray,
-  ApiOptionalString,
   ApiString,
 } from '@dmr.is/decorators'
 
@@ -22,8 +21,8 @@ export class SubmitEqualityReportDto {
   @ApiEnum(ReportProviderEnum)
   providerType!: ReportProviderEnum
 
-  @ApiOptionalString({ nullable: true })
-  providerId!: string | null
+  @ApiString()
+  providerId!: string
 
   @ApiString()
   companyAdminName!: string

--- a/apps/directorate-of-equality-api/src/modules/application/dto/submit-salary-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/submit-salary-report.dto.ts
@@ -5,7 +5,6 @@ import {
   ApiNumber,
   ApiOptionalBoolean,
   ApiOptionalDtoArray,
-  ApiOptionalString,
   ApiString,
   ApiUUID,
 } from '@dmr.is/decorators'
@@ -37,8 +36,8 @@ export class SubmitSalaryReportDto {
   @ApiEnum(ReportProviderEnum)
   providerType!: ReportProviderEnum
 
-  @ApiOptionalString({ nullable: true })
-  providerId!: string | null
+  @ApiString()
+  providerId!: string
 
   @ApiString()
   companyAdminName!: string

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
@@ -48,6 +52,7 @@ describe('ReportCreateService', () => {
   let reportEventCreate: jest.Mock
   let companyFindAll: jest.Mock
   let companyReportBulkCreate: jest.Mock
+  let companyReportFindOne: jest.Mock
   let roleBulkCreate: jest.Mock
   let employeeBulkCreate: jest.Mock
   let roleStepBulkCreate: jest.Mock
@@ -72,6 +77,7 @@ describe('ReportCreateService', () => {
     companyReportBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `cr-${i}` })),
     )
+    companyReportFindOne = jest.fn().mockResolvedValue(null)
     roleBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `role-${i}` })),
     )
@@ -130,7 +136,10 @@ describe('ReportCreateService', () => {
         },
         {
           provide: getModelToken(CompanyReportModel),
-          useValue: { bulkCreate: companyReportBulkCreate },
+          useValue: {
+            bulkCreate: companyReportBulkCreate,
+            findOne: companyReportFindOne,
+          },
         },
         {
           provide: getModelToken(ReportEmployeeRoleModel),
@@ -568,6 +577,115 @@ describe('ReportCreateService', () => {
 
     expect(reportCreate).toHaveBeenCalled()
     expect(reportEventCreate).not.toHaveBeenCalled()
+  })
+
+  describe('idempotent replay on (providerType, providerId)', () => {
+    const EXISTING_REPORT_ID = '00000000-0000-0000-0000-0000000000ee'
+
+    it('SALARY: returns existing reportId without inserting when tuple already exists for the same company', async () => {
+      const input = makeInput()
+      input.providerType = ReportProviderEnum.ISLAND_IS
+      input.providerId = 'island-is-application-uuid-1'
+
+      // First findOne is the provider-tuple lookup → returns existing row.
+      // No follow-up call is made because we short-circuit before
+      // assertEqualityReportApproved.
+      reportFindOne.mockResolvedValueOnce({
+        id: EXISTING_REPORT_ID,
+        providerType: input.providerType,
+        providerId: input.providerId,
+      })
+      companyReportFindOne.mockResolvedValueOnce({
+        companyId: PARENT_COMPANY_ID,
+        parentCompanyId: null,
+      })
+
+      const result = await service.createSalary(input)
+
+      expect(result).toEqual({ reportId: EXISTING_REPORT_ID })
+      expect(reportCreate).not.toHaveBeenCalled()
+      expect(companyReportBulkCreate).not.toHaveBeenCalled()
+      expect(reportResultCreateForReport).not.toHaveBeenCalled()
+      expect(reportEventCreate).not.toHaveBeenCalled()
+    })
+
+    it('SALARY: rejects with 409 when an existing tuple belongs to a different company', async () => {
+      const input = makeInput()
+      input.providerType = ReportProviderEnum.ISLAND_IS
+      input.providerId = 'island-is-application-uuid-1'
+
+      reportFindOne.mockResolvedValueOnce({
+        id: EXISTING_REPORT_ID,
+        providerType: input.providerType,
+        providerId: input.providerId,
+      })
+      companyReportFindOne.mockResolvedValueOnce({
+        companyId: 'someone-else-company-id',
+        parentCompanyId: null,
+      })
+
+      await expect(service.createSalary(input)).rejects.toThrow(
+        ConflictException,
+      )
+      expect(reportCreate).not.toHaveBeenCalled()
+    })
+
+    it('EQUALITY: returns existing reportId without inserting when tuple already exists for the same company', async () => {
+      const input = makeEqualityInput()
+      input.providerType = ReportProviderEnum.ISLAND_IS
+      input.providerId = 'island-is-application-uuid-2'
+
+      reportFindOne.mockResolvedValueOnce({
+        id: EXISTING_REPORT_ID,
+        providerType: input.providerType,
+        providerId: input.providerId,
+      })
+      companyReportFindOne.mockResolvedValueOnce({
+        companyId: PARENT_COMPANY_ID,
+        parentCompanyId: null,
+      })
+
+      const result = await service.createEquality(input)
+
+      expect(result).toEqual({ reportId: EXISTING_REPORT_ID })
+      expect(reportCreate).not.toHaveBeenCalled()
+      expect(companyReportBulkCreate).not.toHaveBeenCalled()
+      expect(reportEventCreate).not.toHaveBeenCalled()
+    })
+
+    it('proceeds with insert when providerId is non-null but no existing tuple matches', async () => {
+      const input = makeInput()
+      input.providerType = ReportProviderEnum.ISLAND_IS
+      input.providerId = 'island-is-application-uuid-3'
+
+      // 1st findOne (provider tuple lookup) → null = no replay.
+      // 2nd findOne (equality report lookup) → approved equality stays.
+      reportFindOne
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ id: EQUALITY_REPORT_ID })
+
+      const result = await service.createSalary(input)
+
+      expect(result).toEqual({ reportId: REPORT_ID })
+      expect(reportCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerType: ReportProviderEnum.ISLAND_IS,
+          providerId: 'island-is-application-uuid-3',
+        }),
+      )
+    })
+
+    it('skips the idempotency check entirely when providerId is null', async () => {
+      // makeInput() defaults to providerType=SYSTEM, providerId=null.
+      // The default reportFindOne mock returns {id: EQUALITY_REPORT_ID}, which
+      // would falsely match the provider-tuple lookup if the check ran. The
+      // fact that this still completes a successful insert proves the null
+      // short-circuit fires before any findOne call.
+      await service.createSalary(makeInput())
+
+      expect(reportCreate).toHaveBeenCalled()
+      expect(companyReportFindOne).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -2,6 +2,7 @@ import { Op } from 'sequelize'
 
 import {
   BadRequestException,
+  ConflictException,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -22,6 +23,7 @@ import {
 } from '../report/lib/employee-scores'
 import {
   ReportModel,
+  ReportProviderEnum,
   ReportStatusEnum,
   ReportTypeEnum,
 } from '../report/models/report.model'
@@ -96,13 +98,26 @@ export class ReportCreateService implements IReportCreateService {
   private async createSalaryReport(
     input: CreateReportDto,
   ): Promise<CreateReportResponseDto> {
+    const submittingCompany = this.getSubmittingCompany(input.companies)
+
+    // Idempotent replay — if upstream retries with the same (provider_type,
+    // provider_id), return the prior reportId instead of inserting again. See
+    // db/README.md → "Provider correlation".
+    const replay = await this.findExistingByProviderTuple(
+      input.providerType,
+      input.providerId,
+      submittingCompany.companyId,
+    )
+    if (replay) {
+      return replay
+    }
+
     const stepScoreByKey = assertParsedPayloadIntegrity(input.parsed)
     const employeeScores = computeEmployeeScores(input.parsed, stepScoreByKey)
     this.assertOutliersReferenceParsedEmployees(input)
     await this.assertOutliersMatchDetectedOutliers(input, employeeScores)
 
     await this.assertEqualityReportApproved(input.equalityReportId)
-    const submittingCompany = this.getSubmittingCompany(input.companies)
     const outliersPostponed = input.outliersPostponed ?? false
 
     // 1. report row — status SUBMITTED so it lands in the reviewer queue.
@@ -283,6 +298,15 @@ export class ReportCreateService implements IReportCreateService {
   ): Promise<CreateReportResponseDto> {
     const submittingCompany = this.getSubmittingCompany(input.companies)
 
+    const replay = await this.findExistingByProviderTuple(
+      input.providerType,
+      input.providerId,
+      submittingCompany.companyId,
+    )
+    if (replay) {
+      return replay
+    }
+
     const report = await this.reportModel.create({
       type: ReportTypeEnum.EQUALITY,
       status: ReportStatusEnum.SUBMITTED,
@@ -316,6 +340,56 @@ export class ReportCreateService implements IReportCreateService {
     })
 
     return { reportId: report.id }
+  }
+
+  /**
+   * Returns the existing `reportId` if a row already exists for the
+   * `(provider_type, provider_id)` tuple, otherwise returns null and the
+   * caller proceeds with insert.
+   *
+   * Null `provider_id` (typical for `provider_type = SYSTEM` admin-created
+   * rows) short-circuits with a null return — those rows are not subject to
+   * the unique constraint and never replay-collide.
+   *
+   * Cross-company collisions (an existing row with the same tuple but a
+   * different submitting company) throw 409. This shouldn't happen under
+   * normal upstream behaviour but is defensible in the "new provider channel
+   * reuses an existing channel's id" scenario the DB constraint guards
+   * against.
+   */
+  private async findExistingByProviderTuple(
+    providerType: ReportProviderEnum,
+    providerId: string | null,
+    submittingCompanyId: string,
+  ): Promise<CreateReportResponseDto | null> {
+    if (providerId === null) {
+      return null
+    }
+
+    const existing = await this.reportModel.findOne({
+      where: { providerType, providerId },
+    })
+    if (!existing) {
+      return null
+    }
+
+    const existingParent = await this.companyReportModel.findOne({
+      where: { reportId: existing.id, parentCompanyId: null },
+    })
+    if (!existingParent || existingParent.companyId !== submittingCompanyId) {
+      throw new ConflictException(
+        `Provider tuple (${providerType}, "${providerId}") is already registered for a different company`,
+      )
+    }
+
+    this.logger.info('Idempotent replay — returning existing report id', {
+      context: LOGGING_CONTEXT,
+      reportId: existing.id,
+      providerType,
+      providerId,
+    })
+
+    return { reportId: existing.id }
   }
 
   private getSubmittingCompany(

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -1,6 +1,9 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common'
 
-import { ReportStatusEnum } from '../report/models/report.model'
+import {
+  ReportStatusEnum,
+  ReportTypeEnum,
+} from '../report/models/report.model'
 import {
   type ReportResourceContext,
   ReportRoleEnum,
@@ -292,8 +295,9 @@ describe('ReportWorkflowService', () => {
   })
 
   describe('approve', () => {
-    it('transitions IN_REVIEW → APPROVED, supersedes prior approvals, emits STATUS_CHANGED + SUPERSEDED', async () => {
+    it('transitions IN_REVIEW → APPROVED, supersedes prior approvals of the same type, emits STATUS_CHANGED + SUPERSEDED', async () => {
       reportModel.update.mockResolvedValue([1])
+      reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.SALARY })
       reportModel.findAll.mockResolvedValue([{ id: 'old-report-1' }])
       reportEventService.emitStatusChanged.mockResolvedValue(undefined)
       reportEventService.emitSuperseded.mockResolvedValue(undefined)
@@ -312,6 +316,14 @@ describe('ReportWorkflowService', () => {
         }),
         { where: { id: 'report-1' } },
       )
+      expect(reportModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: ReportStatusEnum.APPROVED,
+            type: ReportTypeEnum.SALARY,
+          }),
+        }),
+      )
       expect(reportModel.update).toHaveBeenCalledWith(
         { status: ReportStatusEnum.SUPERSEDED, validUntil: expect.any(Date) },
         { where: { id: ['old-report-1'] } },
@@ -328,8 +340,39 @@ describe('ReportWorkflowService', () => {
       )
     })
 
+    it('does not supersede approved reports of a different type (SALARY approval leaves APPROVED EQUALITY untouched)', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.SALARY })
+      // The cross-type EQUALITY sibling exists in company_report but the
+      // type-scoped findAll filters it out, returning no rows to supersede.
+      reportModel.findAll.mockResolvedValue([])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })
+      companyReportModel.findAll.mockResolvedValue([
+        { reportId: 'old-equality-1' },
+        { reportId: 'report-1' },
+      ])
+
+      await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(reportModel.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            id: ['old-equality-1'],
+            status: ReportStatusEnum.APPROVED,
+            type: ReportTypeEnum.SALARY,
+          }),
+        }),
+      )
+      // Only the initial APPROVED transition update ran — no supersede update,
+      // no SUPERSEDED event emitted for the EQUALITY sibling.
+      expect(reportModel.update).toHaveBeenCalledTimes(1)
+      expect(reportEventService.emitSuperseded).not.toHaveBeenCalled()
+    })
+
     it('skips supersede when no sibling reports are APPROVED', async () => {
       reportModel.update.mockResolvedValue([1])
+      reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.EQUALITY })
       reportModel.findAll.mockResolvedValue([])
       reportEventService.emitStatusChanged.mockResolvedValue(undefined)
       companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -9,7 +9,11 @@ import { InjectModel } from '@nestjs/sequelize'
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { CompanyReportModel } from '../company/models/company-report.model'
-import { ReportModel, ReportStatusEnum } from '../report/models/report.model'
+import {
+  ReportModel,
+  ReportStatusEnum,
+  ReportTypeEnum,
+} from '../report/models/report.model'
 import {
   type ReportResourceContext,
   ReportRoleEnum,
@@ -233,6 +237,20 @@ export class ReportWorkflowService implements IReportWorkflowService {
   }
 
   private async supersedePreviousApproved(reportId: string): Promise<void> {
+    // Supersession is scoped to `(company, type)` — approving a new SALARY
+    // must not invalidate a still-valid APPROVED EQUALITY (and vice versa).
+    // See db/README.md → "Report lifecycle" / SUPERSEDED.
+    const newReport = await this.reportModel.findOne({
+      where: { id: reportId },
+      attributes: ['type'],
+    })
+
+    if (!newReport) {
+      return
+    }
+
+    const newReportType: ReportTypeEnum = newReport.type
+
     const companyReport = await this.companyReportModel.findOne({
       where: { reportId },
       attributes: ['companyId'],
@@ -256,7 +274,11 @@ export class ReportWorkflowService implements IReportWorkflowService {
     }
 
     const toSupersede = await this.reportModel.findAll({
-      where: { id: siblingReportIds, status: ReportStatusEnum.APPROVED },
+      where: {
+        id: siblingReportIds,
+        status: ReportStatusEnum.APPROVED,
+        type: newReportType,
+      },
       attributes: ['id'],
     })
 


### PR DESCRIPTION
## Summary

- Applicant-facing endpoints `GET /reports/:providerId` and `POST /reports/:providerId/comments` now look up by the upstream submission id (e.g. island.is application UUID) instead of the internal DoE `report.id` — the applicant never sees the latter.
- New partial unique index on `report (provider_type, provider_id) WHERE provider_id IS NOT NULL`, plus app-layer idempotent-create in `report-create.service.ts`. Upstream retries with the same tuple return the existing `reportId` rather than inserting again; cross-company collisions reject with 409.
- Bug fix: `supersedePreviousApproved` now scopes by `(company, type)`, so approving a new SALARY no longer flips an APPROVED EQUALITY to SUPERSEDED (and vice versa). Every company needs both types active simultaneously.
- `db/README.md` updated in three places: new "Provider correlation" section documenting the constraint and idempotency contract; tightened SUPERSEDED bullet to spell out the per-type scoping; Resubmission/Denial bullet reflowed per team decision (denial is terminal, redo = new upstream application + new `provider_id` + new row; future PUT-edit endpoint flagged as a distinct, separate capability).

## Breaking change

- `providerId` is now required (non-null) on `SubmitEqualityReportDto` and `SubmitSalaryReportDto`. Application-portal callers must supply the upstream id.

## Migration

- `db/migrations/m-20260518-add-provider-id-unique-index.js` — partial unique index.