### PR TITLE
fix(doe): Introduce company size count category

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260521-doe-company-employee-count-bucket.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260521-doe-company-employee-count-bucket.js
@@ -1,0 +1,76 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- ============================================================
+    -- company.employee_count_category / company_report mirror
+    --
+    -- RSK does not give us an exact headcount; companies report into one of
+    -- three regulatory buckets (0–24, 25–49, 50+). Replace the integer
+    -- average_employee_count_from_rsk column on both company and
+    -- company_report (snapshot) with an enum representing the bucket.
+    --
+    -- The salary-report-required DB trigger previously read the integer
+    -- column. It is updated to flag LARGE companies instead.
+    -- ============================================================
+
+    CREATE TYPE company_size_enum AS ENUM ('SMALL', 'MEDIUM', 'LARGE');
+
+    ALTER TABLE company
+      DROP COLUMN average_employee_count_from_rsk;
+    ALTER TABLE company
+      ADD COLUMN employee_count_category company_size_enum NOT NULL DEFAULT 'SMALL';
+
+    ALTER TABLE company_report
+      DROP COLUMN average_employee_count_from_rsk;
+    ALTER TABLE company_report
+      ADD COLUMN employee_count_category company_size_enum NOT NULL DEFAULT 'SMALL';
+
+    CREATE OR REPLACE FUNCTION company_sync_salary_report_required()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF NEW.salary_report_required_override IS DISTINCT FROM TRUE THEN
+        NEW.salary_report_required := (NEW.employee_count_category = 'LARGE');
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    CREATE OR REPLACE FUNCTION company_sync_salary_report_required()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      IF NEW.salary_report_required_override IS DISTINCT FROM TRUE THEN
+        NEW.salary_report_required := (NEW.average_employee_count_from_rsk >= 50);
+      END IF;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    ALTER TABLE company_report
+      DROP COLUMN employee_count_category;
+    ALTER TABLE company_report
+      ADD COLUMN average_employee_count_from_rsk INTEGER NOT NULL DEFAULT 0;
+
+    ALTER TABLE company
+      DROP COLUMN employee_count_category;
+    ALTER TABLE company
+      ADD COLUMN average_employee_count_from_rsk INTEGER NOT NULL DEFAULT 0;
+
+    DROP TYPE company_size_enum;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/core/decorators/auto-provision-company.decorator.ts
+++ b/apps/directorate-of-equality-api/src/core/decorators/auto-provision-company.decorator.ts
@@ -4,9 +4,9 @@ export const AUTO_PROVISION_COMPANY_METADATA = 'autoProvisionCompany'
 
 /**
  * Marks a route handler so `CompanyResourceGuard` will create the company
- * row (with `averageEmployeeCountFromRsk: 0`) when the authenticated
- * national ID has no existing company. Without this, the guard rejects
- * unknown companies with NotFoundException.
+ * row (defaulting `employeeCountCategory` to `SMALL`) when the
+ * authenticated national ID has no existing company. Without this, the
+ * guard rejects unknown companies with NotFoundException.
  */
 export const AutoProvisionCompany = (): MethodDecorator =>
   SetMetadata(AUTO_PROVISION_COMPANY_METADATA, true)

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -10,6 +10,7 @@ import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
+import { CompanySizeEnum } from '../company/models/company.enums'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
 import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
