### PR TITLE
feat(doe): Pre insert guard

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260522-withdrawn-status-and-event.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260522-withdrawn-status-and-event.js
@@ -1,0 +1,101 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- ============================================================
+    -- 1. WITHDRAWN status.
+    --
+    -- Terminal status assigned to a SUBMITTED report when the same
+    -- company submits a new report of the same type. The applicant
+    -- has changed their mind before any reviewer touched the prior
+    -- submission, so it is safe to silently retire the old row and
+    -- accept the new one in its place. IN_REVIEW / POSTPONED prior
+    -- reports are NOT auto-withdrawn — those flows are active and
+    -- the new submission is rejected with 409 instead.
+    -- ============================================================
+
+    ALTER TYPE report_status_enum ADD VALUE IF NOT EXISTS 'WITHDRAWN';
+
+    -- ============================================================
+    -- 2. WITHDRAWN event type.
+    --
+    -- Emitted on the withdrawn report, with related_report_id
+    -- pointing at the new report that replaced it (mirroring the
+    -- SUPERSEDED event shape).
+    -- ============================================================
+
+    ALTER TYPE report_event_type_enum ADD VALUE IF NOT EXISTS 'WITHDRAWN';
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- Postgres has no native DROP VALUE for enums. Reversing WITHDRAWN
+    -- requires the rename-recreate dance. In dev (no live data) the
+    -- forward direction is the one that matters; this down() is
+    -- best-effort and will fail if any row currently holds the value
+    -- being removed. Resolve such rows manually before running down().
+
+    ALTER TYPE report_event_type_enum RENAME TO report_event_type_enum_new;
+
+    CREATE TYPE report_event_type_enum AS ENUM (
+      'SUBMITTED',
+      'ASSIGNED',
+      'UNASSIGNED',
+      'STATUS_CHANGED',
+      'SUPERSEDED',
+      'EDITED'
+    );
+
+    ALTER TABLE report_event
+      ALTER COLUMN event_type TYPE report_event_type_enum
+      USING event_type::text::report_event_type_enum;
+
+    DROP TYPE report_event_type_enum_new;
+
+    ALTER TYPE report_status_enum RENAME TO report_status_enum_new;
+
+    CREATE TYPE report_status_enum AS ENUM (
+      'DRAFT',
+      'SUBMITTED',
+      'POSTPONED',
+      'IN_REVIEW',
+      'DENIED',
+      'APPROVED',
+      'SUPERSEDED'
+    );
+
+    ALTER TABLE report
+      ALTER COLUMN status TYPE report_status_enum
+      USING status::text::report_status_enum;
+
+    ALTER TABLE report_event
+      ALTER COLUMN report_status TYPE report_status_enum
+      USING report_status::text::report_status_enum;
+
+    ALTER TABLE report_event
+      ALTER COLUMN from_status TYPE report_status_enum
+      USING from_status::text::report_status_enum;
+
+    ALTER TABLE report_event
+      ALTER COLUMN to_status TYPE report_status_enum
+      USING to_status::text::report_status_enum;
+
+    ALTER TABLE report_comment
+      ALTER COLUMN report_status TYPE report_status_enum
+      USING report_status::text::report_status_enum;
+
+    DROP TYPE report_status_enum_new;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -50,10 +50,14 @@ describe('ReportCreateService', () => {
   let service: ReportCreateService
   let reportCreate: jest.Mock
   let reportFindOne: jest.Mock
+  let reportFindAll: jest.Mock
+  let reportUpdate: jest.Mock
   let reportEventCreate: jest.Mock
   let companyFindAll: jest.Mock
+  let companyFindOne: jest.Mock
   let companyReportBulkCreate: jest.Mock
   let companyReportFindOne: jest.Mock
+  let companyReportFindAll: jest.Mock
   let roleBulkCreate: jest.Mock
   let employeeBulkCreate: jest.Mock
   let roleStepBulkCreate: jest.Mock
@@ -68,6 +72,8 @@ describe('ReportCreateService', () => {
   beforeEach(async () => {
     reportCreate = jest.fn().mockResolvedValue({ id: REPORT_ID })
     reportFindOne = jest.fn().mockResolvedValue({ id: EQUALITY_REPORT_ID })
+    reportFindAll = jest.fn().mockResolvedValue([])
+    reportUpdate = jest.fn().mockResolvedValue([0])
     reportEventCreate = jest.fn().mockResolvedValue({ id: 'event-1' })
     companyFindAll = jest
       .fn()
@@ -75,10 +81,12 @@ describe('ReportCreateService', () => {
         makeCompanyRow(PARENT_COMPANY_ID, 75),
         makeCompanyRow(SUBSIDIARY_COMPANY_ID, 25),
       ])
+    companyFindOne = jest.fn().mockResolvedValue({ id: PARENT_COMPANY_ID })
     companyReportBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `cr-${i}` })),
     )
     companyReportFindOne = jest.fn().mockResolvedValue(null)
+    companyReportFindAll = jest.fn().mockResolvedValue([])
     roleBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `role-${i}` })),
     )
