### PR TITLE
feat(doe): add Úrbótaáætlun filter option and table label to reports screen

### DIFF
--- a/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
@@ -25,10 +25,12 @@ type Props = {
   statusOptions?: FilterOption[]
   reviewerUserId: string[] | null
   reviewers?: FilterOption[]
+  hasImprovementPlan: boolean | null
   onQChange: (value: string | null) => void
   onTypeChange: (values: string[] | null) => void
   onStatusChange: (values: string[] | null) => void
   onReviewerChange: (values: string[] | null) => void
+  onHasImprovementPlanChange: (value: boolean | null) => void
   onReset: () => void
 }
 
@@ -39,10 +41,12 @@ export const ReportFilter = ({
   statusOptions,
   reviewerUserId,
   reviewers,
+  hasImprovementPlan,
   onQChange,
   onTypeChange,
   onStatusChange,
   onReviewerChange,
+  onHasImprovementPlanChange,
   onReset,
 }: Props) => {
   const [dateFrom, setDateFrom] = useState<Date | undefined>()
@@ -106,15 +110,22 @@ export const ReportFilter = ({
         <FilterMultiChoice
           labelClear={sharedText.filter.labelClear}
           onChange={({ categoryId, selected }) => {
-            if (categoryId === 'type')
-              onTypeChange(selected.length ? selected : null)
+            if (categoryId === 'type') {
+              const hasImprovement = selected.includes('IMPROVEMENT_PLAN')
+              const realTypes = selected.filter((v) => v !== 'IMPROVEMENT_PLAN')
+              onTypeChange(realTypes.length ? realTypes : null)
+              onHasImprovementPlanChange(hasImprovement ? true : null)
+            }
             if (categoryId === 'status')
               onStatusChange(selected.length ? selected : null)
             if (categoryId === 'reviewer')
               onReviewerChange(selected.length ? selected : null)
           }}
           onClear={(categoryId) => {
-            if (categoryId === 'type') onTypeChange(null)
+            if (categoryId === 'type') {
+              onTypeChange(null)
+              onHasImprovementPlanChange(null)
+            }
             if (categoryId === 'status') onStatusChange(null)
             if (categoryId === 'reviewer') onReviewerChange(null)
           }}
@@ -122,10 +133,14 @@ export const ReportFilter = ({
             {
               id: 'type',
               label: overviewText.filter.categoryLabel,
-              selected: type ?? [],
+              selected: [
+                ...(type ?? []),
+                ...(hasImprovementPlan ? ['IMPROVEMENT_PLAN'] : []),
+              ],
               filters: [
                 { value: 'EQUALITY', label: 'Jafnréttisáætlun' },
                 { value: 'SALARY', label: 'Skýrslugjöf' },
+                { value: 'IMPROVEMENT_PLAN', label: 'Úrbótaáætlun' },
               ],
             },
             ...extraCategories,

--- a/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
@@ -18,6 +18,9 @@ import * as styles from './ReportFilter.css'
 
 export type FilterOption = { value: string; label: string }
 
+// UI-only virtual filter value — never sent to the API
+const IMPROVEMENT_PLAN_VALUE = 'IMPROVEMENT_PLAN'
+
 type Props = {
   q: string | null
   type: string[] | null
@@ -111,8 +114,8 @@ export const ReportFilter = ({
           labelClear={sharedText.filter.labelClear}
           onChange={({ categoryId, selected }) => {
             if (categoryId === 'type') {
-              const hasImprovement = selected.includes('IMPROVEMENT_PLAN')
-              const realTypes = selected.filter((v) => v !== 'IMPROVEMENT_PLAN')
+              const hasImprovement = selected.includes(IMPROVEMENT_PLAN_VALUE)
+              const realTypes = selected.filter((v) => v !== IMPROVEMENT_PLAN_VALUE)
               onTypeChange(realTypes.length ? realTypes : null)
               onHasImprovementPlanChange(hasImprovement ? true : null)
             }
@@ -135,12 +138,12 @@ export const ReportFilter = ({
               label: overviewText.filter.categoryLabel,
               selected: [
                 ...(type ?? []),
-                ...(hasImprovementPlan ? ['IMPROVEMENT_PLAN'] : []),
+                ...(hasImprovementPlan ? [IMPROVEMENT_PLAN_VALUE] : []),
               ],
               filters: [
                 { value: 'EQUALITY', label: 'Jafnréttisáætlun' },
                 { value: 'SALARY', label: 'Skýrslugjöf' },
-                { value: 'IMPROVEMENT_PLAN', label: 'Úrbótaáætlun' },
+                { value: IMPROVEMENT_PLAN_VALUE, label: 'Úrbótaáætlun' },
               ],
             },
             ...extraCategories,

--- a/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
@@ -226,7 +226,9 @@ export const ReportsContainer = () => {
                   reviewerUserId: reviewerUserId as typeof filter.reviewerUserId,
                 })
               }
-              onHasImprovementPlanChange={(v) => setFilter({ hasImprovementPlan: v })}
+              onHasImprovementPlanChange={(v) =>
+                setFilter({ hasImprovementPlan: v })
+              }
               onReset={resetFilter}
             />
             <Stack space={2}>

--- a/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
@@ -95,10 +95,11 @@ function mapReportToCase(report: ReportListItemDto): Case {
     date: report.createdAt
       ? new Date(report.createdAt).toLocaleDateString('is-IS')
       : '',
-    type:
-      sharedText.typeLabels[
-        report.type as keyof typeof sharedText.typeLabels
-      ] ?? report.type,
+    type: report.includesImprovementPlan
+      ? 'Úrbótaáætlun'
+      : sharedText.typeLabels[
+          report.type as keyof typeof sharedText.typeLabels
+        ] ?? report.type,
     company: report.companyName ?? '',
     kennitala: formatNationalId(report.companyNationalId ?? ''),
     status:
@@ -212,6 +213,7 @@ export const ReportsContainer = () => {
               statusOptions={statusOptions}
               reviewerUserId={filter.reviewerUserId as string[] | null}
               reviewers={needsUsers ? reviewerOptions : undefined}
+              hasImprovementPlan={filter.hasImprovementPlan ?? null}
               onQChange={(q) => setFilter({ q })}
               onTypeChange={(type) =>
                 setFilter({ type: type as typeof filter.type })
@@ -221,10 +223,10 @@ export const ReportsContainer = () => {
               }
               onReviewerChange={(reviewerUserId) =>
                 setFilter({
-                  reviewerUserId:
-                    reviewerUserId as typeof filter.reviewerUserId,
+                  reviewerUserId: reviewerUserId as typeof filter.reviewerUserId,
                 })
               }
+              onHasImprovementPlanChange={(v) => setFilter({ hasImprovementPlan: v })}
               onReset={resetFilter}
             />
             <Stack space={2}>


### PR DESCRIPTION
## What

- Adds **Úrbótaáætlun** as a third checkbox in the reports category filter (alongside Jafnréttisáætlun and Skýrslugjöf), wired to the existing `hasImprovementPlan` API query param
- Uses a UI-only virtual value inside the existing `type` category — the `onChange` handler splits it so real types go to `type[]` and the virtual value drives `hasImprovementPlan: true | null` separately
- Reports with `includesImprovementPlan === true` now display **Úrbótaáætlun** as their type label in the table instead of Skýrslugjöf

## No backend changes needed
`hasImprovementPlan` was already supported end-to-end: nuqs parser, TRPC router, and API query param were all in place.