### PR TITLE
feat(doe): Company size unknown option

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260603-doe-company-size-unknown.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260603-doe-company-size-unknown.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Add UNKNOWN as the lowest-ordered company size. It is the default for
+    // companies we have not yet classified (e.g. auto-provisioned on report
+    // submission): it imposes no reporting obligation, but is honest about the
+    // size being unknown rather than asserting the company is SMALL.
+    //
+    // ALTER TYPE ... ADD VALUE must be committed before the new value can be
+    // referenced (Postgres forbids using it in the same transaction), so the
+    // SET DEFAULT statements run separately, after this commits.
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_size_enum ADD VALUE IF NOT EXISTS 'UNKNOWN' BEFORE 'SMALL';
+    `)
+
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+      ALTER TABLE company
+        ALTER COLUMN employee_count_category SET DEFAULT 'UNKNOWN';
+      ALTER TABLE company_report
+        ALTER COLUMN employee_count_category SET DEFAULT 'UNKNOWN';
+
+      COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    // Restore the previous default. Postgres has no DROP VALUE, so the
+    // 'UNKNOWN' enum member is left in place (removing it would require
+    // recreating the type). Safe in practice: with no obligation attached,
+    // any UNKNOWN rows behave like SMALL.
+    return await queryInterface.sequelize.query(`
+      BEGIN;
+
+      ALTER TABLE company
+        ALTER COLUMN employee_count_category SET DEFAULT 'SMALL';
+      ALTER TABLE company_report
+        ALTER COLUMN employee_count_category SET DEFAULT 'SMALL';
+
+      COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -106,7 +106,7 @@ describe('CompanyService', () => {
       })
     })
 
-    it('creates a new company with the registry name and zero employee count when missing', async () => {
+    it('creates a new company with the registry name and unknown employee count category when missing', async () => {
       findOne.mockResolvedValue(null)
       getEntityByNationalId.mockResolvedValue({
         entity: makeRegistryEntity({
@@ -119,7 +119,7 @@ describe('CompanyService', () => {
           id: 'company-2',
           name: 'Registry Name ehf.',
           nationalId: '6601234567',
-          employeeCountCategory: CompanySizeEnum.SMALL,
+          employeeCountCategory: CompanySizeEnum.UNKNOWN,
         }),
       )
 
@@ -131,13 +131,13 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Registry Name ehf.',
         nationalId: '6601234567',
-        employeeCountCategory: CompanySizeEnum.SMALL,
+        employeeCountCategory: CompanySizeEnum.UNKNOWN,
       })
       expect(result).toEqual({
         id: 'company-2',
         name: 'Registry Name ehf.',
         nationalId: '6601234567',
-        employeeCountCategory: CompanySizeEnum.SMALL,
+        employeeCountCategory: CompanySizeEnum.UNKNOWN,
       })
     })
 
@@ -149,7 +149,7 @@ describe('CompanyService', () => {
           id: 'company-3',
           name: 'Body-provided name',
           nationalId: '7701234567',
-          employeeCountCategory: CompanySizeEnum.SMALL,
+          employeeCountCategory: CompanySizeEnum.UNKNOWN,
         }),
       )
 
@@ -161,7 +161,7 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Body-provided name',
         nationalId: '7701234567',
-        employeeCountCategory: CompanySizeEnum.SMALL,
+        employeeCountCategory: CompanySizeEnum.UNKNOWN,
       })
       expect(result.name).toBe('Body-provided name')
     })
@@ -235,7 +235,7 @@ describe('CompanyService', () => {
           id: 'company-2',
           name: 'Subsidiary ehf.',
           nationalId: '6601234567',
-          employeeCountCategory: CompanySizeEnum.SMALL,
+          employeeCountCategory: CompanySizeEnum.UNKNOWN,
         }),
       )
 