@@ -125,7 +133,12 @@ describe('ReportCreateService', () => {
         { provide: LOGGER_PROVIDER, useValue: mockLogger },
         {
           provide: getModelToken(ReportModel),
-          useValue: { create: reportCreate, findOne: reportFindOne },
+          useValue: {
+            create: reportCreate,
+            findOne: reportFindOne,
+            findAll: reportFindAll,
+            update: reportUpdate,
+          },
         },
         {
           provide: getModelToken(ReportEventModel),
@@ -133,13 +146,14 @@ describe('ReportCreateService', () => {
         },
         {
           provide: getModelToken(CompanyModel),
-          useValue: { findAll: companyFindAll },
+          useValue: { findAll: companyFindAll, findOne: companyFindOne },
         },
         {
           provide: getModelToken(CompanyReportModel),
           useValue: {
             bulkCreate: companyReportBulkCreate,
             findOne: companyReportFindOne,
+            findAll: companyReportFindAll,
           },
         },
         {
@@ -724,6 +738,215 @@ describe('ReportCreateService', () => {
 
       expect(reportCreate).toHaveBeenCalled()
       expect(companyReportFindOne).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('in-flight sibling guard', () => {
+    const PRIOR_REPORT_ID = '00000000-0000-0000-0000-0000000000aa'
+
+    function mockPriorSibling(status: ReportStatusEnum, providerId = 'prior-1') {
+      companyReportFindAll.mockResolvedValueOnce([
+        { reportId: PRIOR_REPORT_ID },
+      ])
+      reportFindAll.mockResolvedValueOnce([
+        { id: PRIOR_REPORT_ID, status, providerId },
+      ])
+    }
+
+    it('SALARY: withdraws a SUBMITTED predecessor and emits a WITHDRAWN event linked to the new report', async () => {
+      mockPriorSibling(ReportStatusEnum.SUBMITTED, 'prior-providerId')
+
+      const result = await service.createSalary(makeInput())
+
+      expect(result).toEqual({ reportId: REPORT_ID })
+      expect(reportUpdate).toHaveBeenCalledWith(
+        { status: ReportStatusEnum.WITHDRAWN },
+        { where: { id: [PRIOR_REPORT_ID] } },
+      )
+      // SUBMITTED event for the new report + WITHDRAWN event for the prior.
+      expect(reportEventCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reportId: REPORT_ID,
+          eventType: 'SUBMITTED',
+        }),
+      )
+      expect(reportEventCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reportId: PRIOR_REPORT_ID,
+          eventType: 'WITHDRAWN',
+          reportStatus: ReportStatusEnum.WITHDRAWN,
+          relatedReportId: REPORT_ID,
+          actorUserId: null,
+        }),
+      )
+    })
+
+    it('SALARY: rejects with 409 when an IN_REVIEW predecessor exists, no insert, no withdraw, no events', async () => {
+      mockPriorSibling(ReportStatusEnum.IN_REVIEW, 'prior-providerId')
+
+      await expect(service.createSalary(makeInput())).rejects.toThrow(
+        ConflictException,
+      )
+
+      expect(reportCreate).not.toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+      expect(reportEventCreate).not.toHaveBeenCalled()
+    })
+
+    it('SALARY: rejects with 409 when a POSTPONED predecessor exists', async () => {
+      mockPriorSibling(ReportStatusEnum.POSTPONED, 'prior-providerId')
+
+      await expect(service.createSalary(makeInput())).rejects.toThrow(
+        ConflictException,
+      )
+
+      expect(reportCreate).not.toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+    })
+
+    it('SALARY: proceeds normally when no in-flight sibling exists', async () => {
+      // Default mocks: companyReportFindAll → [], reportFindAll → [].
+      await service.createSalary(makeInput())
+
+      expect(reportCreate).toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+      // No WITHDRAWN event emitted.
+      const withdrawnEventCalls = reportEventCreate.mock.calls.filter(
+        ([row]) => row.eventType === 'WITHDRAWN',
+      )
+      expect(withdrawnEventCalls).toHaveLength(0)
+    })
+
+    it('SALARY: ignores prior reports in terminal statuses (APPROVED / DENIED / SUPERSEDED / WITHDRAWN)', async () => {
+      companyReportFindAll.mockResolvedValueOnce([
+        { reportId: PRIOR_REPORT_ID },
+      ])
+      // The Sequelize WHERE clause filters status server-side, so a terminal
+      // prior simulates as "findAll returns no in-flight rows for this filter".
+      reportFindAll.mockResolvedValueOnce([])
+
+      await service.createSalary(makeInput())
+
+      expect(reportCreate).toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+    })
+
+    it('SALARY: scopes the guard by type — an in-flight EQUALITY does not block a new SALARY submission', async () => {
+      // The guard queries reportModel.findAll with WHERE type=SALARY. If an
+      // EQUALITY is in flight, the SQL filter excludes it, so the mock for the
+      // SALARY-scoped findAll returns [].
+      companyReportFindAll.mockResolvedValueOnce([
+        { reportId: PRIOR_REPORT_ID },
+      ])
+      reportFindAll.mockResolvedValueOnce([])
+
+      await service.createSalary(makeInput())
+
+      // The findAll WHERE asserted explicitly for confidence.
+      expect(reportFindAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ type: ReportTypeEnum.SALARY }),
+        }),
+      )
+      expect(reportCreate).toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+    })
+
+    it('SALARY: locks the company row to serialise concurrent submits', async () => {
+      mockPriorSibling(ReportStatusEnum.SUBMITTED)
+
+      await service.createSalary(makeInput())
+
+      expect(companyFindOne).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: PARENT_COMPANY_ID },
+          lock: true,
+        }),
+      )
+    })
+
+    it('EQUALITY: withdraws a SUBMITTED predecessor and emits a linked WITHDRAWN event', async () => {
+      mockPriorSibling(ReportStatusEnum.SUBMITTED, 'prior-equality')
+
+      const result = await service.createEquality(makeEqualityInput())
+
+      expect(result).toEqual({ reportId: REPORT_ID })
+      expect(reportUpdate).toHaveBeenCalledWith(
+        { status: ReportStatusEnum.WITHDRAWN },
+        { where: { id: [PRIOR_REPORT_ID] } },
+      )
+      expect(reportEventCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reportId: PRIOR_REPORT_ID,
+          eventType: 'WITHDRAWN',
+          relatedReportId: REPORT_ID,
+        }),
+      )
+    })
+
+    it('EQUALITY: rejects with 409 when an IN_REVIEW predecessor exists', async () => {
+      mockPriorSibling(ReportStatusEnum.IN_REVIEW, 'prior-equality')
+
+      await expect(service.createEquality(makeEqualityInput())).rejects.toThrow(
+        ConflictException,
+      )
+
+      expect(reportCreate).not.toHaveBeenCalled()
+      expect(reportUpdate).not.toHaveBeenCalled()
+    })
+
+    it('EQUALITY: scopes the guard by type — an in-flight SALARY does not block a new EQUALITY submission', async () => {
+      companyReportFindAll.mockResolvedValueOnce([
+        { reportId: PRIOR_REPORT_ID },
+      ])
+      reportFindAll.mockResolvedValueOnce([])
+
+      await service.createEquality(makeEqualityInput())
+
+      expect(reportFindAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ type: ReportTypeEnum.EQUALITY }),
+        }),
+      )
+      expect(reportCreate).toHaveBeenCalled()
+    })
+
+    it('withdraws multiple SUBMITTED predecessors defensively (data drift before the guard was added)', async () => {
+      const OTHER_PRIOR_ID = '00000000-0000-0000-0000-0000000000bb'
+      companyReportFindAll.mockResolvedValueOnce([
+        { reportId: PRIOR_REPORT_ID },
+        { reportId: OTHER_PRIOR_ID },
+      ])
+      reportFindAll.mockResolvedValueOnce([
+        {
+          id: PRIOR_REPORT_ID,
+          status: ReportStatusEnum.SUBMITTED,
+          providerId: 'a',
+        },
+        {
+          id: OTHER_PRIOR_ID,
+          status: ReportStatusEnum.SUBMITTED,
+          providerId: 'b',
+        },
+      ])
+
+      await service.createSalary(makeInput())
+
+      expect(reportUpdate).toHaveBeenCalledWith(
+        { status: ReportStatusEnum.WITHDRAWN },
+        { where: { id: [PRIOR_REPORT_ID, OTHER_PRIOR_ID] } },
+      )
+      // Two WITHDRAWN events, one per prior, both pointing at the new report.
+      const withdrawnCalls = reportEventCreate.mock.calls.filter(
+        ([row]) => row.eventType === 'WITHDRAWN',
+      )
+      expect(withdrawnCalls).toHaveLength(2)
+      expect(withdrawnCalls.map(([row]) => row.reportId)).toEqual([
+        PRIOR_REPORT_ID,
+        OTHER_PRIOR_ID,
+      ])
+      expect(withdrawnCalls.every(([row]) => row.relatedReportId === REPORT_ID))
+        .toBe(true)
     })
   })
 })

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -118,6 +118,12 @@ export class ReportCreateService implements IReportCreateService {
     await this.assertOutliersMatchDetectedOutliers(input, employeeScores)
 
     await this.assertEqualityReportApproved(input.equalityReportId)
+
+    const withdrawnReportIds = await this.withdrawOrRejectInflightSibling(
+      submittingCompany.companyId,
+      ReportTypeEnum.SALARY,
+    )
+
     const outliersPostponed = input.outliersPostponed ?? false
 
     // 1. report row. Status splits on the postponement choice:
@@ -296,6 +302,10 @@ export class ReportCreateService implements IReportCreateService {
       companyId: submittingCompany.companyId,
     })
 
