### PR TITLE
feat(doe): error handling and error screen

### DIFF
--- a/apps/directorate-of-equality-web/src/app/(protected)/error.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/error.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
+
+import { useEffect } from 'react'
+
+import { forceLogin } from '@dmr.is/auth/useLogOut'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { ProblemTemplate } from '@dmr.is/ui/components/island-is/ProblemTemplate'
+
+import { serverErrorText } from '../../lib/text'
+
+export default function ProtectedError({
+  error: _error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  const pathName = usePathname()
+  const router = useRouter()
+  const { data: session, status } = useSession()
+
+  useEffect(() => {
+    if (session?.invalid === true && status === 'authenticated') {
+      forceLogin(pathName ?? '/innskraning')
+    }
+  }, [session?.invalid, status, pathName])
+
+  return (
+    <GridContainer>
+      <Box marginTop={10}>
+        <ProblemTemplate
+          variant="error"
+          title={serverErrorText.title}
+          message={serverErrorText.message}
+          noBorder={false}
+          imgSrc="/assets/tolfraedi-image.svg"
+        />
+        <Box
+          display="flex"
+          justifyContent="center"
+          columnGap={2}
+          marginTop={4}
+        >
+          <Button variant="primary" onClick={() => reset()}>
+            {serverErrorText.tryAgain}
+          </Button>
+          <Button variant="ghost" onClick={() => router.push('/yfirlit')}>
+            {serverErrorText.backToOverview}
+          </Button>
+        </Box>
+      </Box>
+    </GridContainer>
+  )
+}

--- a/apps/directorate-of-equality-web/src/app/(protected)/yfirlit/[id]/not-found.tsx
+++ b/apps/directorate-of-equality-web/src/app/(protected)/yfirlit/[id]/not-found.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { ProblemTemplate } from '@dmr.is/ui/components/island-is/ProblemTemplate'
+
+import { reportNotFoundText } from '../../../../lib/text'
+
+export default function ReportNotFound() {
+  return (
+    <GridContainer>
+      <Box marginTop={10}>
+        <ProblemTemplate
+          variant="info"
+          title={reportNotFoundText.title}
+          message={reportNotFoundText.message}
+          noBorder={false}
+          imgSrc="/assets/tolfraedi-image.svg"
+        />
+        <Box display="flex" justifyContent="center" marginTop={4}>
+          <Link href="/yfirlit">
+            <Button variant="primary">{reportNotFoundText.backToOverview}</Button>
+          </Link>
+        </Box>
+      </Box>
+    </GridContainer>
+  )
+}

--- a/apps/directorate-of-equality-web/src/app/error.tsx
+++ b/apps/directorate-of-equality-web/src/app/error.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { ProblemTemplate } from '@dmr.is/ui/components/island-is/ProblemTemplate'
+
+import { serverErrorText } from '../lib/text'
+
+export default function RootError({
+  error: _error,
+  reset,
+}: {
+  error: Error
+  reset: () => void
+}) {
+  return (
+    <GridContainer>
+      <Box marginTop={10}>
+        <ProblemTemplate
+          variant="error"
+          title={serverErrorText.title}
+          message={serverErrorText.message}
+          noBorder={false}
+          imgSrc="/assets/tolfraedi-image.svg"
+        />
+        <Box display="flex" justifyContent="center" marginTop={4}>
+          <Button variant="primary" onClick={() => reset()}>
+            {serverErrorText.tryAgain}
+          </Button>
+        </Box>
+      </Box>
+    </GridContainer>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/users/UserModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/users/UserModal.tsx
@@ -63,6 +63,17 @@ export const UserModal = ({ user, isOpen, onClose }: Props) => {
         toast.success(u.createSuccess)
         onClose()
       },
+      onError: (error) => {
+        //TODO: Revisit error handling here, ideally the API would return a specific error code for this case instead of relying on the error message
+        const userAlreadyExists = 'User with this national ID already exists'
+        const message =
+          error instanceof Error
+            ? error.message === userAlreadyExists
+              ? u.userAlreadyExists
+              : u.createError + ' - ' + error.message
+            : u.createError
+        toast.error(message, { autoClose: 5000 })
+      },
     }),
   )
 