@@ -53,7 +54,7 @@ const mockLogger = {
 const COMPANY: CompanyDto = {
   id: 'company-1',
   name: 'Acme ehf.',
-  averageEmployeeCountFromRsk: 3,
+  employeeCountCategory: CompanySizeEnum.LARGE,
   nationalId: '5501234567',
   salaryReportRequired: true,
   salaryReportRequiredOverride: false,
@@ -461,7 +462,7 @@ describe('ApplicationService', () => {
     const PROVIDER_ID = 'island-is-application-aa'
     const EQUALITY_REPORT_ID = '00000000-0000-0000-0000-0000000000bb'
 
-    it("throws NotFoundException when no report matches the providerId", async () => {
+    it('throws NotFoundException when no report matches the providerId', async () => {
       reportFindOne.mockResolvedValueOnce(null)
 
       await expect(service.getReport(PROVIDER_ID, COMPANY)).rejects.toThrow(
@@ -706,7 +707,7 @@ describe('ApplicationService', () => {
     const REPORT_ID = '00000000-0000-0000-0000-0000000000aa'
     const PROVIDER_ID = 'island-is-application-aa'
 
-    it("throws NotFoundException when no report matches the providerId", async () => {
+    it('throws NotFoundException when no report matches the providerId', async () => {
       reportFindOne.mockResolvedValueOnce(null)
 
       await expect(
@@ -1065,11 +1066,7 @@ describe('ApplicationService', () => {
       getResultByReportId.mockResolvedValueOnce(detectedSnapshot([1, 2]))
 
       await expect(
-        service.editOutliers(
-          PROVIDER_ID,
-          { outliers: [validRow(1)] },
-          COMPANY,
-        ),
+        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
       expect(outlierUpdate).not.toHaveBeenCalled()
     })
@@ -1111,11 +1108,7 @@ describe('ApplicationService', () => {
       ])
 
       await expect(
-        service.editOutliers(
-          PROVIDER_ID,
-          { outliers: [validRow(1)] },
-          COMPANY,
-        ),
+        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
@@ -1133,11 +1126,7 @@ describe('ApplicationService', () => {
       ])
 
       await expect(
-        service.editOutliers(
-          PROVIDER_ID,
-          { outliers: [validRow(1)] },
-          COMPANY,
-        ),
+        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
   })
@@ -1372,7 +1361,7 @@ function makeCompanyReportRow(
     address: 'Laugavegur 1',
     city: 'Reykjavík',
     postcode: '101',
-    averageEmployeeCountFromRsk: COMPANY.averageEmployeeCountFromRsk,
+    employeeCountCategory: COMPANY.employeeCountCategory,
     isatCategory: '62.0',
     ...overrides,
   } as unknown as CompanyReportModel
@@ -1462,7 +1451,8 @@ function makeReportResultDto(
     base: snapshot,
     full: snapshot,
     outlierAnalysis: {
-      method: SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
+      method:
+        SalaryOutlierAnalysisMethodEnum.BASE_SALARY_LINEAR_REGRESSION_BY_SCORE,
       thresholdPercent: 3.9,
       allowedDifferencePercent: 1.95,
       regressions: {

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@dmr.is/clients-national-registry'
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { CompanySizeEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
 import { CompanyService } from './company.service'
 
@@ -86,7 +87,7 @@ describe('CompanyService', () => {
           id: 'company-1',
           name: 'Acme ehf.',
           nationalId: '5501234567',
-          averageEmployeeCountFromRsk: 12,
+          employeeCountCategory: CompanySizeEnum.SMALL,
         }),
       )
 
@@ -101,7 +102,7 @@ describe('CompanyService', () => {
         id: 'company-1',
         name: 'Acme ehf.',
         nationalId: '5501234567',
-        averageEmployeeCountFromRsk: 12,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       })
     })
 
@@ -118,7 +119,7 @@ describe('CompanyService', () => {
           id: 'company-2',
           name: 'Registry Name ehf.',
           nationalId: '6601234567',
-          averageEmployeeCountFromRsk: 0,
+          employeeCountCategory: CompanySizeEnum.SMALL,
         }),
       )
 
@@ -130,13 +131,13 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Registry Name ehf.',
         nationalId: '6601234567',
-        averageEmployeeCountFromRsk: 0,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       })
       expect(result).toEqual({
         id: 'company-2',
         name: 'Registry Name ehf.',
         nationalId: '6601234567',
-        averageEmployeeCountFromRsk: 0,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       })
     })
 
@@ -148,7 +149,7 @@ describe('CompanyService', () => {
           id: 'company-3',
           name: 'Body-provided name',
           nationalId: '7701234567',
-          averageEmployeeCountFromRsk: 0,
+          employeeCountCategory: CompanySizeEnum.SMALL,
         }),
       )
 
@@ -160,7 +161,7 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Body-provided name',
         nationalId: '7701234567',
-        averageEmployeeCountFromRsk: 0,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       })
       expect(result.name).toBe('Body-provided name')
     })
@@ -193,7 +194,7 @@ describe('CompanyService', () => {
           id: 'company-1',
           name: 'Acme ehf.',
           nationalId: '5501234567',
-          averageEmployeeCountFromRsk: 12,
+          employeeCountCategory: CompanySizeEnum.SMALL,
         }),
       )
 
@@ -234,7 +235,7 @@ describe('CompanyService', () => {
           id: 'company-2',
           name: 'Subsidiary ehf.',
           nationalId: '6601234567',
-          averageEmployeeCountFromRsk: 0,
+          employeeCountCategory: CompanySizeEnum.SMALL,
         }),
       )
 
@@ -246,7 +247,7 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Subsidiary ehf.',
         nationalId: '6601234567',
-        averageEmployeeCountFromRsk: 0,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       })
       expect(result).toEqual({
         companyId: 'company-2',
@@ -297,7 +298,7 @@ function makeCompanyModel(overrides: Partial<CompanyModel> = {}): CompanyModel {
     id: 'company-1',
     name: 'Acme ehf.',
     nationalId: '5501234567',
-    averageEmployeeCountFromRsk: 3,
+    employeeCountCategory: CompanySizeEnum.SMALL,
     ...overrides,
   }
   return {

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -22,6 +22,7 @@ import {
   CompanySortDirectionEnum,
 } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { CompanySizeEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
 import {
   CreateCompanyInput,
@@ -58,15 +59,15 @@ export class CompanyService implements ICompanyService {
       })
     }
 
-    if (query.minEmployeeCount !== undefined) {
+    if (query.employeeCountCategory !== undefined) {
       Object.assign(where, {
-        averageEmployeeCountFromRsk: { [Op.gte]: query.minEmployeeCount },
+        employeeCountCategory: query.employeeCountCategory,
       })
     }
 
     const sortCol =
       query.sortBy === CompanySortByEnum.EMPLOYEE_COUNT
-        ? 'averageEmployeeCountFromRsk'
+        ? 'employeeCountCategory'
         : 'name'
     const sortDir = (
       query.direction ?? CompanySortDirectionEnum.ASC
@@ -137,7 +138,7 @@ export class CompanyService implements ICompanyService {
     const company = await this.companyModel.create({
       name: input.name,
       nationalId: input.nationalId,
-      averageEmployeeCountFromRsk: input.averageEmployeeCountFromRsk,
+      employeeCountCategory: input.employeeCountCategory,
     })
 
     return company.fromModel()
@@ -187,7 +188,7 @@ export class CompanyService implements ICompanyService {
     const company = await this.companyModel.create({
       name,
       nationalId,
-      averageEmployeeCountFromRsk: 0,
+      employeeCountCategory: CompanySizeEnum.SMALL,
     })
 
     return company.fromModel()
@@ -220,7 +221,7 @@ export class CompanyService implements ICompanyService {
       (await this.companyModel.create({
         name: registry.entity.nafn,
         nationalId: input.nationalId,
-        averageEmployeeCountFromRsk: 0,
+        employeeCountCategory: CompanySizeEnum.SMALL,
       }))
 
     return {

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-report.dto.ts
@@ -1,9 +1,11 @@
 import {
-  ApiNumber,
+  ApiEnum,
   ApiOptionalUuid,
   ApiString,
   ApiUUId,
 } from '@dmr.is/decorators'
+
+import { CompanySizeEnum } from '../models/company.enums'
 
 export class CompanyReportDto {
   @ApiUUId()
@@ -33,8 +35,8 @@ export class CompanyReportDto {
   @ApiString()
   postcode!: string
 
-  @ApiNumber()
-  averageEmployeeCountFromRsk!: number
+  @ApiEnum(CompanySizeEnum, { enumName: 'CompanySizeEnum' })
+  employeeCountCategory!: CompanySizeEnum
 
   @ApiString()
   isatCategory!: string

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
@@ -1,4 +1,6 @@
-import { ApiBoolean, ApiNumber, ApiString, ApiUUId } from '@dmr.is/decorators'
+import { ApiBoolean, ApiEnum, ApiString, ApiUUId } from '@dmr.is/decorators'
+
+import { CompanySizeEnum } from '../models/company.enums'
 
 export class CompanyDto {
   @ApiUUId()
@@ -7,8 +9,8 @@ export class CompanyDto {
   @ApiString()
   name!: string
 
-  @ApiNumber()
-  averageEmployeeCountFromRsk!: number
+  @ApiEnum(CompanySizeEnum, { enumName: 'CompanySizeEnum' })
+  employeeCountCategory!: CompanySizeEnum
 
   @ApiString()
   nationalId!: string

--- a/apps/directorate-of-equality-api/src/modules/company/dto/create-company-input.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/create-company-input.dto.ts
@@ -1,5 +1,7 @@
+import { CompanySizeEnum } from '../models/company.enums'
+
 export class CreateCompanyInput {
   name!: string
   nationalId!: string
-  averageEmployeeCountFromRsk!: number
+  employeeCountCategory!: CompanySizeEnum
 }

--- a/apps/directorate-of-equality-api/src/modules/company/dto/create-company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/create-company.dto.ts
@@ -1,4 +1,6 @@
-import { ApiNumber, ApiString } from '@dmr.is/decorators'
+import { ApiEnum, ApiString } from '@dmr.is/decorators'
+
+import { CompanySizeEnum } from '../models/company.enums'
 
 export class CreateCompanyDto {
   @ApiString()
@@ -7,6 +9,6 @@ export class CreateCompanyDto {
   @ApiString()
   name!: string
 
-  @ApiNumber()
-  averageEmployeeCountFromRsk!: number
+  @ApiEnum(CompanySizeEnum, { enumName: 'CompanySizeEnum' })
+  employeeCountCategory!: CompanySizeEnum
 }

--- a/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
@@ -1,12 +1,9 @@
-import { Transform } from 'class-transformer'
-import { IsEnum, IsNumber, IsOptional, IsString, Min } from 'class-validator'
+import { IsEnum, IsOptional, IsString } from 'class-validator'
 
-import {
-  ApiOptionalEnum,
-  ApiOptionalNumber,
-  ApiOptionalString,
-} from '@dmr.is/decorators'
+import { ApiOptionalEnum, ApiOptionalString } from '@dmr.is/decorators'
 import { PagingQuery } from '@dmr.is/shared-dto'
+
+import { CompanySizeEnum } from '../models/company.enums'
 
 export enum CompanySortByEnum {
   NAME = 'name',
@@ -26,20 +23,13 @@ export class GetCompaniesQueryDto extends PagingQuery {
   @IsString()
   q?: string
 
-  @ApiOptionalNumber({
-    description:
-      'Return only companies with averageEmployeeCountFromRsk >= this value.',
-    minimum: 0,
-  })
-  @Transform(({ value }) => {
-    if (value == null) return undefined
-    const n = parseInt(value, 10)
-    return Number.isNaN(n) ? undefined : n
+  @ApiOptionalEnum(CompanySizeEnum, {
+    enumName: 'CompanySizeEnum',
+    description: 'Return only companies whose employee-count bucket matches.',
   })
   @IsOptional()
-  @IsNumber()
-  @Min(0)
-  minEmployeeCount?: number
+  @IsEnum(CompanySizeEnum)
+  employeeCountCategory?: CompanySizeEnum
 
   @ApiOptionalEnum(CompanySortByEnum, { enumName: 'CompanySortByEnum' })
   @IsOptional()

--- a/apps/directorate-of-equality-api/src/modules/company/models/company-report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company-report.model.ts
@@ -5,6 +5,7 @@ import { ImmutableModel, ImmutableTable } from '@dmr.is/shared-models-base'
 import { DoeModels } from '../../../core/constants'
 import { ReportModel } from '../../report/models/report.model'
 import type { CompanyReportDto } from '../dto/company-report.dto'
+import { CompanySizeEnum } from './company.enums'
 import { CompanyModel } from './company.model'
 
 type CompanyReportAttributes = {
@@ -17,7 +18,7 @@ type CompanyReportAttributes = {
   address: string
   city: string
   postcode: string
-  averageEmployeeCountFromRsk: number
+  employeeCountCategory: CompanySizeEnum
   isatCategory: string
 }
 
@@ -31,7 +32,7 @@ type CompanyReportCreateAttributes = {
   address: string
   city: string
   postcode: string
-  averageEmployeeCountFromRsk: number
+  employeeCountCategory: CompanySizeEnum
   isatCategory: string
 }
 
@@ -68,11 +69,11 @@ export class CompanyReportModel extends ImmutableModel<
   postcode!: string
 
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.ENUM(...Object.values(CompanySizeEnum)),
     allowNull: false,
-    field: 'average_employee_count_from_rsk',
+    field: 'employee_count_category',
   })
-  averageEmployeeCountFromRsk!: number
+  employeeCountCategory!: CompanySizeEnum
 
   @Column({ type: DataType.TEXT, allowNull: false, field: 'isat_category' })
   isatCategory!: string
@@ -100,7 +101,7 @@ export class CompanyReportModel extends ImmutableModel<
       address: model.address,
       city: model.city,
       postcode: model.postcode,
-      averageEmployeeCountFromRsk: model.averageEmployeeCountFromRsk,
+      employeeCountCategory: model.employeeCountCategory,
       isatCategory: model.isatCategory,
     }
   }

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
@@ -1,0 +1,22 @@
+/**
+ * Coarse company-size bucket derived from RSK headcount. Persisted on
+ * `company.employee_count_category` and snapshotted onto `company_report`.
+ *
+ * Bucket boundaries (regulatory):
+ *   SMALL  → 0–24 employees
+ *   MEDIUM → 25–49 employees
+ *   LARGE  → 50+ employees
+ *
+ * The LARGE bucket is the threshold that triggers a required salary report
+ * (see the `company_sync_salary_report_required` DB trigger).
+ *
+ * Declaration order is load-bearing: Postgres orders enum values by
+ * declaration order, so `ORDER BY employee_count_category` yields
+ * SMALL < MEDIUM < LARGE. A future bucket (e.g. between MEDIUM and LARGE)
+ * can be inserted in Postgres with `ALTER TYPE ... ADD VALUE 'XYZ' BEFORE 'LARGE'`.
+ */
+export enum CompanySizeEnum {
+  SMALL = 'SMALL',
+  MEDIUM = 'MEDIUM',
+  LARGE = 'LARGE',
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
@@ -5,10 +5,11 @@ import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 import { DoeModels } from '../../../core/constants'
 import type { CreateReportCompanySnapshotDto } from '../../report-create/dto/create-report.dto'
 import type { CompanyDto } from '../dto/company.dto'
+import { CompanySizeEnum } from './company.enums'
 
 type CompanyAttributes = {
   name: string
-  averageEmployeeCountFromRsk: number
+  employeeCountCategory: CompanySizeEnum
   nationalId: string
   salaryReportRequired: boolean
   salaryReportRequiredOverride: boolean
@@ -16,7 +17,7 @@ type CompanyAttributes = {
 
 type CompanyCreateAttributes = {
   name: string
-  averageEmployeeCountFromRsk: number
+  employeeCountCategory: CompanySizeEnum
   nationalId: string
   salaryReportRequired?: boolean
   salaryReportRequiredOverride?: boolean
@@ -31,11 +32,11 @@ export class CompanyModel extends MutableModel<
   name!: string
 
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.ENUM(...Object.values(CompanySizeEnum)),
     allowNull: false,
-    field: 'average_employee_count_from_rsk',
+    field: 'employee_count_category',
   })
-  averageEmployeeCountFromRsk!: number
+  employeeCountCategory!: CompanySizeEnum
 
   @Column({ type: DataType.TEXT, allowNull: false, field: 'national_id' })
   nationalId!: string
@@ -60,7 +61,7 @@ export class CompanyModel extends MutableModel<
     return {
       id: model.id,
       name: model.name,
-      averageEmployeeCountFromRsk: model.averageEmployeeCountFromRsk,
+      employeeCountCategory: model.employeeCountCategory,
       nationalId: model.nationalId,
       salaryReportRequired: model.salaryReportRequired,
       salaryReportRequiredOverride: model.salaryReportRequiredOverride,

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -8,6 +8,7 @@ import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { CompanySizeEnum } from '../company/models/company.enums'
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
@@ -72,8 +73,8 @@ describe('ReportCreateService', () => {
     companyFindAll = jest
       .fn()
       .mockResolvedValue([
-        makeCompanyRow(PARENT_COMPANY_ID, 75),
-        makeCompanyRow(SUBSIDIARY_COMPANY_ID, 25),
+        makeCompanyRow(PARENT_COMPANY_ID, CompanySizeEnum.LARGE),
+        makeCompanyRow(SUBSIDIARY_COMPANY_ID, CompanySizeEnum.MEDIUM),
       ])
     companyReportBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `cr-${i}` })),
@@ -218,7 +219,7 @@ describe('ReportCreateService', () => {
       reportId: REPORT_ID,
       companyId: PARENT_COMPANY_ID,
       parentCompanyId: null,
-      averageEmployeeCountFromRsk: 75,
+      employeeCountCategory: CompanySizeEnum.LARGE,
     })
 
     // 1 role, 1 criterion, 1 sub_criterion, 2 steps, 1 employee.
@@ -291,7 +292,7 @@ describe('ReportCreateService', () => {
     expect(rows[1]).toMatchObject({
       companyId: SUBSIDIARY_COMPANY_ID,
       parentCompanyId: PARENT_COMPANY_ID,
-      averageEmployeeCountFromRsk: 25,
+      employeeCountCategory: CompanySizeEnum.MEDIUM,
     })
   })
 
@@ -563,7 +564,7 @@ describe('ReportCreateService', () => {
       reportId: REPORT_ID,
       companyId: PARENT_COMPANY_ID,
       parentCompanyId: null,
-      averageEmployeeCountFromRsk: 75,
+      employeeCountCategory: CompanySizeEnum.LARGE,
     })
 
     // No criteria, no employees, no role/personal joins, no snapshot.
@@ -603,7 +604,7 @@ describe('ReportCreateService', () => {
     expect(rows[1]).toMatchObject({
       companyId: SUBSIDIARY_COMPANY_ID,
       parentCompanyId: PARENT_COMPANY_ID,
-      averageEmployeeCountFromRsk: 25,
+      employeeCountCategory: CompanySizeEnum.MEDIUM,
     })
   })
 
@@ -746,11 +747,11 @@ function makeCompanySnapshot(
 
 function makeCompanyRow(
   id: string,
-  averageEmployeeCountFromRsk: number,
+  employeeCountCategory: CompanySizeEnum,
 ): CompanyModel {
   return {
     id,
-    averageEmployeeCountFromRsk,
+    employeeCountCategory,
   } as CompanyModel
 }
 

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -447,19 +447,28 @@ export class ReportCreateService implements IReportCreateService {
     }
 
     await this.companyReportModel.bulkCreate(
-      companies.map((company) => ({
-        companyId: company.companyId,
-        reportId,
-        parentCompanyId: company.parentCompanyId,
-        name: company.name,
-        nationalId: company.nationalId,
-        address: company.address,
-        city: company.city,
-        postcode: company.postcode,
-        averageEmployeeCountFromRsk: companyById.get(company.companyId)!
-          .averageEmployeeCountFromRsk,
-        isatCategory: company.isatCategory,
-      })),
+      companies.map((company) => {
+        const stored = companyById.get(company.companyId)
+        // Guaranteed present by the validation loop above; checked again
+        // here purely to narrow the type for the compiler.
+        if (!stored) {
+          throw new BadRequestException(
+            `Company "${company.companyId}" not found`,
+          )
+        }
+        return {
+          companyId: company.companyId,
+          reportId,
+          parentCompanyId: company.parentCompanyId,
+          name: company.name,
+          nationalId: company.nationalId,
+          address: company.address,
+          city: company.city,
+          postcode: company.postcode,
+          employeeCountCategory: stored.employeeCountCategory,
+          isatCategory: company.isatCategory,
+        }
+      }),
     )
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
@@ -4,11 +4,11 @@ import {
   ApiOptionalDateTime,
   ApiOptionalDto,
   ApiOptionalEnum,
-  ApiOptionalNumber,
   ApiOptionalString,
   ApiUUId,
 } from '@dmr.is/decorators'
 
+import { CompanySizeEnum } from '../../company/models/company.enums'
 import { UserDto } from '../../user/dto/user.dto'
 import {
   GenderEnum,
@@ -44,8 +44,11 @@ export class ReportListItemDto {
   @ApiOptionalString({ nullable: true })
   companyIsatCategory!: string | null
 
-  @ApiOptionalNumber({ nullable: true })
-  companyAverageEmployeeCountFromRsk!: number | null
+  @ApiOptionalEnum(CompanySizeEnum, {
+    enumName: 'CompanySizeEnum',
+    nullable: true,
+  })
+  companyEmployeeCountCategory!: CompanySizeEnum | null
 
   @ApiOptionalString({ nullable: true })
   companyAdminName!: string | null

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -377,8 +377,8 @@ export class ReportModel extends MutableModel<
       companyName: model.companyReport?.name ?? null,
       companyNationalId: model.companyReport?.nationalId ?? null,
       companyIsatCategory: model.companyReport?.isatCategory ?? null,
-      companyAverageEmployeeCountFromRsk:
-        model.companyReport?.averageEmployeeCountFromRsk ?? null,
+      companyEmployeeCountCategory:
+        model.companyReport?.employeeCountCategory ?? null,
       companyAdminName: model.companyAdminName,
       companyAdminEmail: model.companyAdminEmail,
       companyAdminGender: model.companyAdminGender,

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -4,6 +4,7 @@ import { Op } from 'sequelize'
 
 import type { Logger } from '@dmr.is/logging'
 
+import { CompanySizeEnum } from '../company/models/company.enums'
 import type { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { ReportStatusEnum, ReportTypeEnum } from './models/report.enums'
 import type { ReportModel } from './models/report.model'
@@ -39,7 +40,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
       name: 'Blámi hf.',
       nationalId: '4703013920',
       isatCategory: '62.01.0',
-      averageEmployeeCountFromRsk: 25,
+      employeeCountCategory: CompanySizeEnum.MEDIUM,
     },
     reviewer: null,
     ...overrides,
@@ -53,7 +54,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
           name?: string
           nationalId?: string
           isatCategory?: string
-          averageEmployeeCountFromRsk?: number
+          employeeCountCategory?: CompanySizeEnum
         }
       | null
     return {
@@ -64,8 +65,8 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
       companyName: companyReport?.name ?? null,
       companyNationalId: companyReport?.nationalId ?? null,
       companyIsatCategory: companyReport?.isatCategory ?? null,
-      companyAverageEmployeeCountFromRsk:
-        companyReport?.averageEmployeeCountFromRsk ?? null,
+      companyEmployeeCountCategory:
+        companyReport?.employeeCountCategory ?? null,
       companyAdminName: row.companyAdminName,
       companyAdminEmail: row.companyAdminEmail,
       companyAdminGender: row.companyAdminGender,
@@ -398,7 +399,7 @@ describe('ReportService.getById', () => {
       address: 'Hafnarstræti 5',
       city: 'Reykjavík',
       postcode: '101',
-      averageEmployeeCountFromRsk: 45,
+      employeeCountCategory: CompanySizeEnum.MEDIUM,
       isatCategory: '62010',
     },
     comments: [],
@@ -611,7 +612,7 @@ describe('ReportService.getById', () => {
         address: 'Hafnarstræti 6',
         city: 'Reykjavík',
         postcode: '101',
-        averageEmployeeCountFromRsk: 12,
+        employeeCountCategory: CompanySizeEnum.SMALL,
         isatCategory: '62010',
       }
       companyReportFindAll.mockResolvedValueOnce([


### PR DESCRIPTION
Introduce company size count category.

WHY? Because we dont have concrete numbers of employee counts. We get bucket information about company. This handles that case.