+    // 11. WITHDRAWN audit events — one per predecessor we just retired, each
+    //     linked to the new report that replaced it.
+    await this.emitWithdrawnEvents(withdrawnReportIds, report.id)
+
     return { reportId: report.id }
   }
 
@@ -317,6 +327,11 @@ export class ReportCreateService implements IReportCreateService {
     if (replay) {
       return replay
     }
+
+    const withdrawnReportIds = await this.withdrawOrRejectInflightSibling(
+      submittingCompany.companyId,
+      ReportTypeEnum.EQUALITY,
+    )
 
     const report = await this.reportModel.create({
       type: ReportTypeEnum.EQUALITY,
@@ -350,7 +365,109 @@ export class ReportCreateService implements IReportCreateService {
       companyId: submittingCompany.companyId,
     })
 
+    await this.emitWithdrawnEvents(withdrawnReportIds, report.id)
+
     return { reportId: report.id }
+  }
+
+  /**
+   * Pre-insert guard for submissions: a company may not have more than one
+   * in-flight report of a given type at the same time. Policy by status of
+   * the existing sibling:
+   *
+   * - SUBMITTED → silently withdraw the prior report. The applicant changed
+   *   their mind before any reviewer interaction, so retiring the old row is
+   *   safe; the new submission takes its place.
+   * - IN_REVIEW or POSTPONED → reject with 409. The reviewer (or the
+   *   postponement-resolution flow) is mid-workflow on the prior report and
+   *   it cannot be discarded silently.
+   *
+   * Returns the ids of any reports that were withdrawn so the caller can
+   * emit one WITHDRAWN event per retiree linked to the new replacing report.
+   *
+   * Concurrency: the helper takes an exclusive row-lock on the company row
+   * before checking siblings, serialising concurrent submits for the same
+   * company. Without this lock, two simultaneous submits could each observe
+   * no in-flight sibling (or the same SUBMITTED predecessor) and both
+   * proceed to insert, leaving two SUBMITTED reports behind.
+   */
+  private async withdrawOrRejectInflightSibling(
+    companyId: string,
+    type: ReportTypeEnum,
+  ): Promise<string[]> {
+    await this.companyModel.findOne({
+      where: { id: companyId },
+      attributes: ['id'],
+      lock: true,
+    })
+
+    const inflightStatuses = [
+      ReportStatusEnum.SUBMITTED,
+      ReportStatusEnum.IN_REVIEW,
+      ReportStatusEnum.POSTPONED,
+    ]
+
+    const parentSnapshots = await this.companyReportModel.findAll({
+      where: { companyId, parentCompanyId: null },
+      attributes: ['reportId'],
+    })
+
+    if (parentSnapshots.length === 0) {
+      return []
+    }
+
+    const candidateIds = parentSnapshots.map((row) => row.reportId)
+
+    const siblings = await this.reportModel.findAll({
+      where: {
+        id: { [Op.in]: candidateIds },
+        type,
+        status: { [Op.in]: inflightStatuses },
+      },
+    })
+
+    if (siblings.length === 0) {
+      return []
+    }
+
+    const blocking = siblings.find(
+      (sibling) =>
+        sibling.status === ReportStatusEnum.IN_REVIEW ||
+        sibling.status === ReportStatusEnum.POSTPONED,
+    )
+    if (blocking) {
+      throw new ConflictException(
+        `Company already has a ${type} report in status ${blocking.status} (providerId: ${blocking.providerId ?? 'n/a'}). Resolve it before submitting another.`,
+      )
+    }
+
+    const withdrawnIds = siblings.map((sibling) => sibling.id)
+    await this.reportModel.update(
+      { status: ReportStatusEnum.WITHDRAWN },
+      { where: { id: withdrawnIds } },
+    )
+
+    this.logger.info(
+      `Withdrew ${withdrawnIds.length} SUBMITTED ${type} report(s) for company ${companyId}`,
+      { context: LOGGING_CONTEXT, withdrawnIds },
+    )
+
+    return withdrawnIds
+  }
+
+  private async emitWithdrawnEvents(
+    withdrawnReportIds: string[],
+    replacingReportId: string,
+  ): Promise<void> {
+    for (const withdrawnId of withdrawnReportIds) {
+      await this.reportEventModel.create({
+        reportId: withdrawnId,
+        eventType: ReportEventTypeEnum.WITHDRAWN,
+        reportStatus: ReportStatusEnum.WITHDRAWN,
+        actorUserId: null,
+        relatedReportId: replacingReportId,
+      })
+    }
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
@@ -25,6 +25,7 @@ export interface IReportEventService {
     reportStatus: ReportStatusEnum,
     companyId: string,
   ): Promise<void>
+  emitWithdrawn(reportId: string, relatedReportId: string): Promise<void>
 }
 
 export const IReportEventService = Symbol('IReportEventService')

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
@@ -133,4 +133,23 @@ export class ReportEventService implements IReportEventService {
       relatedReportId,
     })
   }
