### PR TITLE
feat(doe): improvement plan addition

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -11,6 +11,7 @@ import {
   ParseFilePipe,
   Post,
   Put,
+  Query,
   StreamableFile,
   UploadedFile,
   UseGuards,
@@ -25,6 +26,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 
+import { PagingQuery } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { AutoProvisionCompany } from '../../core/decorators/auto-provision-company.decorator'
@@ -34,6 +36,7 @@ import { CompanyResourceGuard } from '../../core/guards/company-resource/company
 import { CompanyDto } from '../company/dto/company.dto'
 import { EqualityReportSummaryDto } from '../report/dto/equality-report-summary.dto'
 import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { ParsedReportDto } from '../report-excel/dto/parsed-report.dto'
 import { IReportExcelService } from '../report-excel/report-excel.service.interface'
 import { ApplicationReportCommentDto } from './dto/application-report-comment.dto'
@@ -221,6 +224,28 @@ export class ApplicationController {
     @CurrentCompany() company: CompanyDto,
   ): Promise<ApplicationReportDetailDto> {
     return this.applicationService.getReport(providerId, company)
+  }
+
+  @Get('reports/:providerId/outliers')
+  @ApiParam({
+    name: 'providerId',
+    type: String,
+    description:
+      'Upstream submission ID (e.g. the island.is application UUID).',
+  })
+  @DoeResponse({
+    operationId: 'getApplicationReportOutliers',
+    include404: true,
+    description:
+      'Paginated list of the report\'s employee outliers. Split out from the report-detail payload because a single salary report can carry hundreds of rows. Ordered by `employeeOrdinal` ascending.',
+    type: GetReportOutliersResponseDto,
+  })
+  async getReportOutliers(
+    @Param('providerId') providerId: string,
+    @CurrentCompany() company: CompanyDto,
+    @Query() query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto> {
+    return this.applicationService.getReportOutliers(providerId, company, query)
   }
 
   @Post('reports/:providerId/comments')

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
@@ -1,6 +1,9 @@
+import { PagingQuery } from '@dmr.is/shared-dto'
+
 import { CompanyDto } from '../company/dto/company.dto'
 import { EqualityReportSummaryDto } from '../report/dto/equality-report-summary.dto'
 import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { ApplicationReportCommentDto } from './dto/application-report-comment.dto'
 import { ApplicationReportDetailDto } from './dto/application-report-detail.dto'
 import { EditEqualityContentDto } from './dto/edit-equality-content.dto'
@@ -31,6 +34,11 @@ export interface IApplicationService {
     providerId: string,
     company: CompanyDto,
   ): Promise<ApplicationReportDetailDto>
+  getReportOutliers(
+    providerId: string,
+    company: CompanyDto,
+    query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto>
   createReportComment(
     providerId: string,
     input: SubmitApplicationReportCommentDto,

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -70,6 +70,8 @@ describe('ApplicationService', () => {
   let reportUpdate: jest.Mock
   let companyReportFindAll: jest.Mock
   let outlierFindAll: jest.Mock
+  let outlierFindAndCountAll: jest.Mock
+  let outlierCount: jest.Mock
   let outlierUpdate: jest.Mock
   let eventFindOne: jest.Mock
   let getCommentsByReportId: jest.Mock
@@ -93,6 +95,10 @@ describe('ApplicationService', () => {
     reportUpdate = jest.fn().mockResolvedValue([1])
     companyReportFindAll = jest.fn().mockResolvedValue([])
     outlierFindAll = jest.fn().mockResolvedValue([])
+    outlierFindAndCountAll = jest
+      .fn()
+      .mockResolvedValue({ rows: [], count: 0 })
+    outlierCount = jest.fn().mockResolvedValue(0)
     outlierUpdate = jest.fn().mockResolvedValue([1])
     eventFindOne = jest.fn().mockResolvedValue(null)
     getCommentsByReportId = jest.fn().mockResolvedValue([])
@@ -152,7 +158,12 @@ describe('ApplicationService', () => {
         },
         {
           provide: getModelToken(ReportEmployeeOutlierModel),
-          useValue: { findAll: outlierFindAll, update: outlierUpdate },
+          useValue: {
+            findAll: outlierFindAll,
+            findAndCountAll: outlierFindAndCountAll,
+            count: outlierCount,
+            update: outlierUpdate,
+          },
         },
         {
           provide: getModelToken(ReportEventModel),
@@ -543,7 +554,7 @@ describe('ApplicationService', () => {
         }),
       ])
       getResultByReportId.mockResolvedValueOnce(reportResult)
-      outlierFindAll.mockResolvedValueOnce([outlier])
+      outlierCount.mockResolvedValueOnce(1)
       getCommentsByReportId.mockResolvedValueOnce([externalComment])
 
       const result = await service.getReport(PROVIDER_ID, COMPANY)
@@ -565,6 +576,7 @@ describe('ApplicationService', () => {
         submittedAt,
         equalityReportContent: null,
         outliersPostponed: false,
+        includesImprovementPlan: true,
         result: reportResult,
         externalComments: [slimExternalComment],
         denialReason: null,
@@ -576,18 +588,10 @@ describe('ApplicationService', () => {
         approvedAt,
         validUntil,
       })
-      expect(result.outliers).toEqual([
-        {
-          id: outlier.id,
-          reportEmployeeId: outlier.reportEmployeeId,
-          gender: GenderEnum.FEMALE,
-          roleTitle: 'Manager',
-          reason: outlier.reason,
-          action: outlier.action,
-          signatureName: outlier.signatureName,
-          signatureRole: outlier.signatureRole,
-        },
-      ])
+      // outlier row reference retained so the mock factory stays in use for
+      // the editOutliers tests below; the detail payload itself no longer
+      // includes the outlier list.
+      expect(outlier.id).toBe('outlier-1')
       expect(getCommentsByReportId).toHaveBeenCalledWith(
         expect.objectContaining({
           reportId: REPORT_ID,
@@ -620,11 +624,11 @@ describe('ApplicationService', () => {
 
       expect(result.equalityReport).toBeNull()
       expect(result.equalityReportContent).toBe('Equality plan narrative')
-      expect(result.outliers).toEqual([])
+      expect(result.includesImprovementPlan).toBe(false)
       expect(result.outliersPostponed).toBeNull()
       expect(result.result).toBeNull()
       expect(getResultByReportId).not.toHaveBeenCalled()
-      expect(outlierFindAll).not.toHaveBeenCalled()
+      expect(outlierCount).not.toHaveBeenCalled()
     })
 
     it('surfaces the latest denial reason when the report is DENIED', async () => {

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -10,6 +10,11 @@ import {
 import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { PagingQuery } from '@dmr.is/shared-dto'
+import {
+  generatePaging,
+  getLimitAndOffset,
+} from '@dmr.is/utils-server/serverUtils'
 
 import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
@@ -49,6 +54,7 @@ import {
 } from '../report-create/dto/create-report.dto'
 import { CreateReportResponseDto } from '../report-create/dto/create-report-response.dto'
 import { IReportCreateService } from '../report-create/report-create.service.interface'
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
@@ -279,7 +285,7 @@ export class ApplicationService implements IApplicationService {
         report.type === ReportTypeEnum.SALARY
           ? report.status === ReportStatusEnum.POSTPONED
           : null,
-      outliers: salaryData.outliers,
+      includesImprovementPlan: salaryData.includesImprovementPlan,
       result: salaryData.result,
       externalComments: externalComments.map(
         ApplicationReportCommentDto.fromReportComment,
@@ -709,30 +715,25 @@ export class ApplicationService implements IApplicationService {
 
   private async loadSalaryData(report: ReportModel): Promise<{
     result: ReportResultDto | null
-    outliers: ApplicationReportDetailDto['outliers']
+    includesImprovementPlan: boolean
   }> {
     if (report.type !== ReportTypeEnum.SALARY) {
-      return { result: null, outliers: [] }
+      return { result: null, includesImprovementPlan: false }
     }
 
-    const [result, outlierRows] = await Promise.all([
+    // Outlier rows themselves are served by the paginated
+    // `GET /application/reports/:providerId/outliers` endpoint — the detail
+    // view only needs the boolean indicator.
+    const [result, outlierCount] = await Promise.all([
       this.getReportResultOrNull(report.id),
-      this.reportEmployeeOutlierModel.findAll({
+      this.reportEmployeeOutlierModel.count({
         include: [
           {
             model: ReportEmployeeModel,
             as: 'reportEmployee',
-            attributes: ['gender'],
+            attributes: [],
             where: { reportId: report.id },
             required: true,
-            include: [
-              {
-                model: ReportEmployeeRoleModel,
-                as: 'role',
-                attributes: ['title'],
-                required: true,
-              },
-            ],
           },
         ],
       }),
@@ -740,10 +741,77 @@ export class ApplicationService implements IApplicationService {
 
     return {
       result,
-      outliers: outlierRows.map((row) =>
-        ReportEmployeeOutlierModel.fromModel(row),
-      ),
+      includesImprovementPlan: outlierCount > 0,
     }
+  }
+
+  async getReportOutliers(
+    providerId: string,
+    company: CompanyDto,
+    query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto> {
+    this.logger.debug('Listing report outliers from application portal', {
+      context: LOGGING_CONTEXT,
+      companyId: company.id,
+      providerId,
+    })
+
+    const report = await this.findOwnedReportByProviderTuple(
+      providerId,
+      company,
+    )
+
+    const { limit, offset } = getLimitAndOffset(query)
+
+    const [result, { rows, count }] = await Promise.all([
+      this.getReportResultOrNull(report.id),
+      this.reportEmployeeOutlierModel.findAndCountAll({
+        include: [
+          {
+            model: ReportEmployeeModel,
+            as: 'reportEmployee',
+            attributes: ['id', 'ordinal', 'gender'],
+            where: { reportId: report.id },
+            required: true,
+            include: [
+              {
+                model: ReportEmployeeRoleModel,
+                as: 'role',
+                attributes: ['id', 'title'],
+                required: false,
+              },
+            ],
+          },
+        ],
+        order: [
+          [{ model: ReportEmployeeModel, as: 'reportEmployee' }, 'ordinal', 'ASC'],
+        ],
+        limit,
+        offset,
+        distinct: true,
+        subQuery: false,
+      }),
+    ])
+
+    const analysisByOrdinal = new Map(
+      result?.outlierAnalysis.employees.map((employee) => [
+        employee.ordinal,
+        employee,
+      ]) ?? [],
+    )
+
+    const outliers = rows.map((row) =>
+      ReportEmployeeOutlierModel.fromModel(
+        row,
+        row.reportEmployee
+          ? analysisByOrdinal.get(row.reportEmployee.ordinal) ?? null
+          : null,
+      ),
+    )
+
+    const paging = generatePaging(outliers, query.page, query.pageSize, count)
+
+    return { outliers, paging }
   }
 
   private async getReportResultOrNull(

--- a/apps/directorate-of-equality-api/src/modules/application/dto/application-report-detail.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/application-report-detail.dto.ts
@@ -1,4 +1,5 @@
 import {
+  ApiBoolean,
   ApiDtoArray,
   ApiEnum,
   ApiOptionalBoolean,
@@ -14,7 +15,6 @@ import {
   ReportStatusEnum,
   ReportTypeEnum,
 } from '../../report/models/report.enums'
-import { ReportEmployeeOutlierDto } from '../../report-employee/dto/report-employee-outlier.dto'
 import { ReportResultDto } from '../../report-result/dto/report-result.dto'
 import { ApplicationReportCommentDto } from './application-report-comment.dto'
 
@@ -59,8 +59,11 @@ export class ApplicationReportDetailDto {
   })
   outliersPostponed!: boolean | null
 
-  @ApiDtoArray(ReportEmployeeOutlierDto)
-  outliers!: ReportEmployeeOutlierDto[]
+  @ApiBoolean({
+    description:
+      'True when the report has at least one employee outlier. The full list is fetched separately via `GET /application/reports/:providerId/outliers`.',
+  })
+  includesImprovementPlan!: boolean
 
   @ApiOptionalDto(ReportResultDto, { nullable: true })
   result!: ReportResultDto | null

--- a/apps/directorate-of-equality-api/src/modules/report-employee/dto/get-report-outliers-response.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/dto/get-report-outliers-response.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+import { Paging } from '@dmr.is/shared-dto'
+
+import { ReportEmployeeOutlierDto } from './report-employee-outlier.dto'
+
+/**
+ * Paginated list of a single report's outliers. Used by both the admin
+ * (`GET /reports/:id/outliers`) and applicant (`GET /application/reports/:providerId/outliers`)
+ * endpoints — the shape is identical because the underlying row is the same.
+ *
+ * The endpoint was split out from the report-detail payload because a
+ * single report can legitimately have hundreds of outliers, and the detail
+ * view does not always need the full list (only a "do outliers exist"
+ * indicator). Callers that just need the indicator should read
+ * `includesImprovementPlan` from the detail response instead of paginating
+ * an empty list.
+ */
+export class GetReportOutliersResponseDto {
+  @ApiProperty({ type: [ReportEmployeeOutlierDto] })
+  outliers!: ReportEmployeeOutlierDto[]
+
+  @ApiProperty({ type: Paging })
+  paging!: Paging
+}

--- a/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
@@ -1,5 +1,6 @@
 import {
   ApiOptionalEnum,
+  ApiOptionalNumber,
   ApiOptionalString,
   ApiUUId,
 } from '@dmr.is/decorators'
@@ -12,6 +13,13 @@ export class ReportEmployeeOutlierDto {
 
   @ApiUUId()
   reportEmployeeId!: string
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description:
+      "1-indexed ordinal of the outlier employee in the report's parsed employee list. Mirrors `report_employee.ordinal` — used to cross-reference the canonical detected set on `report_result.outlier_analysis_snapshot.employees`.",
+  })
+  employeeOrdinal!: number | null
 
   @ApiOptionalEnum(GenderEnum, { enumName: 'GenderEnum', nullable: true })
   gender!: GenderEnum | null
@@ -34,4 +42,45 @@ export class ReportEmployeeOutlierDto {
 
   @ApiOptionalString({ nullable: true })
   signatureRole!: string | null
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description:
+      "Employee's full-time-equivalent base salary at submission, projected from the matching `outlier_analysis_snapshot.employees` entry. Null if the snapshot has no matching ordinal.",
+  })
+  adjustedBaseSalary!: number | null
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description:
+      'Salary predicted by the regression line at the employee\'s exact score. Null when the regression had no slope (insufficient sample) or no matching snapshot entry exists.',
+  })
+  predictedBaseSalary!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreBucketRangeFrom!: number | null
+
+  @ApiOptionalNumber({ nullable: true })
+  scoreBucketRangeTo!: number | null
+
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      "Sign of the deviation from the predicted salary: 'ABOVE' | 'BELOW' | 'EQUAL'. Null when no prediction was available.",
+  })
+  direction!: string | null
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description:
+      "Signed percent deviation of the employee's adjusted base salary from the predicted salary.",
+  })
+  differencePercent!: number | null
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description:
+      'Half-threshold band (in percent) used to flag this row as an outlier — i.e. the report-wide allowed deviation at submission time.',
+  })
+  allowedDifferencePercent!: number | null
 }

--- a/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
@@ -6,6 +6,24 @@ import { DoeModels } from '../../../core/constants'
 import type { ReportEmployeeOutlierDto } from '../dto/report-employee-outlier.dto'
 import { ReportEmployeeModel } from './report-employee.model'
 
+/**
+ * Shape of the per-employee entry on the canonical outlier analysis. Defined
+ * structurally rather than re-using `SalaryOutlierAnalysisEmployeeSnapshot`
+ * directly so both call paths — admin (reads the raw model snapshot with the
+ * strict `'ABOVE' | 'BELOW' | 'EQUAL'` union) and application (reads the
+ * DTO-projected variant with `direction: string | null`) — can pass their
+ * matching entry without an unsafe cast.
+ */
+export type OutlierAnalysisEntry = {
+  adjustedBaseSalary: number
+  predictedBaseSalary: number | null
+  scoreBucketRangeFrom: number | null
+  scoreBucketRangeTo: number | null
+  direction: string | null
+  differencePercent: number | null
+  allowedDifferencePercent: number
+}
+
 type ReportEmployeeOutlierAttributes = {
   reportEmployeeId: string
   reason: string | null
@@ -53,22 +71,43 @@ export class ReportEmployeeOutlierModel extends MutableModel<
   })
   reportEmployee?: ReportEmployeeModel
 
+  /**
+   * Project an outlier row to its DTO. The persisted row only carries the
+   * applicant's improvement-plan response (reason / action / signature). The
+   * analysis numbers (`adjustedBaseSalary`, regression prediction, score
+   * bucket, direction, etc.) live in `report_result.outlier_analysis_snapshot`
+   * as the canonical "what the engine detected at submit time" — callers are
+   * expected to look that up by the joined `reportEmployee.ordinal` and pass
+   * the matching entry in via `analysis`. Pass `null` when the matching entry
+   * is unavailable; the analysis-derived fields then surface as null.
+   */
   static fromModel(
     model: ReportEmployeeOutlierModel,
+    analysis: OutlierAnalysisEntry | null = null,
   ): ReportEmployeeOutlierDto {
     return {
       id: model.id,
       reportEmployeeId: model.reportEmployeeId,
+      employeeOrdinal: model.reportEmployee?.ordinal ?? null,
       gender: model.reportEmployee?.gender ?? null,
       roleTitle: model.reportEmployee?.role?.title ?? null,
       reason: model.reason,
       action: model.action,
       signatureName: model.signatureName,
       signatureRole: model.signatureRole,
+      adjustedBaseSalary: analysis?.adjustedBaseSalary ?? null,
+      predictedBaseSalary: analysis?.predictedBaseSalary ?? null,
+      scoreBucketRangeFrom: analysis?.scoreBucketRangeFrom ?? null,
+      scoreBucketRangeTo: analysis?.scoreBucketRangeTo ?? null,
+      direction: analysis?.direction ?? null,
+      differencePercent: analysis?.differencePercent ?? null,
+      allowedDifferencePercent: analysis?.allowedDifferencePercent ?? null,
     }
   }
 
-  fromModel(): ReportEmployeeOutlierDto {
-    return ReportEmployeeOutlierModel.fromModel(this)
+  fromModel(
+    analysis: OutlierAnalysisEntry | null = null,
+  ): ReportEmployeeOutlierDto {
+    return ReportEmployeeOutlierModel.fromModel(this, analysis)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/get-reports.query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/get-reports.query.dto.ts
@@ -97,6 +97,21 @@ export class GetReportsQueryDto extends PagingQuery {
   @IsBoolean()
   unassignedReviewer?: boolean
 
+  @ApiProperty({
+    type: Boolean,
+    required: false,
+    description:
+      'When true, returns only reports that have at least one employee outlier (i.e. an improvement plan applies). When false, returns only reports with no outliers. Omit for no constraint.',
+  })
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true
+    if (value === 'false' || value === false) return false
+    return undefined
+  })
+  @IsOptional()
+  @IsBoolean()
+  hasImprovementPlan?: boolean
+
   @ApiOptionalDateTime()
   createdFrom?: Date
 

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-detail.dto.ts
@@ -1,7 +1,6 @@
-import { ApiDto, ApiDtoArray, ApiOptionalDto } from '@dmr.is/decorators'
+import { ApiBoolean, ApiDto, ApiDtoArray, ApiOptionalDto } from '@dmr.is/decorators'
 
 import { CompanyReportDto } from '../../company/dto/company-report.dto'
-import { ReportEmployeeOutlierDto } from '../../report-employee/dto/report-employee-outlier.dto'
 import { ReportResultDto } from '../../report-result/dto/report-result.dto'
 import { ReportRoleResultDto } from '../../report-result/dto/report-role-result.dto'
 import { EqualityReportDto } from './equality-report.dto'
@@ -32,12 +31,17 @@ import { ReportTimelineItemDto } from './report-timeline-item.dto'
  *   (`EVENT` | `COMMENT`) and exactly one of `event` / `comment`
  *   populated. Paranoid-deleted comments are excluded.
  *
- * - `result` / `roleResults` / `employeeOutliers`: salary-only calculation
- *   outputs. For equality reports these are `null` / `[]`; for salary reports
- *   they're populated once the scoring engine has run. The UI uses them to
- *   render the Skýrslugjöf charts: `result` → gender-gap summary, `roleResults`
- *   → scatter-plot points per role, `employeeOutliers` → the Úrbótaáætlun
- *   table listing employees who fall outside the acceptable pay-gap threshold.
+ * - `result` / `roleResults`: salary-only calculation outputs. For equality
+ *   reports these are `null` / `[]`; for salary reports they're populated
+ *   once the scoring engine has run. The UI uses them to render the
+ *   Skýrslugjöf charts: `result` → gender-gap summary, `roleResults` →
+ *   scatter-plot points per role.
+ *
+ * - `includesImprovementPlan`: cheap boolean indicating whether the
+ *   Úrbótaáætlun (improvement plan) table has any rows. The full,
+ *   potentially-large list is served by a separate paginated endpoint
+ *   (`GET /reports/:id/outliers`) — the detail view only carries the flag
+ *   so it stays small for reports with hundreds of outliers.
  */
 export class ReportDetailDto extends ReportDto {
   @ApiDto(CompanyReportDto)
@@ -58,6 +62,9 @@ export class ReportDetailDto extends ReportDto {
   @ApiDtoArray(ReportRoleResultDto)
   roleResults!: ReportRoleResultDto[]
 
-  @ApiDtoArray(ReportEmployeeOutlierDto)
-  employeeOutliers!: ReportEmployeeOutlierDto[]
+  @ApiBoolean({
+    description:
+      'True when the report has at least one employee outlier. The full list is fetched separately via `GET /reports/:id/outliers`.',
+  })
+  includesImprovementPlan!: boolean
 }

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
@@ -65,6 +65,12 @@ export class ReportListItemDto {
   })
   waitingForAction!: boolean
 
+  @ApiBoolean({
+    description:
+      'True when the report has at least one employee outlier — outliers are the input that drives the company-side improvement plan.',
+  })
+  includesImprovementPlan!: boolean
+
   @ApiOptionalDateTime({ nullable: true })
   createdAt!: Date | null
 

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -368,6 +368,7 @@ export class ReportModel extends MutableModel<
   static fromModelToListItem(
     model: ReportModel,
     waitingForAction = false,
+    includesImprovementPlan = false,
   ): ReportListItemDto {
     return {
       id: model.id,
@@ -384,6 +385,7 @@ export class ReportModel extends MutableModel<
       companyAdminGender: model.companyAdminGender,
       reviewer: model.reviewer ? UserModel.fromModel(model.reviewer) : null,
       waitingForAction,
+      includesImprovementPlan,
       createdAt: model.createdAt,
       correctionDeadline: model.correctionDeadline,
       validUntil: model.validUntil,
@@ -394,8 +396,15 @@ export class ReportModel extends MutableModel<
     return ReportModel.fromModelToEqualityReport(this)
   }
 
-  fromModelToListItem(waitingForAction = false): ReportListItemDto {
-    return ReportModel.fromModelToListItem(this, waitingForAction)
+  fromModelToListItem(
+    waitingForAction = false,
+    includesImprovementPlan = false,
+  ): ReportListItemDto {
+    return ReportModel.fromModelToListItem(
+      this,
+      waitingForAction,
+      includesImprovementPlan,
+    )
   }
 
   fromModel(): ReportDto {

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -11,10 +11,12 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 
 import { CurrentUser } from '@dmr.is/decorators'
 import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
+import { PagingQuery } from '@dmr.is/shared-dto'
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
 import { ReportDetailDto } from './dto/report-detail.dto'
@@ -66,5 +68,20 @@ export class ReportController {
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<ReportDetailDto> {
     return this.reportService.getById(id)
+  }
+
+  @Get(':id/outliers')
+  @DoeResponse({
+    operationId: 'getReportOutliers',
+    type: GetReportOutliersResponseDto,
+    include404: true,
+    description:
+      'Paginated list of a report\'s employee outliers — the rows behind the Úrbótaáætlun table. Split out from the report-detail payload because a single salary report can carry hundreds of rows. Ordered by `employeeOrdinal` ascending.',
+  })
+  async getOutliers(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query() query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto> {
+    return this.reportService.getOutliers(id, query)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
@@ -1,3 +1,6 @@
+import { PagingQuery } from '@dmr.is/shared-dto'
+
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { EqualityReportSummaryDto } from './dto/equality-report-summary.dto'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
@@ -8,6 +11,10 @@ import { ReportOverviewStatisticsDto } from './dto/report-overview-statistics.dt
 export interface IReportService {
   list(query: GetReportsQueryDto): Promise<GetReportsResponseDto>
   getById(id: string): Promise<ReportDetailDto>
+  getOutliers(
+    reportId: string,
+    query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto>
   getActiveEqualityForCompany(
     companyId: string,
   ): Promise<EqualityReportSummaryDto | null>

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -47,7 +47,10 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
   // Instance methods the service calls — projections the real model
   // provides via BaseModel. Tests only need something that returns a
   // plain object shape-compatible with the DTO.
-  row.fromModelToListItem = (waitingForAction = false) => {
+  row.fromModelToListItem = (
+    waitingForAction = false,
+    includesImprovementPlan = false,
+  ) => {
     const companyReport = row.companyReport as
       | {
           name?: string
@@ -71,6 +74,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
       companyAdminGender: row.companyAdminGender,
       reviewer: row.reviewer,
       waitingForAction,
+      includesImprovementPlan,
       createdAt: row.createdAt,
       correctionDeadline: row.correctionDeadline,
       validUntil: row.validUntil,
@@ -113,6 +117,10 @@ const makeService = () => {
   // outputs unless a test overrides.
   const roleResultFindAll = jest.fn().mockResolvedValue([])
   const outlierFindAll = jest.fn().mockResolvedValue([])
+  const outlierFindAndCountAll = jest
+    .fn()
+    .mockResolvedValue({ rows: [], count: 0 })
+  const outlierCount = jest.fn().mockResolvedValue(0)
   const companyReportFindAll = jest.fn().mockResolvedValue([])
   const reportEventModel = {
     findAll: jest.fn().mockResolvedValue([]),
@@ -122,6 +130,8 @@ const makeService = () => {
   } as unknown as typeof import('../report-result/models/report-role-result.model').ReportRoleResultModel
   const reportEmployeeOutlierModel = {
     findAll: outlierFindAll,
+    findAndCountAll: outlierFindAndCountAll,
+    count: outlierCount,
   } as unknown as typeof import('../report-employee/models/report-employee-outlier.model').ReportEmployeeOutlierModel
   const companyReportModel = {
     findAll: companyReportFindAll,
@@ -146,6 +156,8 @@ const makeService = () => {
     findOne,
     roleResultFindAll,
     outlierFindAll,
+    outlierFindAndCountAll,
+    outlierCount,
     companyReportFindAll,
     logger,
   }
@@ -648,8 +660,12 @@ describe('ReportService.getById', () => {
 
   describe('salary calculations', () => {
     it('returns null/empty calc blocks for equality reports without querying role results or outliers', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
-        makeService()
+      const {
+        service,
+        findByPkOrThrow,
+        roleResultFindAll,
+        outlierCount,
+      } = makeService()
       findByPkOrThrow.mockResolvedValueOnce(
         makeDetailedReportRow({
           type: ReportTypeEnum.EQUALITY,
@@ -661,14 +677,18 @@ describe('ReportService.getById', () => {
 
       expect(detail.result).toBeNull()
       expect(detail.roleResults).toEqual([])
-      expect(detail.employeeOutliers).toEqual([])
+      expect(detail.includesImprovementPlan).toBe(false)
       expect(roleResultFindAll).not.toHaveBeenCalled()
-      expect(outlierFindAll).not.toHaveBeenCalled()
+      expect(outlierCount).not.toHaveBeenCalled()
     })
 
     it('returns null/empty calc blocks for salary reports before scoring has run (result missing)', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
-        makeService()
+      const {
+        service,
+        findByPkOrThrow,
+        roleResultFindAll,
+        outlierCount,
+      } = makeService()
       findByPkOrThrow.mockResolvedValueOnce(
         makeDetailedReportRow({
           type: ReportTypeEnum.SALARY,
@@ -688,14 +708,18 @@ describe('ReportService.getById', () => {
 
       expect(detail.result).toBeNull()
       expect(detail.roleResults).toEqual([])
-      expect(detail.employeeOutliers).toEqual([])
+      expect(detail.includesImprovementPlan).toBe(false)
       expect(roleResultFindAll).not.toHaveBeenCalled()
-      expect(outlierFindAll).not.toHaveBeenCalled()
+      expect(outlierCount).not.toHaveBeenCalled()
     })
 
-    it('loads role results and employee outliers when result exists on salary report', async () => {
-      const { service, findByPkOrThrow, roleResultFindAll, outlierFindAll } =
-        makeService()
+    it('loads role results and flags includesImprovementPlan when outliers exist on salary report', async () => {
+      const {
+        service,
+        findByPkOrThrow,
+        roleResultFindAll,
+        outlierCount,
+      } = makeService()
 
       const resultId = '00000000-0000-0000-0000-000000000111'
       const linkedEqualityId = '00000000-0000-0000-0000-000000000099'
@@ -753,16 +777,8 @@ describe('ReportService.getById', () => {
         maximumFemaleSalary: 1200,
         maximumNeutralSalary: 0,
       })
-      const outlierRow = withFromModel({
-        id: 'd1',
-        reportEmployeeId: 'e1',
-        reason: 'Seniority premium',
-        action: 'Reviewed and accepted',
-        signatureName: 'Admin',
-        signatureRole: 'HR',
-      })
       roleResultFindAll.mockResolvedValueOnce([roleResultRow])
-      outlierFindAll.mockResolvedValueOnce([outlierRow])
+      outlierCount.mockResolvedValueOnce(3)
 
       const detail = await service.getById(baseReport.id)
 
@@ -773,20 +789,152 @@ describe('ReportService.getById', () => {
       expect(detail.roleResults[0]).toEqual(
         expect.objectContaining({ reportResultId: resultId }),
       )
-      expect(detail.employeeOutliers).toHaveLength(1)
-      expect(detail.employeeOutliers[0]).toEqual(
-        expect.objectContaining({ reason: 'Seniority premium' }),
-      )
+      expect(detail.includesImprovementPlan).toBe(true)
+      expect(outlierCount).toHaveBeenCalledTimes(1)
 
       expect(roleResultFindAll).toHaveBeenCalledWith({
         where: { reportResultId: resultId },
       })
-      expect(outlierFindAll).toHaveBeenCalledWith(
-        expect.objectContaining({
-          include: expect.any(Array),
-        }),
-      )
     })
+  })
+})
+
+describe('ReportService.getOutliers', () => {
+  const REPORT_ID = '00000000-0000-0000-0000-000000000001'
+
+  const makeDetailedSalaryReportRow = () => {
+    const row = {
+      id: REPORT_ID,
+      type: ReportTypeEnum.SALARY,
+      status: ReportStatusEnum.SUBMITTED,
+      result: {
+        outlierAnalysisSnapshot: {
+          employees: [
+            {
+              ordinal: 1,
+              adjustedBaseSalary: 950000,
+              predictedBaseSalary: 1000000,
+              scoreBucketRangeFrom: 500,
+              scoreBucketRangeTo: 600,
+              direction: 'BELOW',
+              differencePercent: -5,
+              allowedDifferencePercent: 1.95,
+              isOutlier: true,
+            },
+          ],
+        },
+      },
+    }
+    return row
+  }
+
+  const makeOutlierRow = (
+    overrides: Partial<Record<string, unknown>> = {},
+  ) => ({
+    id: 'outlier-1',
+    reportEmployeeId: 'employee-1',
+    reason: 'Tenure premium',
+    action: 'Reviewed',
+    signatureName: 'Reviewer',
+    signatureRole: 'HR',
+    reportEmployee: {
+      id: 'employee-1',
+      ordinal: 1,
+      gender: 'FEMALE',
+      role: { id: 'role-1', title: 'Engineer' },
+    },
+    fromModel(
+      analysis: {
+        adjustedBaseSalary?: number
+        predictedBaseSalary?: number | null
+        scoreBucketRangeFrom?: number | null
+        scoreBucketRangeTo?: number | null
+        direction?: string | null
+        differencePercent?: number | null
+        allowedDifferencePercent?: number
+      } | null = null,
+    ) {
+      const r = this as unknown as Record<string, unknown>
+      const re = r.reportEmployee as Record<string, unknown> | undefined
+      const role = re?.role as Record<string, unknown> | undefined
+      return {
+        id: r.id,
+        reportEmployeeId: r.reportEmployeeId,
+        employeeOrdinal: re?.ordinal ?? null,
+        gender: re?.gender ?? null,
+        roleTitle: role?.title ?? null,
+        reason: r.reason,
+        action: r.action,
+        signatureName: r.signatureName,
+        signatureRole: r.signatureRole,
+        adjustedBaseSalary: analysis?.adjustedBaseSalary ?? null,
+        predictedBaseSalary: analysis?.predictedBaseSalary ?? null,
+        scoreBucketRangeFrom: analysis?.scoreBucketRangeFrom ?? null,
+        scoreBucketRangeTo: analysis?.scoreBucketRangeTo ?? null,
+        direction: analysis?.direction ?? null,
+        differencePercent: analysis?.differencePercent ?? null,
+        allowedDifferencePercent: analysis?.allowedDifferencePercent ?? null,
+      }
+    },
+    ...overrides,
+  })
+
+  it('paginates outliers and merges analysis snapshot fields by ordinal', async () => {
+    const { service, findByPkOrThrow, outlierFindAndCountAll } = makeService()
+    findByPkOrThrow.mockResolvedValueOnce(
+      makeDetailedSalaryReportRow() as unknown as ReportModel,
+    )
+    outlierFindAndCountAll.mockResolvedValueOnce({
+      rows: [makeOutlierRow()],
+      count: 1,
+    })
+
+    const result = await service.getOutliers(REPORT_ID, {
+      page: 1,
+      pageSize: 10,
+    })
+
+    expect(result.outliers).toHaveLength(1)
+    expect(result.outliers[0]).toEqual(
+      expect.objectContaining({
+        employeeOrdinal: 1,
+        roleTitle: 'Engineer',
+        gender: 'FEMALE',
+        reason: 'Tenure premium',
+        adjustedBaseSalary: 950000,
+        predictedBaseSalary: 1000000,
+        scoreBucketRangeFrom: 500,
+        scoreBucketRangeTo: 600,
+        direction: 'BELOW',
+        allowedDifferencePercent: 1.95,
+      }),
+    )
+    expect(result.paging).toEqual(
+      expect.objectContaining({
+        page: 1,
+        pageSize: 10,
+        totalItems: 1,
+        totalPages: 1,
+      }),
+    )
+  })
+
+  it('returns empty list with null-safe analysis when the report has no result', async () => {
+    const { service, findByPkOrThrow, outlierFindAndCountAll } = makeService()
+    findByPkOrThrow.mockResolvedValueOnce({
+      id: REPORT_ID,
+      type: ReportTypeEnum.EQUALITY,
+      result: null,
+    } as unknown as ReportModel)
+    outlierFindAndCountAll.mockResolvedValueOnce({ rows: [], count: 0 })
+
+    const result = await service.getOutliers(REPORT_ID, {
+      page: 1,
+      pageSize: 10,
+    })
+
+    expect(result.outliers).toEqual([])
+    expect(result.paging.totalItems).toBe(0)
   })
 })
 

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -22,6 +22,7 @@ import {
 import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { PagingQuery } from '@dmr.is/shared-dto'
 import {
   generatePaging,
   getLimitAndOffset,
@@ -29,8 +30,10 @@ import {
 
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportCommentModel } from '../report-comment/models/report-comment.model'
+import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { UserModel } from '../user/models/user.model'
 import { EqualityReportDto } from './dto/equality-report.dto'
@@ -58,7 +61,11 @@ import { ReportStatusEnum, ReportTypeEnum } from './models/report.enums'
 import { ReportModel } from './models/report.model'
 import { ReportEventModel } from './models/report-event.model'
 import { ReportRoleEnum } from './types/report-resource-context'
-import { buildFreeTextWhere, dateRangeFilter } from './utils/filters'
+import {
+  buildFreeTextWhere,
+  buildImprovementPlanWhere,
+  dateRangeFilter,
+} from './utils/filters'
 import { IReportService } from './report.service.interface'
 
 const LOGGING_CONTEXT = 'ReportService'
@@ -144,9 +151,16 @@ export class ReportService implements IReportService {
         }),
       ])
 
-    const waitingMap = await this.computeWaitingForAction(rows.map((r) => r.id))
+    const pageIds = rows.map((r) => r.id)
+    const [waitingMap, improvementPlanMap] = await Promise.all([
+      this.computeWaitingForAction(pageIds),
+      this.computeIncludesImprovementPlan(pageIds),
+    ])
     const reports = rows.map((r) =>
-      r.fromModelToListItem(waitingMap.get(r.id) ?? false),
+      r.fromModelToListItem(
+        waitingMap.get(r.id) ?? false,
+        improvementPlanMap.get(r.id) ?? false,
+      ),
     )
     const paging = generatePaging(reports, query.page, query.pageSize, count)
 
@@ -197,12 +211,15 @@ export class ReportService implements IReportService {
       )
     }
 
-    const [{ result, roleResults, employeeOutliers }, timeline, subsidiaries] =
-      await Promise.all([
-        this.loadSalaryCalculations(report),
-        this.buildTimeline(id, report.comments ?? []),
-        this.loadSubsidiaries(id),
-      ])
+    const [
+      { result, roleResults, includesImprovementPlan },
+      timeline,
+      subsidiaries,
+    ] = await Promise.all([
+      this.loadSalaryCalculations(report),
+      this.buildTimeline(id, report.comments ?? []),
+      this.loadSubsidiaries(id),
+    ])
 
     return {
       ...base,
@@ -212,7 +229,7 @@ export class ReportService implements IReportService {
       timeline,
       result,
       roleResults,
-      employeeOutliers,
+      includesImprovementPlan,
     }
   }
 
@@ -275,6 +292,38 @@ export class ReportService implements IReportService {
       }
     }
 
+    return result
+  }
+
+  /**
+   * Per-page boolean: true when the report has at least one employee outlier.
+   * Outliers are owned by `ReportEmployeeOutlierModel` and link to the report
+   * via `ReportEmployeeModel.reportId`. One grouped query scoped to the
+   * page's report IDs — bounded by pageSize, no N+1.
+   */
+  private async computeIncludesImprovementPlan(
+    reportIds: string[],
+  ): Promise<Map<string, boolean>> {
+    const result = new Map<string, boolean>()
+    if (reportIds.length === 0) return result
+    for (const id of reportIds) result.set(id, false)
+
+    const rows = (await this.reportEmployeeOutlierModel.findAll({
+      include: [
+        {
+          model: ReportEmployeeModel,
+          as: 'reportEmployee',
+          attributes: [],
+          where: { reportId: { [Op.in]: reportIds } },
+          required: true,
+        },
+      ],
+      attributes: [[col('reportEmployee.report_id'), 'reportId']],
+      group: [col('reportEmployee.report_id')],
+      raw: true,
+    })) as unknown as { reportId: string }[]
+
+    for (const row of rows) result.set(row.reportId, true)
     return result
   }
 
@@ -510,17 +559,20 @@ export class ReportService implements IReportService {
   private async loadSalaryCalculations(report: ReportModel): Promise<{
     result: ReportDetailDto['result']
     roleResults: ReportDetailDto['roleResults']
-    employeeOutliers: ReportDetailDto['employeeOutliers']
+    includesImprovementPlan: boolean
   }> {
     if (report.type !== ReportTypeEnum.SALARY || !report.result) {
-      return { result: null, roleResults: [], employeeOutliers: [] }
+      return { result: null, roleResults: [], includesImprovementPlan: false }
     }
 
-    const [roleResultRows, outlierRows] = await Promise.all([
+    // Outlier rows themselves are served by the paginated
+    // `GET /reports/:id/outliers` endpoint — too many to inline into the
+    // detail payload. We only need the boolean here, so a count is enough.
+    const [roleResultRows, outlierCount] = await Promise.all([
       this.reportRoleResultModel.findAll({
         where: { reportResultId: report.result.id },
       }),
-      this.reportEmployeeOutlierModel.findAll({
+      this.reportEmployeeOutlierModel.count({
         include: [
           {
             model: ReportEmployeeModel,
@@ -536,8 +588,72 @@ export class ReportService implements IReportService {
     return {
       result: report.result.fromModel(),
       roleResults: roleResultRows.map((r) => r.fromModel()),
-      employeeOutliers: outlierRows.map((d) => d.fromModel()),
+      includesImprovementPlan: outlierCount > 0,
     }
+  }
+
+  async getOutliers(
+    reportId: string,
+    query: PagingQuery,
+  ): Promise<GetReportOutliersResponseDto> {
+    this.logger.debug('Listing report outliers', {
+      context: LOGGING_CONTEXT,
+      reportId,
+    })
+
+    // Verify the report exists + load its result so we can project each
+    // outlier with the matching analysis snapshot entry.
+    const report = await this.reportModel
+      .withScope('detailed')
+      .findByPkOrThrow(reportId)
+
+    const { limit, offset } = getLimitAndOffset(query)
+
+    const { rows, count } = await this.reportEmployeeOutlierModel.findAndCountAll({
+      include: [
+        {
+          model: ReportEmployeeModel,
+          as: 'reportEmployee',
+          attributes: ['id', 'ordinal', 'gender'],
+          where: { reportId: report.id },
+          required: true,
+          include: [
+            {
+              model: ReportEmployeeRoleModel,
+              as: 'role',
+              attributes: ['id', 'title'],
+              required: false,
+            },
+          ],
+        },
+      ],
+      // Stable ordinal-based order so paging is deterministic and matches
+      // how the FE renders the improvement-plan list (1, 2, 3, ...).
+      order: [[{ model: ReportEmployeeModel, as: 'reportEmployee' }, 'ordinal', 'ASC']],
+      limit,
+      offset,
+      distinct: true,
+      subQuery: false,
+    })
+
+    const analysisByOrdinal = new Map(
+      report.result?.outlierAnalysisSnapshot.employees.map((employee) => [
+        employee.ordinal,
+        employee,
+      ]) ?? [],
+    )
+
+    const outliers = rows.map((row) =>
+      row.fromModel(
+        row.reportEmployee
+          ? analysisByOrdinal.get(row.reportEmployee.ordinal) ?? null
+          : null,
+      ),
+    )
+
+    const paging = generatePaging(outliers, query.page, query.pageSize, count)
+
+    return { outliers, paging }
   }
 
   /**
@@ -581,6 +697,10 @@ export class ReportService implements IReportService {
 
     if (query.q?.trim()) {
       Object.assign(where, buildFreeTextWhere(query.q))
+    }
+
+    if (query.hasImprovementPlan !== undefined) {
+      Object.assign(where, buildImprovementPlanWhere(query.hasImprovementPlan))
     }
 
     return where

--- a/apps/directorate-of-equality-api/src/modules/report/utils/filters.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/utils/filters.ts
@@ -4,7 +4,10 @@
  * service file stays focused on orchestration rather than clause shapes.
  */
 
-import { Op, WhereOptions } from 'sequelize'
+import { literal, Op, WhereOptions } from 'sequelize'
+
+import { DoeModels } from '../../../core/constants'
+import { ReportModel } from '../models/report.model'
 
 /**
  * Build the `Op.or` clause for the `q` free-text search. Matches
@@ -29,6 +32,36 @@ export const buildFreeTextWhere = (term: string): WhereOptions => {
       { contactEmail: { [Op.iLike]: pattern } },
       { '$companyReport.name$': { [Op.iLike]: pattern } },
       { '$companyReport.national_id$': { [Op.iLike]: pattern } },
+    ],
+  }
+}
+
+/**
+ * Build a `where` clause that filters reports by whether they have at least
+ * one employee outlier — the underlying signal that drives the company-side
+ * "improvement plan". Implemented as an EXISTS subquery so the main list
+ * query doesn't need to join (or paginate around) the per-employee tables.
+ *
+ * - `true`  → only reports WITH outliers
+ * - `false` → only reports WITHOUT outliers
+ *
+ * The outer table is referenced by its Sequelize alias (`ReportModel.name`)
+ * — `findAndCountAll` / `count` both alias the main table by class name in
+ * the surrounding SQL, so the subquery's correlated column resolves
+ * correctly regardless of whether `subQuery` is on or off.
+ */
+export const buildImprovementPlanWhere = (
+  hasImprovementPlan: boolean,
+): WhereOptions => {
+  const negation = hasImprovementPlan ? '' : 'NOT '
+  return {
+    [Op.and]: [
+      literal(
+        `${negation}EXISTS (SELECT 1 FROM "${DoeModels.REPORT_EMPLOYEE}" "re" ` +
+          `INNER JOIN "${DoeModels.REPORT_EMPLOYEE_OUTLIER}" "reo" ` +
+          `ON "reo"."report_employee_id" = "re"."id" ` +
+          `WHERE "re"."report_id" = "${ReportModel.name}"."id")`,
+      ),
     ],
   }
 }

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -235,11 +235,11 @@
             "schema": { "type": "string" }
           },
           {
-            "name": "minEmployeeCount",
+            "name": "employeeCountCategory",
             "required": false,
             "in": "query",
-            "description": "Return only companies with averageEmployeeCountFromRsk >= this value.",
-            "schema": { "minimum": 0, "type": "number" }
+            "description": "Return only companies whose employee-count bucket matches.",
+            "schema": { "$ref": "#/components/schemas/CompanySizeEnum" }
           },
           {
             "name": "sortBy",
@@ -1153,6 +1153,13 @@
             "schema": { "type": "boolean" }
           },
           {
+            "name": "hasImprovementPlan",
+            "required": false,
+            "in": "query",
+            "description": "When true, returns only reports that have at least one employee outlier (i.e. an improvement plan applies). When false, returns only reports with no outliers. Omit for no constraint.",
+            "schema": { "type": "boolean" }
+          },
+          {
             "name": "createdFrom",
             "required": false,
             "in": "query",
@@ -1318,6 +1325,87 @@
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/ReportDetailDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Reports"]
+      }
+    },
+    "/api/v1/reports/{id}/outliers": {
+      "get": {
+        "description": "Paginated list of a report's employee outliers — the rows behind the Úrbótaáætlun table. Split out from the report-detail payload because a single salary report can carry hundreds of rows. Ordered by `employeeOrdinal` ascending.",
+        "operationId": "getReportOutliers",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": { "default": 1, "example": 1, "type": "number" }
+          },
+          {
+            "name": "pageSize",
+            "required": false,
+            "in": "query",
+            "schema": { "default": 10, "example": 10, "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetReportOutliersResponseDto"
+                }
               }
             }
           },
@@ -2538,6 +2626,10 @@
           "equalityReportContent"
         ]
       },
+      "CompanySizeEnum": {
+        "type": "string",
+        "enum": ["SMALL", "MEDIUM", "LARGE"]
+      },
       "CompanySortByEnum": {
         "type": "string",
         "enum": ["name", "employeeCount"]
@@ -2548,7 +2640,9 @@
         "properties": {
           "id": { "type": "string", "format": "uuid" },
           "name": { "type": "string" },
-          "averageEmployeeCountFromRsk": { "type": "number" },
+          "employeeCountCategory": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
+          },
           "nationalId": { "type": "string" },
           "salaryReportRequired": { "type": "boolean" },
           "salaryReportRequiredOverride": { "type": "boolean" }
@@ -2556,7 +2650,7 @@
         "required": [
           "id",
           "name",
-          "averageEmployeeCountFromRsk",
+          "employeeCountCategory",
           "nationalId",
           "salaryReportRequired",
           "salaryReportRequiredOverride"
@@ -2614,9 +2708,11 @@
         "properties": {
           "nationalId": { "type": "string" },
           "name": { "type": "string" },
-          "averageEmployeeCountFromRsk": { "type": "number" }
+          "employeeCountCategory": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
+          }
         },
-        "required": ["nationalId", "name", "averageEmployeeCountFromRsk"]
+        "required": ["nationalId", "name", "employeeCountCategory"]
       },
       "UserDto": {
         "type": "object",
@@ -2739,7 +2835,8 @@
               "IN_REVIEW",
               "DENIED",
               "APPROVED",
-              "SUPERSEDED"
+              "SUPERSEDED",
+              "WITHDRAWN"
             ]
           },
           "count": { "type": "number" },
@@ -2783,7 +2880,8 @@
           "IN_REVIEW",
           "DENIED",
           "APPROVED",
-          "SUPERSEDED"
+          "SUPERSEDED",
+          "WITHDRAWN"
         ]
       },
       "ReportSortByEnum": {
@@ -2813,9 +2911,9 @@
           "companyName": { "type": "string", "nullable": true },
           "companyNationalId": { "type": "string", "nullable": true },
           "companyIsatCategory": { "type": "string", "nullable": true },
-          "companyAverageEmployeeCountFromRsk": {
-            "type": "number",
-            "nullable": true
+          "companyEmployeeCountCategory": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
           },
           "companyAdminName": { "type": "string", "nullable": true },
           "companyAdminEmail": { "type": "string", "nullable": true },
@@ -2830,6 +2928,10 @@
           "waitingForAction": {
             "type": "boolean",
             "description": "True when the most recent activity on this report is a comment authored by the company (application side). Resets to false whenever a reviewer action/event or reviewer comment supersedes it."
+          },
+          "includesImprovementPlan": {
+            "type": "boolean",
+            "description": "True when the report has at least one employee outlier — outliers are the input that drives the company-side improvement plan."
           },
           "createdAt": {
             "type": "string",
@@ -2850,7 +2952,13 @@
             "nullable": true
           }
         },
-        "required": ["id", "type", "status", "waitingForAction"]
+        "required": [
+          "id",
+          "type",
+          "status",
+          "waitingForAction",
+          "includesImprovementPlan"
+        ]
       },
       "ReportStatusCountsDto": {
         "type": "object",
@@ -2895,7 +3003,9 @@
           "address": { "type": "string" },
           "city": { "type": "string" },
           "postcode": { "type": "string" },
-          "averageEmployeeCountFromRsk": { "type": "number" },
+          "employeeCountCategory": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
+          },
           "isatCategory": { "type": "string" }
         },
         "required": [
@@ -2907,7 +3017,7 @@
           "address",
           "city",
           "postcode",
-          "averageEmployeeCountFromRsk",
+          "employeeCountCategory",
           "isatCategory"
         ]
       },
@@ -2953,7 +3063,8 @@
           "UNASSIGNED",
           "STATUS_CHANGED",
           "SUPERSEDED",
-          "EDITED"
+          "EDITED",
+          "WITHDRAWN"
         ]
       },
       "ReportEventDto": {
@@ -3277,27 +3388,6 @@
           "full"
         ]
       },
-      "ReportEmployeeOutlierDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "reportEmployeeId": { "type": "string", "format": "uuid" },
-          "gender": {
-            "nullable": true,
-            "allOf": [{ "$ref": "#/components/schemas/GenderEnum" }]
-          },
-          "roleTitle": { "type": "string", "nullable": true },
-          "reason": {
-            "type": "string",
-            "nullable": true,
-            "description": "Null only when the parent report has `status = POSTPONED`. Otherwise required and non-empty."
-          },
-          "action": { "type": "string", "nullable": true },
-          "signatureName": { "type": "string", "nullable": true },
-          "signatureRole": { "type": "string", "nullable": true }
-        },
-        "required": ["id", "reportEmployeeId"]
-      },
       "ReportDetailDto": {
         "type": "object",
         "properties": {
@@ -3397,9 +3487,9 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/ReportRoleResultDto" }
           },
-          "employeeOutliers": {
-            "type": "array",
-            "items": { "$ref": "#/components/schemas/ReportEmployeeOutlierDto" }
+          "includesImprovementPlan": {
+            "type": "boolean",
+            "description": "True when the report has at least one employee outlier. The full list is fetched separately via `GET /reports/:id/outliers`."
           }
         },
         "required": [
@@ -3413,8 +3503,72 @@
           "equalityReport",
           "timeline",
           "roleResults",
-          "employeeOutliers"
+          "includesImprovementPlan"
         ]
+      },
+      "ReportEmployeeOutlierDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "reportEmployeeId": { "type": "string", "format": "uuid" },
+          "employeeOrdinal": {
+            "type": "number",
+            "nullable": true,
+            "description": "1-indexed ordinal of the outlier employee in the report's parsed employee list. Mirrors `report_employee.ordinal` — used to cross-reference the canonical detected set on `report_result.outlier_analysis_snapshot.employees`."
+          },
+          "gender": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/GenderEnum" }]
+          },
+          "roleTitle": { "type": "string", "nullable": true },
+          "reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Null only when the parent report has `status = POSTPONED`. Otherwise required and non-empty."
+          },
+          "action": { "type": "string", "nullable": true },
+          "signatureName": { "type": "string", "nullable": true },
+          "signatureRole": { "type": "string", "nullable": true },
+          "adjustedBaseSalary": {
+            "type": "number",
+            "nullable": true,
+            "description": "Employee's full-time-equivalent base salary at submission, projected from the matching `outlier_analysis_snapshot.employees` entry. Null if the snapshot has no matching ordinal."
+          },
+          "predictedBaseSalary": {
+            "type": "number",
+            "nullable": true,
+            "description": "Salary predicted by the regression line at the employee's exact score. Null when the regression had no slope (insufficient sample) or no matching snapshot entry exists."
+          },
+          "scoreBucketRangeFrom": { "type": "number", "nullable": true },
+          "scoreBucketRangeTo": { "type": "number", "nullable": true },
+          "direction": {
+            "type": "string",
+            "nullable": true,
+            "description": "Sign of the deviation from the predicted salary: 'ABOVE' | 'BELOW' | 'EQUAL'. Null when no prediction was available."
+          },
+          "differencePercent": {
+            "type": "number",
+            "nullable": true,
+            "description": "Signed percent deviation of the employee's adjusted base salary from the predicted salary."
+          },
+          "allowedDifferencePercent": {
+            "type": "number",
+            "nullable": true,
+            "description": "Half-threshold band (in percent) used to flag this row as an outlier — i.e. the report-wide allowed deviation at submission time."
+          }
+        },
+        "required": ["id", "reportEmployeeId"]
+      },
+      "GetReportOutliersResponseDto": {
+        "type": "object",
+        "properties": {
+          "outliers": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReportEmployeeOutlierDto" }
+          },
+          "paging": { "$ref": "#/components/schemas/Paging" }
+        },
+        "required": ["outliers", "paging"]
       },
       "CreateReportCommentDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../gen/fetch/types.gen'
 import { formatNationalId } from '../../lib/utils'
 import * as styles from './CompanyExpandedRow.css'
+import { COMPANY_SIZE_LABEL } from './companyStatus'
 
 type Props = {
   company: CompanyDto
@@ -76,7 +77,7 @@ export const CompanyExpandedRow = ({ company, approvedReports }: Props) => {
     { label: 'Kennitala', value: formatNationalId(company.nationalId) },
     {
       label: 'Meðalfjöldi starfsmanna',
-      value: company.averageEmployeeCountFromRsk,
+      value: COMPANY_SIZE_LABEL[company.employeeCountCategory],
     },
     {
       label: 'Skýrslugjöf skylda',

--- a/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
@@ -14,7 +14,13 @@ import {
 } from '../../gen/fetch/types.gen'
 import { formatNationalId } from '../../lib/utils'
 import { CompanyExpandedRow } from './CompanyExpandedRow'
-import { deriveStatus, normalizeId, STATUS_LABEL, STATUS_TAG_VARIANT } from './companyStatus'
+import {
+  COMPANY_SIZE_LABEL,
+  deriveStatus,
+  normalizeId,
+  STATUS_LABEL,
+  STATUS_TAG_VARIANT,
+} from './companyStatus'
 
 import { type ColumnDef, type SortingState } from '@tanstack/react-table'
 
@@ -46,7 +52,7 @@ export const CompanyTable = ({
       },
       {
         id: 'employeeCount',
-        accessorFn: (row) => row.averageEmployeeCountFromRsk,
+        accessorFn: (row) => COMPANY_SIZE_LABEL[row.employeeCountCategory],
         header: 'Meðalfjöldi starfsmanna',
         enableSorting: true,
       },

--- a/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
@@ -13,6 +13,7 @@ import { Modal } from '@dmr.is/ui/components/Modal/Modal'
 
 import { companiesText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
+import { employeeCountCategoryFromCount } from './companyStatus'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 
@@ -67,7 +68,9 @@ export const CreateCompanyModal = ({ isOpen, onClose }: Props) => {
     createMutation.mutate({
       nationalId: lookupQuery.data.nationalId,
       name: lookupQuery.data.name,
-      averageEmployeeCountFromRsk: Number(employeeCount),
+      employeeCountCategory: employeeCountCategoryFromCount(
+        Number(employeeCount),
+      ),
     })
   }
 

--- a/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
+++ b/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
@@ -1,5 +1,6 @@
 import {
   type CompanyDto,
+  CompanySizeEnum,
   type ReportListItemDto,
 } from '../../gen/fetch/types.gen'
 
@@ -27,11 +28,16 @@ export const STATUS_TAG_VARIANT: Record<
 }
 
 export const EMPLOYEE_RANGES = [
-  { value: '1-50', label: '1–50' },
-  { value: '51-100', label: '51–100' },
-  { value: '101-200', label: '101–200' },
-  { value: '201+', label: '201+' },
+  { value: CompanySizeEnum.SMALL, label: '0–24' },
+  { value: CompanySizeEnum.MEDIUM, label: '25–49' },
+  { value: CompanySizeEnum.LARGE, label: '50+' },
 ]
+
+export const COMPANY_SIZE_LABEL: Record<CompanySizeEnum, string> = {
+  [CompanySizeEnum.SMALL]: '0–24',
+  [CompanySizeEnum.MEDIUM]: '25–49',
+  [CompanySizeEnum.LARGE]: '50+',
+}
 
 export const STATUS_FILTER_OPTIONS = (
   ['missing-equality', 'has-equality', 'missing-salary', 'compliant'] as const
@@ -52,12 +58,12 @@ export const PAGE_SIZE = 10
 export const normalizeId = (id: string | null | undefined) =>
   (id ?? '').replace(/[^0-9]/g, '')
 
-export const inRange = (count: number, range: string): boolean => {
-  if (range === '1-50') return count >= 1 && count <= 50
-  if (range === '51-100') return count >= 51 && count <= 100
-  if (range === '101-200') return count >= 101 && count <= 200
-  if (range === '201+') return count >= 201
-  return false
+export const employeeCountCategoryFromCount = (
+  count: number,
+): CompanySizeEnum => {
+  if (count >= 50) return CompanySizeEnum.LARGE
+  if (count >= 25) return CompanySizeEnum.MEDIUM
+  return CompanySizeEnum.SMALL
 }
 
 function getActiveReportTypes(

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Tabs } from '@island.is/island-ui/core'
 
@@ -11,20 +11,40 @@ import {
   SalaryByGenderAndScoreDto,
 } from '../../../gen/fetch'
 import { reportText } from '../../../lib/text'
+import { useTRPC } from '../../../lib/trpc/client/trpc'
 import { CompanyInfoTab } from './company-tab/CompanyInfoTab'
 import { EqualityReportTab } from './equality-tab/EqualityReportTab'
 import { SalaryReportTab } from './salary-tab/SalaryReportTab'
+
+import { useQuery } from '@tanstack/react-query'
 
 type ReportTabsProps = {
   report: ReportDetailDto
   salaryStats?: SalaryByGenderAndScoreDto
 }
 
+const OUTLIERS_PAGE_SIZE = 10
+
 export function ReportTabs({ report, salaryStats }: ReportTabsProps) {
+  const trpc = useTRPC()
   const isSalary = report.type === ReportTypeEnum.SALARY
   const [selectedTab, setSelectedTab] = useState(
     isSalary ? 'launagreining' : 'jafnrettisaetlun',
   )
+  const [outliersPage, setOutliersPage] = useState(1)
+
+  useEffect(() => {
+    setOutliersPage(1)
+  }, [report.id])
+
+  const { data: outliersData, isLoading: outliersLoading } = useQuery({
+    ...trpc.reports.getOutliers.queryOptions({
+      id: report.id,
+      page: outliersPage,
+      pageSize: OUTLIERS_PAGE_SIZE,
+    }),
+    enabled: isSalary && report.includesImprovementPlan,
+  })
 
   const jafnrettisaetlun = {
     id: 'jafnrettisaetlun',
@@ -70,7 +90,10 @@ export function ReportTabs({ report, salaryStats }: ReportTabsProps) {
             content: (
               <SalaryReportTab
                 data={salaryStats}
-                outliers={report.employeeOutliers}
+                outliers={outliersData?.outliers ?? []}
+                outliersPaging={outliersData?.paging}
+                outliersLoading={outliersLoading}
+                onOutliersPageChange={setOutliersPage}
                 outlierDate={
                   report.correctionDeadline
                     ? new Date(report.correctionDeadline)

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/company-tab/CompanyInfoTab.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/company-tab/CompanyInfoTab.tsx
@@ -7,7 +7,9 @@ import { AccordionItem } from '@dmr.is/ui/components/island-is/AccordionItem'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Table } from '@dmr.is/ui/components/Tables/Table'
 
+import { type CompanySizeEnum } from '../../../../gen/fetch'
 import { formatNationalId } from '../../../../lib/utils'
+import { COMPANY_SIZE_LABEL } from '../../../companies/companyStatus'
 import { InfoItems } from './InfoItems'
 
 import { type ColumnDef } from '@tanstack/react-table'
@@ -39,7 +41,7 @@ interface CompanyInfoTabProps {
     nationalId?: string
     address?: string
     city?: string
-    averageEmployeeCountFromRsk?: number
+    employeeCountCategory?: CompanySizeEnum
     isatCategory?: string
   }
   admin?: {
@@ -88,7 +90,9 @@ export const CompanyInfoTab = ({
               { label: 'Sveitarfélag', children: company?.city },
               {
                 label: 'Fjöldi starfsmanna',
-                children: company?.averageEmployeeCountFromRsk,
+                children: company?.employeeCountCategory
+                  ? COMPANY_SIZE_LABEL[company.employeeCountCategory]
+                  : undefined,
               },
               {
                 label: 'ÍSAT atvinnugreinaflokkun',

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
@@ -1,44 +1,45 @@
-'use client'
-
-import { useState } from 'react'
-
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { Table } from '@dmr.is/ui/components/Tables/Table/Table'
 
-import { type ReportEmployeeOutlierDto } from '../../../../gen/fetch'
+import { type Paging, type ReportEmployeeOutlierDto } from '../../../../gen/fetch'
 
 import { type ColumnDef } from '@tanstack/react-table'
 
-const PAGE_SIZE = 10
-
 interface OutlierPlanTableProps {
   outliers: ReportEmployeeOutlierDto[]
+  paging?: Paging
+  loading?: boolean
+  onPageChange?: (page: number) => void
 }
+
+const dash = '–'
 
 const columns: ColumnDef<ReportEmployeeOutlierDto>[] = [
   {
-    accessorKey: 'reportEmployeeId',
+    accessorKey: 'employeeOrdinal',
     header: 'Númer',
+    cell: ({ getValue }) => getValue<number | null>() ?? dash,
   },
   {
     id: 'starf',
     header: 'Starf',
-    cell: () => 'TODO',
+    cell: ({ row }) => row.original.roleTitle ?? dash,
   },
   {
     id: 'kyn',
     header: 'Kyn',
-    cell: () => 'TODO',
+    cell: ({ row }) => row.original.gender ?? dash,
   },
   {
     id: 'launafravik',
     header: 'Launafrávik',
-    cell: () => 'TODO',
+    cell: ({ row }) =>
+      row.original.differencePercent == null
+        ? dash
+        : `${row.original.differencePercent.toLocaleString('is-IS')}%`,
   },
 ]
-
-const dash = '–'
 
 const ExpandedRow = ({ row }: { row: ReportEmployeeOutlierDto }) => (
   <Box background="blue100" padding={2}>
@@ -70,11 +71,12 @@ const ExpandedRow = ({ row }: { row: ReportEmployeeOutlierDto }) => (
   </Box>
 )
 
-export const OutlierPlanTable = ({ outliers }: OutlierPlanTableProps) => {
-  const [page, setPage] = useState(1)
-  const start = (page - 1) * PAGE_SIZE
-  const pageData = outliers.slice(start, start + PAGE_SIZE)
-
+export const OutlierPlanTable = ({
+  outliers,
+  paging,
+  loading,
+  onPageChange,
+}: OutlierPlanTableProps) => {
   return (
     <>
       <Text variant="h4" marginBottom={4}>
@@ -82,20 +84,13 @@ export const OutlierPlanTable = ({ outliers }: OutlierPlanTableProps) => {
       </Text>
       <Table
         columns={columns}
-        data={pageData}
+        data={outliers}
         getRowExpanded={(row) => <ExpandedRow row={row} />}
-        paging={
-          outliers.length > PAGE_SIZE
-            ? {
-                page,
-                pageSize: PAGE_SIZE,
-                totalItems: outliers.length,
-                totalPages: Math.ceil(outliers.length / PAGE_SIZE),
-              }
-            : undefined
-        }
-        onPageChange={setPage}
+        paging={paging}
+        loading={loading}
+        onPageChange={onPageChange}
         showPageSizeSelect={false}
+        noDataMessage="Engin úrbótaáætlun skráð"
       />
     </>
   )

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryReportTab.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryReportTab.tsx
@@ -1,6 +1,7 @@
 import { Stack } from '@island.is/island-ui/core'
 
 import {
+  Paging,
   ReportEmployeeOutlierDto,
   SalaryByGenderAndScoreDto,
 } from '../../../../gen/fetch'
@@ -13,6 +14,9 @@ import { SalaryStatistics } from './SalaryStatistics'
 interface SalaryReportTabProps {
   data: SalaryByGenderAndScoreDto
   outliers: ReportEmployeeOutlierDto[]
+  outliersPaging?: Paging
+  outliersLoading?: boolean
+  onOutliersPageChange: (page: number) => void
   outlierDate?: Date
 }
 
@@ -22,6 +26,9 @@ const formatSalary = (v: number) =>
 export const SalaryReportTab = ({
   data,
   outliers,
+  outliersPaging,
+  outliersLoading,
+  onOutliersPageChange,
   outlierDate,
 }: SalaryReportTabProps) => {
   if (!data) {
@@ -41,7 +48,12 @@ export const SalaryReportTab = ({
         femaleAverageSalary={formatSalary(data.totals.femaleAverageSalary)}
         wageGapPercent={data.totals.wageGapPercent?.toString() ?? '0'}
       />
-      <OutlierPlanTable outliers={outliers} />
+      <OutlierPlanTable
+        outliers={outliers}
+        paging={outliersPaging}
+        loading={outliersLoading}
+        onPageChange={onOutliersPageChange}
+      />
       <OutlierInputForm outlierDate={outlierDate} />
     </Stack>
   )

--- a/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
@@ -13,7 +13,6 @@ import {
   type CompanyFilters,
 } from '../../components/companies/CompanyFilter'
 import {
-  inRange,
   matchesStatusFilter,
   normalizeId,
 } from '../../components/companies/companyStatus'
@@ -79,9 +78,7 @@ export const CompaniesContainer = () => {
     return companies.filter((company) => {
       if (
         filters.employees.length &&
-        !filters.employees.some((r) =>
-          inRange(company.averageEmployeeCountFromRsk, r),
-        )
+        !filters.employees.includes(company.employeeCountCategory)
       )
         return false
 

--- a/apps/directorate-of-equality-web/src/containers/front-page/SectionContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/front-page/SectionContainer.tsx
@@ -39,6 +39,7 @@ const STATUS_LABELS: Record<ReportStatusEnum, string> = {
   [ReportStatusEnum.APPROVED]: 'Samþykkt',
   [ReportStatusEnum.DENIED]: 'Hafnað',
   [ReportStatusEnum.SUPERSEDED]: 'Yfirtekið',
+  [ReportStatusEnum.WITHDRAWN]: 'Dregin til baka',
 }
 
 const STATUS_COLORS: Record<ReportStatusEnum, string> = {
@@ -49,6 +50,7 @@ const STATUS_COLORS: Record<ReportStatusEnum, string> = {
   [ReportStatusEnum.APPROVED]: theme.color.mint600,
   [ReportStatusEnum.DENIED]: theme.color.red400,
   [ReportStatusEnum.SUPERSEDED]: theme.color.blueberry400,
+  [ReportStatusEnum.WITHDRAWN]: theme.color.dark300,
 }
 
 type StatisticsWindow = 'last30Days' | 'currentYear' | 'allTime'

--- a/apps/directorate-of-equality-web/src/lib/constants.ts
+++ b/apps/directorate-of-equality-web/src/lib/constants.ts
@@ -42,6 +42,7 @@ export enum ReportStatusTranslatedEnum {
   APPROVED = 'Afgreitt',
   DENIED = 'Hafnað',
   SUPERSEDED = 'Úrelt',
+  WITHDRAWN = 'Dregin til baka',
 }
 import { overviewText, reportText } from './text'
 

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -10,7 +10,7 @@ const zGetCompaniesQuery = z.object({
   page: z.number().min(1).optional(),
   pageSize: z.number().min(1).optional(),
   q: z.string().optional(),
-  minEmployeeCount: z.number().min(0).optional(),
+  employeeCountCategory: z.enum(['SMALL', 'MEDIUM', 'LARGE']).optional(),
   sortBy: z.enum(['name', 'employeeCount']).optional(),
   direction: z.enum(['asc', 'desc']).optional(),
 })

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
@@ -1,5 +1,7 @@
 import {
   zGetReportByIdPath,
+  zGetReportOutliersPath,
+  zGetReportOutliersQuery,
   zListReportsQuery,
 } from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
@@ -20,6 +22,16 @@ export const reportsRouter = router({
         path: { id: input.id },
       }),
     ),
+
+  getOutliers: protectedProcedure
+    .input(zGetReportOutliersPath.merge(zGetReportOutliersQuery))
+    .query(({ ctx, input }) => {
+      const { id, page, pageSize } = input
+      return ctx.api.getReportOutliers({
+        path: { id },
+        query: { page, pageSize },
+      })
+    }),
 
   overview: protectedProcedure.query(({ ctx }) => ctx.api.getReportOverview()),
 


### PR DESCRIPTION
Persisted outlier rows are now enriched with the engine's analysis fields at read time. ReportEmployeeOutlierDto gained employeeOrdinal, adjustedBaseSalary, predictedBaseSalary, scoreBucketRangeFrom/To, direction, differencePercent, allowedDifferencePercent — merged from the matching report_result.outlier_analysis_snapshot.employees entry by ordinal. No schema change; the snapshot stays the single source of truth.

includesImprovementPlan boolean was added to the list and both detail responses (ReportListItemDto, ReportDetailDto, ApplicationReportDetailDto) plus a hasImprovementPlan filter on GetReportsQueryDto — backed by an EXISTS subquery in buildImprovementPlanWhere.

The outlier list moved off the detail payload into its own paginated endpoint — GET /api/v1/reports/:id/outliers (admin) and GET /api/v1/application/reports/:providerId/outliers (applicant), both returning { outliers, paging } sorted by employeeOrdinal ASC. The detail responses now only carry the boolean, keeping them lightweight for reports with hundreds of outliers.