@@ -72,6 +83,10 @@ export const UserModal = ({ user, isOpen, onClose }: Props) => {
         queryClient.invalidateQueries({ queryKey: trpc.user.list.queryKey() })
         toast.success(u.saveSuccess)
         onClose()
+      },
+      onError: (error) => {
+        const message = error instanceof Error ? error.message : u.saveError
+        toast.error(u.saveError + ' - ' + message, { autoClose: 5000 })
       },
     }),
   )

--- a/apps/directorate-of-equality-web/src/components/users/UserModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/users/UserModal.tsx
@@ -85,8 +85,11 @@ export const UserModal = ({ user, isOpen, onClose }: Props) => {
         onClose()
       },
       onError: (error) => {
-        const message = error instanceof Error ? error.message : u.saveError
-        toast.error(u.saveError + ' - ' + message, { autoClose: 5000 })
+        const message =
+          error instanceof Error
+            ? u.saveError + ' - ' + error.message
+            : u.saveError
+        toast.error(message, { autoClose: 5000 })
       },
     }),
   )

--- a/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 
 import { useQuery } from '@dmr.is/trpc/client/trpc'
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
@@ -23,13 +24,14 @@ import {
 } from '../../gen/fetch'
 import { useCompanies } from '../../hooks/useCompanies'
 import { useIsTablet } from '../../hooks/useIsTablet'