+
+  async emitWithdrawn(
+    reportId: string,
+    relatedReportId: string,
+  ): Promise<void> {
+    this.logger.info(`Emitting WITHDRAWN event for report ${reportId}`, {
+      context: LOGGING_CONTEXT,
+      reportId: reportId,
+      relatedReportId: relatedReportId,
+    })
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.WITHDRAWN,
+      actorUserId: null,
+      reportStatus: ReportStatusEnum.WITHDRAWN,
+      relatedReportId,
+    })
+  }
 }

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -15,6 +15,7 @@ export enum ReportEventTypeEnum {
   STATUS_CHANGED = 'STATUS_CHANGED',
   SUPERSEDED = 'SUPERSEDED',
   EDITED = 'EDITED',
+  WITHDRAWN = 'WITHDRAWN',
 }
 
 type ReportEventAttributes = {

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.enums.ts
@@ -18,6 +18,7 @@ export enum ReportStatusEnum {
   DENIED = 'DENIED',
   APPROVED = 'APPROVED',
   SUPERSEDED = 'SUPERSEDED',
+  WITHDRAWN = 'WITHDRAWN',
 }
 
 export enum GenderEnum {

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -194,6 +194,32 @@ describe('ReportService.list — filter & query building', () => {
     })
   })
 
+  it('default-excludes WITHDRAWN reports when no status filter is supplied', async () => {
+    const { service, findAndCountAll } = makeService()
+    findAndCountAll.mockResolvedValueOnce({ rows: [], count: 0 })
+
+    await service.list(baseQuery({}))
+
+    const where = findAndCountAll.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >
+    expect(where.status).toEqual({ [Op.ne]: ReportStatusEnum.WITHDRAWN })
+  })
+
+  it('allows callers to explicitly request WITHDRAWN via the status filter', async () => {
+    const { service, findAndCountAll } = makeService()
+    findAndCountAll.mockResolvedValueOnce({ rows: [], count: 0 })
+
+    await service.list(baseQuery({ status: [ReportStatusEnum.WITHDRAWN] }))
+
+    const where = findAndCountAll.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >
+    expect(where.status).toEqual({ [Op.in]: [ReportStatusEnum.WITHDRAWN] })
+  })
+
   it('prefers unassignedReviewer over reviewerUserId when both are given', async () => {
     const { service, findAndCountAll } = makeService()
     findAndCountAll.mockResolvedValueOnce({ rows: [], count: 0 })

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -552,6 +552,12 @@ export class ReportService implements IReportService {
     }
     if (query.status?.length) {
       Object.assign(where, { status: { [Op.in]: query.status } })
+    } else {
+      // Withdrawn reports are not surfaced in admin list views by default.
+      // Callers can still request them explicitly via `query.status`.
+      Object.assign(where, {
+        status: { [Op.ne]: ReportStatusEnum.WITHDRAWN },
+      })
     }
 
     // `unassignedReviewer` deliberately overrides `reviewerUserId` — the


### PR DESCRIPTION
#### Pre insert guard

```
 * Pre-insert guard for submissions: a company may not have more than one
   * in-flight report of a given type at the same time. Policy by status of
   * the existing sibling:
   *
   * - SUBMITTED → silently withdraw the prior report. The applicant changed
   *   their mind before any reviewer interaction, so retiring the old row is
   *   safe; the new submission takes its place.
   * - IN_REVIEW or POSTPONED → reject with 409. The reviewer (or the
   *   postponement-resolution flow) is mid-workflow on the prior report and
   *   it cannot be discarded silently.
   ```