@@ -247,7 +247,7 @@ describe('CompanyService', () => {
       expect(create).toHaveBeenCalledWith({
         name: 'Subsidiary ehf.',
         nationalId: '6601234567',
-        employeeCountCategory: CompanySizeEnum.SMALL,
+        employeeCountCategory: CompanySizeEnum.UNKNOWN,
       })
       expect(result).toEqual({
         companyId: 'company-2',

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -87,7 +87,7 @@ export class CompanyService implements ICompanyService {
         ? [
             [
               literal(
-                `CASE employee_count_category WHEN 'SMALL' THEN 1 WHEN 'MEDIUM' THEN 2 WHEN 'LARGE' THEN 3 END`,
+                `CASE employee_count_category WHEN 'UNKNOWN' THEN 0 WHEN 'SMALL' THEN 1 WHEN 'MEDIUM' THEN 2 WHEN 'LARGE' THEN 3 END`,
               ),
               sortDir,
             ],
@@ -208,7 +208,7 @@ export class CompanyService implements ICompanyService {
     const company = await this.companyModel.create({
       name,
       nationalId,
-      employeeCountCategory: CompanySizeEnum.SMALL,
+      employeeCountCategory: CompanySizeEnum.UNKNOWN,
     })
 
     return company.fromModel()
@@ -241,7 +241,7 @@ export class CompanyService implements ICompanyService {
       (await this.companyModel.create({
         name: registry.entity.nafn,
         nationalId: input.nationalId,
-        employeeCountCategory: CompanySizeEnum.SMALL,
+        employeeCountCategory: CompanySizeEnum.UNKNOWN,
       }))
 
     return {

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
@@ -3,19 +3,26 @@
  * `company.employee_count_category` and snapshotted onto `company_report`.
  *
  * Bucket boundaries (regulatory):
- *   SMALL  → 0–24 employees
- *   MEDIUM → 25–49 employees
- *   LARGE  → 50+ employees
+ *   UNKNOWN → size not yet established (e.g. auto-provisioned company)
+ *   SMALL   → 0–24 employees
+ *   MEDIUM  → 25–49 employees
+ *   LARGE   → 50+ employees
+ *
+ * UNKNOWN is the default for companies we have no headcount for: it imposes no
+ * reporting obligations (like SMALL) until an admin classifies the company, but
+ * is honest about the size being unknown rather than asserting it is small.
  *
  * The LARGE bucket is the threshold that triggers a required salary report
  * (see the `company_sync_salary_report_required` DB trigger).
  *
  * Declaration order is load-bearing: Postgres orders enum values by
  * declaration order, so `ORDER BY employee_count_category` yields
- * SMALL < MEDIUM < LARGE. A future bucket (e.g. between MEDIUM and LARGE)
- * can be inserted in Postgres with `ALTER TYPE ... ADD VALUE 'XYZ' BEFORE 'LARGE'`.
+ * UNKNOWN < SMALL < MEDIUM < LARGE. A future bucket (e.g. between MEDIUM and
+ * LARGE) can be inserted in Postgres with
+ * `ALTER TYPE ... ADD VALUE 'XYZ' BEFORE 'LARGE'`.
  */
 export enum CompanySizeEnum {
+  UNKNOWN = 'UNKNOWN',
   SMALL = 'SMALL',
   MEDIUM = 'MEDIUM',
   LARGE = 'LARGE',

--- a/apps/directorate-of-equality-api/src/modules/company/utils/filters.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/utils/filters.ts
@@ -11,6 +11,12 @@ export enum CompanyStatusFilterEnum {
   COMPLIANT = 'compliant',
 }
 
+// Sizes that carry no reporting obligation. UNKNOWN means we have not yet
+// classified the company, so it imposes nothing until an admin sets a size.
+const NO_REQUIREMENT_SIZES = [CompanySizeEnum.SMALL, CompanySizeEnum.UNKNOWN]
+// Sizes that must file an equality report (LARGE additionally needs salary).
+const EQUALITY_REQUIRED_SIZES = [CompanySizeEnum.MEDIUM, CompanySizeEnum.LARGE]
+
 function activeReportExists(type: 'SALARY' | 'EQUALITY'): string {
   return `EXISTS (
     SELECT 1 FROM "${DoeModels.COMPANY_REPORT}" cr
@@ -40,19 +46,19 @@ function statusCondition(status: CompanyStatusFilterEnum): WhereOptions {
           {
             [Op.and]: [needsSalary, literal(activeReportExists('SALARY'))],
           },
-          // MEDIUM: equality requirement fulfilled (no salary needed, not SMALL)
+          // MEDIUM: equality requirement fulfilled (no salary needed)
           {
             [Op.and]: [
               noSalaryNeeded,
-              { employeeCountCategory: { [Op.ne]: CompanySizeEnum.SMALL } },
+              { employeeCountCategory: { [Op.in]: EQUALITY_REQUIRED_SIZES } },
               literal(activeReportExists('EQUALITY')),
             ],
           },
-          // SMALL: no requirements and nothing submitted
+          // SMALL / UNKNOWN: no requirements and nothing submitted
           {
             [Op.and]: [
               noSalaryNeeded,
-              { employeeCountCategory: CompanySizeEnum.SMALL },
+              { employeeCountCategory: { [Op.in]: NO_REQUIREMENT_SIZES } },
               literal(`NOT ${activeReportExists('EQUALITY')}`),
             ],
           },
@@ -82,11 +88,11 @@ function statusCondition(status: CompanyStatusFilterEnum): WhereOptions {
               literal(`NOT ${activeReportExists('EQUALITY')}`),
             ],
           },
-          // Non-SMALL, no salary obligation, no equality
+          // MEDIUM/LARGE, no salary obligation, no equality
           {
             [Op.and]: [
               noSalaryNeeded,
-              { employeeCountCategory: { [Op.ne]: CompanySizeEnum.SMALL } },
+              { employeeCountCategory: { [Op.in]: EQUALITY_REQUIRED_SIZES } },
               literal(`NOT ${activeReportExists('EQUALITY')}`),
             ],
           },

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -2652,7 +2652,7 @@
       },
       "CompanySizeEnum": {
         "type": "string",
-        "enum": ["SMALL", "MEDIUM", "LARGE"]
+        "enum": ["UNKNOWN", "SMALL", "MEDIUM", "LARGE"]
       },
       "CompanyStatusFilterEnum": {
         "type": "string",

--- a/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
+++ b/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
@@ -89,14 +89,18 @@ export function deriveStatus(
     company,
     approvedReports,
   )
-  const isSmall = company.employeeCountCategory === CompanySizeEnum.SMALL
+  // UNKNOWN and SMALL both carry no reporting obligation. UNKNOWN means the
+  // company size has not been classified yet, so we impose nothing until it is.
+  const noRequirement =
+    company.employeeCountCategory === CompanySizeEnum.SMALL ||
+    company.employeeCountCategory === CompanySizeEnum.UNKNOWN
 
   if (needsSalary && hasSalary) return 'compliant' // LARGE: both reports filed
   if (needsSalary && hasEquality) return 'missing-salary' // LARGE: equality done, salary missing
   if (needsSalary) return 'missing-equality' // LARGE: equality is the prerequisite
   // No salary requirement below this line
-  if (!isSmall && hasEquality) return 'compliant' // MEDIUM with equality: obligation met
-  if (!isSmall) return 'missing-equality' // MEDIUM without equality
-  if (hasEquality) return 'has-equality' // SMALL voluntary submission
-  return 'compliant' // SMALL with nothing: no obligation
+  if (!noRequirement && hasEquality) return 'compliant' // MEDIUM with equality: obligation met
+  if (!noRequirement) return 'missing-equality' // MEDIUM without equality
+  if (hasEquality) return 'has-equality' // SMALL/UNKNOWN voluntary submission
+  return 'compliant' // SMALL/UNKNOWN with nothing: no obligation
 }

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -10,7 +10,7 @@ const zGetCompaniesQuery = z.object({
   page: z.number().min(1).optional(),
   pageSize: z.number().min(1).optional(),
   q: z.string().optional(),
-  employeeCountCategory: z.enum(['SMALL', 'MEDIUM', 'LARGE']).optional(),
+  employeeCountCategory: z.enum(['UNKNOWN', 'SMALL', 'MEDIUM', 'LARGE']).optional(),
   companyStatus: z
     .array(
       z.enum(['missing-equality', 'has-equality', 'missing-salary', 'compliant']),

--- a/apps/directorate-of-equality-web/src/lib/utils.ts
+++ b/apps/directorate-of-equality-web/src/lib/utils.ts
@@ -37,9 +37,11 @@ export const EMPLOYEE_RANGES = [
   { value: CompanySizeEnum.SMALL, label: '0–24' },
   { value: CompanySizeEnum.MEDIUM, label: '25–49' },
   { value: CompanySizeEnum.LARGE, label: '50+' },
+  { value: CompanySizeEnum.UNKNOWN, label: 'Óþekkt' },
 ]
 
 export const COMPANY_SIZE_LABEL: Record<CompanySizeEnum, string> = {
+  [CompanySizeEnum.UNKNOWN]: 'Óþekkt',
   [CompanySizeEnum.SMALL]: '0–24',
   [CompanySizeEnum.MEDIUM]: '25–49',
   [CompanySizeEnum.LARGE]: '50+',


### PR DESCRIPTION
Company size unknown option


```
    // Add UNKNOWN as the lowest-ordered company size. It is the default for
    // companies we have not yet classified (e.g. auto-provisioned on report
    // submission): it imposes no reporting obligation, but is honest about the
    // size being unknown rather than asserting the company is SMALL.
```