+import { serverErrorText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
 export const CompaniesContainer = () => {
   const { isTablet } = useIsTablet()
   const [isModalOpen, setIsModalOpen] = useState(false)
 
-  const { data, filter, setFilter, resetFilter } = useCompanies({
+  const { data, isError, filter, setFilter, resetFilter } = useCompanies({
     pageSize: 10,
   })
 
@@ -135,6 +137,15 @@ export const CompaniesContainer = () => {
           {!isTablet && newButton}
         </GridColumn>
         <GridColumn span={['12/12', '12/12', '12/12', '9/12']}>
+          {isError && (
+            <Box marginBottom={3}>
+              <AlertMessage
+                type="error"
+                title={serverErrorText.title}
+                message={serverErrorText.message}
+              />
+            </Box>
+          )}
           {data?.paging && (
             <CompanyTable
               rows={rows}

--- a/apps/directorate-of-equality-web/src/containers/front-page/SectionContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/front-page/SectionContainer.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic'
 import { useState } from 'react'
 
 import { theme } from '@dmr.is/island-ui-theme'
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
@@ -18,10 +19,10 @@ import { TrackerTable } from '@dmr.is/ui/components/Tables/TrackerTable'
 import { Wrapper } from '@dmr.is/ui/components/Wrapper/Wrapper'
 
 import { ReportStatusEnum } from '../../gen/fetch/types.gen'
-import { frontPageText, overviewText, sharedText } from '../../lib/text'
+import { frontPageText, overviewText, serverErrorText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
-import { useSuspenseQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 
 const PieChart = dynamic(
   () =>
@@ -100,23 +101,26 @@ export const SectionContainer = ({ userId }: Props) => {
   const [statsWindow, setStatsWindow] = useState<StatisticsWindow>('last30Days')
 
   const trpc = useTRPC()
-  const { data: overview } = useSuspenseQuery(
+  const { data: overview, isError: overviewError } = useQuery(
     trpc.reports.overview.queryOptions(),
   )
-  const { data: statistics } = useSuspenseQuery(
+  const { data: statistics, isError: statisticsError } = useQuery(
     trpc.reports.overviewStatistics.queryOptions(),
   )
 
-  const windowItems = statistics[statsWindow].items
-  const pieItems = CHART_STATUSES.map((status) => {
-    const match = windowItems.find((i) => i.status === status)
-    return {
-      color: STATUS_COLORS[status],
-      title: STATUS_LABELS[status],
-      count: match?.count ?? 0,
-      percentage: match?.percentage ?? 0,
-    }
-  })
+  const pieItems = statistics
+    ? CHART_STATUSES.map((status) => {
+        const match = statistics[statsWindow].items.find(
+          (i) => i.status === status,
+        )
+        return {
+          color: STATUS_COLORS[status],
+          title: STATUS_LABELS[status],
+          count: match?.count ?? 0,
+          percentage: match?.percentage ?? 0,
+        }
+      })
+    : []
 
   return (
     <Section bleed variant="blue">
@@ -136,79 +140,97 @@ export const SectionContainer = ({ userId }: Props) => {
                 }
                 linkText={overviewText.openAdmin}
               >
-                <Tabs
-                  label="Mál flokkar"
-                  selected={selectedTab}
-                  onChange={setSelectedTab}
-                  contentBackground="white"
-                  tabs={[
-                    {
-                      id: 'almennt',
-                      label: frontPageText.tabGeneral,
-                      content: (
-                        <TrackerTable
-                          rows={[
-                            {
-                              text: `${overview.general.submittedToday} ný mál hafa borist í dag`,
-                            },
-                            {
-                              text: `${overview.general.inProgress} mál eru til skoðunar hjá starfsmönnum`,
-                            },
-                            {
-                              text: `${overview.general.reportsWithComments} opin mál eru með skráðar athugasemdir`,
-                            },
-                            {
-                              text: `${overview.general.reportsWithoutEmployee} opin mál eru án úthlutaðs starfsmanns`,
-                            },
-                          ]}
-                        />
-                      ),
-                    },
-                    {
-                      id: 'min-mal',
-                      label: frontPageText.tabMine,
-                      content: (
-                        <TrackerTable
-                          rows={[
-                            {
-                              text: `${overview.assigned.totalAssigned} opin mál eru úthlutað til mín`,
-                            },
-                            {
-                              text: `${overview.assigned.assignedWithComments} af mínum málum eru með skráðar athugasemdir`,
-                            },
-                          ]}
-                        />
-                      ),
-                    },
-                  ]}
-                />
+                {overviewError ? (
+                  <AlertMessage
+                    type="error"
+                    title={serverErrorText.title}
+                    message={serverErrorText.message}
+                  />
+                ) : (
+                  <Tabs
+                    label="Mál flokkar"
+                    selected={selectedTab}
+                    onChange={setSelectedTab}
+                    contentBackground="white"
+                    tabs={[
+                      {
+                        id: 'almennt',
+                        label: frontPageText.tabGeneral,
+                        content: (
+                          <TrackerTable
+                            rows={[
+                              {
+                                text: `${overview?.general.submittedToday ?? 0} ný mál hafa borist í dag`,
+                              },
+                              {
+                                text: `${overview?.general.inProgress ?? 0} mál eru til skoðunar hjá starfsmönnum`,
+                              },
+                              {
+                                text: `${overview?.general.reportsWithComments ?? 0} opin mál eru með skráðar athugasemdir`,
+                              },
+                              {
+                                text: `${overview?.general.reportsWithoutEmployee ?? 0} opin mál eru án úthlutaðs starfsmanns`,
+                              },
+                            ]}
+                          />
+                        ),
+                      },
+                      {
+                        id: 'min-mal',
+                        label: frontPageText.tabMine,
+                        content: (
+                          <TrackerTable
+                            rows={[
+                              {
+                                text: `${overview?.assigned.totalAssigned ?? 0} opin mál eru úthlutað til mín`,
+                              },
+                              {
+                                text: `${overview?.assigned.assignedWithComments ?? 0} af mínum málum eru með skráðar athugasemdir`,
+                              },
+                            ]}
+                          />
+                        ),
+                      },
+                    ]}
+                  />
+                )}
               </Wrapper>
             </Stack>
           </GridColumn>
           <GridColumn span={['12/12', '5/12']}>
             <Wrapper title={frontPageText.statsTitle}>
-              <Box
-                display="flex"
-                flexWrap="wrap"
-                columnGap={1}
-                rowGap={1}
-                marginBottom={2}
-              >
-                {STATS_WINDOWS.map(({ id, label, variant }) => (
-                  <Tag
-                    key={id}
-                    active={statsWindow === id}
-                    variant={variant}
-                    onClick={() => setStatsWindow(id)}
+              {statisticsError ? (
+                <AlertMessage
+                  type="error"
+                  title={serverErrorText.title}
+                  message={serverErrorText.message}
+                />
+              ) : (
+                <>
+                  <Box
+                    display="flex"
+                    flexWrap="wrap"
+                    columnGap={1}
+                    rowGap={1}
+                    marginBottom={2}
                   >
-                    {label}
-                  </Tag>
-                ))}
-              </Box>
-              <PieChart
-                intro={STATS_WINDOW_INTROS[statsWindow]}
-                items={pieItems}
-              />
+                    {STATS_WINDOWS.map(({ id, label, variant }) => (
+                      <Tag
+                        key={id}
+                        active={statsWindow === id}
+                        variant={variant}
+                        onClick={() => setStatsWindow(id)}
+                      >
+                        {label}
+                      </Tag>
+                    ))}
+                  </Box>
+                  <PieChart
+                    intro={STATS_WINDOW_INTROS[statsWindow]}
+                    items={pieItems}
+                  />
+                </>
+              )}
             </Wrapper>
           </GridColumn>
         </GridRow>

--- a/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
@@ -2,11 +2,14 @@
 
 import { useState } from 'react'
 
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+
 import { CommentsForm } from '../../components/report/report-tabs/comments/CommentsForm'
 import {
   CommentVisibilityEnum,
   ReportStatusEnum,
 } from '../../gen/fetch/types.gen'
+import { reportText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -39,6 +42,7 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
         queryKey: trpc.reports.getById.queryKey({ id: reportId }),
       })
     },
+    onError: () => toast.error(reportText.comments.createError),
   })
 
   const { mutate: deleteComment } = useMutation({
@@ -48,6 +52,7 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
         queryKey: trpc.reports.getById.queryKey({ id: reportId }),
       })
     },
+    onError: () => toast.error(reportText.comments.deleteError),
   })
 
   const handleSubmit = () => {
@@ -63,6 +68,7 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
 
   const handleDelete = (commentId: string) => {
     deleteComment({ reportId, commentId })
+    toast.success(reportText.comments.deleteSuccess)
   }
 
   return (

--- a/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
@@ -48,6 +48,7 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
   const { mutate: deleteComment } = useMutation({
     ...trpc.reportComments.delete.mutationOptions(),
     onSuccess: () => {
+      toast.success(reportText.comments.deleteSuccess)
       queryClient.invalidateQueries({
         queryKey: trpc.reports.getById.queryKey({ id: reportId }),
       })
@@ -68,7 +69,6 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
 
   const handleDelete = (commentId: string) => {
     deleteComment({ reportId, commentId })
-    toast.success(reportText.comments.deleteSuccess)
   }
 
   return (

--- a/apps/directorate-of-equality-web/src/containers/report/ReportTabsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportTabsContainer.tsx
@@ -38,7 +38,7 @@ export function ReportTabsContainer({ report }: ReportTabsContainerProps) {
       <AlertMessage
         type="error"
         title={reportText.salaryStatsLoadError}
-        message=""
+        message={reportText.salaryStatsLoadErrorMessage}
       />
     )
   }

--- a/apps/directorate-of-equality-web/src/containers/report/ReportTabsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportTabsContainer.tsx
@@ -1,9 +1,11 @@
 'use client'
 
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
 
 import { ReportTabs } from '../../components/report/report-tabs/ReportTabs'
 import { ReportDetailDto, ReportTypeEnum } from '../../gen/fetch'
+import { reportText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
 import { useQuery } from '@tanstack/react-query'
@@ -16,7 +18,11 @@ export function ReportTabsContainer({ report }: ReportTabsContainerProps) {
   const trpc = useTRPC()
   const isSalary = report.type === ReportTypeEnum.SALARY
 
-  const { data: salaryStats, isLoading: salaryLoading } = useQuery({
+  const {
+    data: salaryStats,
+    isLoading: salaryLoading,
+    isError: salaryError,
+  } = useQuery({
     ...trpc.reportStatistics.baseSalaryByGenderAndScoreAll.queryOptions({
       reportId: report.id,
     }),
@@ -25,6 +31,16 @@ export function ReportTabsContainer({ report }: ReportTabsContainerProps) {
 
   if (isSalary && salaryLoading) {
     return <SkeletonLoader repeat={4} height={44} space={1} />
+  }
+
+  if (isSalary && salaryError) {
+    return (
+      <AlertMessage
+        type="error"
+        title={reportText.salaryStatsLoadError}
+        message=""
+      />
+    )
   }
 
   return <ReportTabs report={report} salaryStats={salaryStats} />

--- a/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
@@ -3,6 +3,7 @@
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
 
 import { useQuery } from '@dmr.is/trpc/client/trpc'
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
@@ -34,7 +35,7 @@ import {
   COLUMN_STATUS,
   COLUMNS,
 } from '../../lib/constants'
-import { overviewText, sharedText } from '../../lib/text'
+import { overviewText, serverErrorText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 import { formatNationalId } from '../../lib/utils'
 
@@ -176,7 +177,7 @@ export const ReportsContainer = () => {
   const fixedStatus = TAB_FIXED_STATUS[activeTab]
   const fixedQuery = fixedStatus ? { status: fixedStatus } : undefined
 
-  const { data, isLoading, filter, setFilter, resetFilter } =
+  const { data, isLoading, isError, filter, setFilter, resetFilter } =
     useReports(fixedQuery)
 
   const needsUsers = activeTab !== 'innsendingar'
@@ -284,6 +285,20 @@ export const ReportsContainer = () => {
       </GridRow>
     </Box>
   )
+
+  if (isError) {
+    return (
+      <GridContainer>
+        <Box marginTop={4}>
+          <AlertMessage
+            type="error"
+            title={serverErrorText.title}
+            message={serverErrorText.message}
+          />
+        </Box>
+      </GridContainer>
+    )
+  }
 
   return (
     <GridContainer>

--- a/apps/directorate-of-equality-web/src/hooks/useCompanies.ts
+++ b/apps/directorate-of-equality-web/src/hooks/useCompanies.ts
@@ -26,7 +26,7 @@ export function useCompanies(fixedQuery?: Partial<GetCompaniesInput>) {
     ]),
   )
 
-  const { data, isLoading, isFetching } = useQuery(
+  const { data, isLoading, isFetching, isError } = useQuery(
     trpc.company.list.queryOptions(query, { placeholderData: (prev) => prev }),
   )
 
@@ -37,5 +37,5 @@ export function useCompanies(fixedQuery?: Partial<GetCompaniesInput>) {
       ) as Parameters<typeof setFilter>[0],
     )
 
-  return { data, isLoading, isFetching, filter, setFilter, resetFilter }
+  return { data, isLoading, isFetching, isError, filter, setFilter, resetFilter }
 }

--- a/apps/directorate-of-equality-web/src/hooks/useReports.ts
+++ b/apps/directorate-of-equality-web/src/hooks/useReports.ts
@@ -37,7 +37,7 @@ export function useReports(
     }).map(([k, v]) => [k, v ?? undefined]),
   )
 
-  const { data, isLoading, isFetching } = useQuery(
+  const { data, isLoading, isFetching, isError } = useQuery(
     trpc.reports.list.queryOptions(query, { placeholderData: (prev) => prev }),
   )
 
@@ -48,5 +48,5 @@ export function useReports(
       ) as Parameters<typeof setFilter>[0],
     )
 
-  return { data, isLoading, isFetching, filter, setFilter, resetFilter }
+  return { data, isLoading, isFetching, isError, filter, setFilter, resetFilter }
 }

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -204,6 +204,8 @@ export const reportText = {
     movesToStatus: 'færir mál í stöðuna:',
   },
   salaryStatsLoadError: 'Villa við að hlaða tölfræðigögn fyrir skýrslu',
+  salaryStatsLoadErrorMessage:
+    'Vinsamlegast reyndu aftur síðar eða hafðu samband við kerfisstjóra ef vandamálið heldur áfram.',
   loadError: 'Villa kom upp við að hlaða skýrslu',
   loadSidebarError: 'Villa kom upp við að hlaða hliðarstiku',
 }
@@ -296,7 +298,8 @@ export const notFoundText = {
 
 export const reportNotFoundText = {
   title: 'Skýrsla fannst ekki',
-  message: 'Engin skýrsla fannst með þetta auðkenni. Mögulega hefur hún verið fjarlægð eða auðkennið er rangt.',
+  message:
+    'Engin skýrsla fannst með þetta auðkenni. Mögulega hefur hún verið fjarlægð eða auðkennið er rangt.',
   backToOverview: 'Til baka í yfirlit',
 }
 

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -286,6 +286,14 @@ export const notFoundText = {
     'Ekkert fannst á þessari slóð. Mögulega hefur síðan verið fjarlægð eða færð til.',
 }
 
+export const serverErrorText = {
+  title: 'Eitthvað fór úrskeiðis',
+  message:
+    'Villa kom upp við að sækja gögn. Vinsamlegast reyndu aftur síðar eða hafðu samband við kerfisstjóra ef vandinn líður áfram.',
+  tryAgain: 'Reyna aftur',
+  backToOverview: 'Til baka í yfirlit',
+}
+
 export const headerText = {
   logoAlt: 'Jafnréttisstofa logo',
   brand: 'Jafnréttisstofa',

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -110,6 +110,9 @@ export const reportText = {
     submit: 'Vista athugasemd',
     visibleToApplicant: 'Sýnileg innsendanda',
     seeAllComments: 'Sjá allar athugasemdir',
+    createError: 'Villa við að vista athugasemd',
+    deleteError: 'Villa við að eyða athugasemd',
+    deleteSuccess: 'Athugasemd eytt',
   },
   statusSelect: {
     successToast: 'Uppfærsla á stöðu tókst.',
@@ -200,6 +203,7 @@ export const reportText = {
     claimsCase: 'merkir sér málið',
     movesToStatus: 'færir mál í stöðuna:',
   },
+  salaryStatsLoadError: 'Villa við að hlaða tölfræðigögn fyrir skýrslu',
   loadError: 'Villa kom upp við að hlaða skýrslu',
   loadSidebarError: 'Villa kom upp við að hlaða hliðarstiku',
 }
@@ -261,6 +265,10 @@ export const usersText = {
     save: 'Vista breytingar',
     createSuccess: 'Ritstjóri stofnaður',
     saveSuccess: 'Breytingar vistaðar',
+    createError: 'Villa við stofnun ritstjóra',
+    userAlreadyExists:
+      'Ritstjóri með þessari kennitölu er þegar til. Athugaðu hvort hann geti verið í listanum yfir óvirka ritstjóra.',
+    saveError: 'Villa við vistun breytinga',
   },
 }
 
@@ -284,6 +292,12 @@ export const notFoundText = {
   title: 'Síða fannst ekki',
   message:
     'Ekkert fannst á þessari slóð. Mögulega hefur síðan verið fjarlægð eða færð til.',
+}
+
+export const reportNotFoundText = {
+  title: 'Skýrsla fannst ekki',
+  message: 'Engin skýrsla fannst með þetta auðkenni. Mögulega hefur hún verið fjarlægð eða auðkennið er rangt.',
+  backToOverview: 'Til baka í yfirlit',
 }
 
 export const serverErrorText = {


### PR DESCRIPTION
## What 

Adds global error boundaries and fills in missing error handling across all major data flows.

 ### Error screens
  - app/error.tsx — root-level error boundary for unexpected errors
  - app/(protected)/error.tsx — protected routes boundary; handles invalid sessions and API failures with retry + back-to-overview actions
  - app/(protected)/yfirlit/[id]/not-found.tsx — report-specific 404 (wrong ID) distinct from the global page-not-found

 ### Missing onError handlers added
  - Create/delete comment
  - Create/update user

 ### Query error states
  - Reports overview list — replaces tab view with AlertMessage on failure
  - Companies list — shows AlertMessage above table on failure
  - Salary stats chart — shows AlertMessage in place of chart on failure
  - Frontpage overview tabs and statistics chart — switched from useSuspenseQuery to useQuery so failures degrade to inline AlertMessage per panel rather than breaking the whole page

 ### How errors route
  - 404 from API → notFound() → nearest segment not-found.tsx
  - 5xx / network error on page load → throws → (protected)/error.tsx
  - Mutation failure → error toast
  - Background query failure → inline AlertMessage in the affected panel