### PR TITLE
fix(shared): Partner information for undivided settlements + modal

### DIFF
--- a/apps/legal-gazette-api/src/modules/advert/advert.service.ts
+++ b/apps/legal-gazette-api/src/modules/advert/advert.service.ts
@@ -685,6 +685,9 @@ export class AdvertService implements IAdvertService {
               name: body.settlement.name,
               nationalId: body.settlement.nationalId,
               declaredClaims: body.settlement.declaredClaims ?? null,
+              partnerName: body.settlement.partnerName ?? null,
+              partnerNationalId: body.settlement.partnerNationalId ?? null,
+              partnerDateOfDeath: body.settlement.partnerDateOfDeath ?? null,
               companies: body.settlement.companies,
             }
           : undefined,

--- a/apps/legal-gazette-web/src/components/field-set-items/SettlementFields.tsx
+++ b/apps/legal-gazette-web/src/components/field-set-items/SettlementFields.tsx
@@ -229,25 +229,27 @@ export const SettlementFields = ({
               onBlur={(evt) => updatePartnerNationalId(evt.target.value)}
             />
           </GridColumn>
-          <GridColumn span={['12/12', '6/12']}>
-            <DatePicker
-              disabled={!canEdit}
-              size="sm"
-              placeholderText=""
-              backgroundColor="blue"
-              name="settlement-partner-date-of-death"
-              label="Dánardagur maka"
-              locale="is"
-              selected={
-                settlement.partnerDateOfDeath
-                  ? new Date(settlement.partnerDateOfDeath)
-                  : undefined
-              }
-              handleChange={(date) => {
-                updatePartnerDateOfDeath(date.toISOString())
-              }}
-            />
-          </GridColumn>
+          <GridRow>
+            <GridColumn span={['12/12', '6/12']}>
+              <DatePicker
+                disabled={!canEdit}
+                size="sm"
+                placeholderText=""
+                backgroundColor="blue"
+                name="settlement-partner-date-of-death"
+                label="Dánardagur maka"
+                locale="is"
+                selected={
+                  settlement.partnerDateOfDeath
+                    ? new Date(settlement.partnerDateOfDeath)
+                    : undefined
+                }
+                handleChange={(date) => {
+                  updatePartnerDateOfDeath(date.toISOString())
+                }}
+              />
+            </GridColumn>
+          </GridRow>
         </GridRow>
       )}
       <GridRow>

--- a/libs/legal-gazette/html/src/lib/preview/application.ts
+++ b/libs/legal-gazette/html/src/lib/preview/application.ts
@@ -46,6 +46,19 @@ const mapStatementType = (statementType: string | null | undefined = '') => {
   }
 }
 
+const mapSettlementType = (
+  settlementType: string | null | undefined,
+): 'default' | 'undivided' | 'owner' => {
+  switch (settlementType) {
+    case 'UNDIVIDED':
+      return 'undivided'
+    case 'OWNER':
+      return 'owner'
+    default:
+      return 'default'
+  }
+}
+
 type ApplicationPreview =
   | {
       html: string
@@ -172,6 +185,10 @@ export const getApplicationPreview = (
       const dateOfDeath = answers.fields?.settlementFields?.dateOfDeath
         ? new Date(answers.fields.settlementFields.dateOfDeath)
         : undefined
+      const partnerDateOfDeath = answers.fields?.settlementFields
+        ?.partnerDateOfDeath
+        ? new Date(answers.fields.settlementFields.partnerDateOfDeath)
+        : undefined
 
       const html = getAdvertHTMLMarkup({
         templateType: LegalGazetteHTMLTemplates.RECALL_DECEASED,
@@ -180,6 +197,7 @@ export const getApplicationPreview = (
         signature: answers.signature,
         title: `Innköllun dánarbús - ${answers.fields?.settlementFields?.name ?? ''}`,
         settlement: {
+          type: mapSettlementType(answers.fields?.settlementFields?.type),
           statementType: mapStatementType(
             answers.fields?.settlementFields?.recallRequirementStatementType,
           ),
@@ -194,6 +212,10 @@ export const getApplicationPreview = (
             answers.fields?.settlementFields?.liquidatorName ?? '',
           name: answers.fields?.settlementFields?.name ?? '',
           nationalId: answers.fields?.settlementFields?.nationalId ?? '',
+          partnerName: answers.fields?.settlementFields?.partnerName ?? '',
+          partnerNationalId:
+            answers.fields?.settlementFields?.partnerNationalId ?? '',
+          partnerDateOfDeath: partnerDateOfDeath,
           companies: answers.fields?.settlementFields?.companies ?? [],
         },
       })

--- a/libs/legal-gazette/html/src/lib/templates/division-ending-deceased.ts
+++ b/libs/legal-gazette/html/src/lib/templates/division-ending-deceased.ts
@@ -18,6 +18,7 @@ export function getDivisionEndingDeceasedTemplate({
   settlementName,
   settlementNationalId,
   settlementDeclaredClaims,
+  content = '',
 }: DivisionEndingTemplateProps): string {
   const [formattedJudgementDate] = parseAndFormatDate(judgementDate)
   const [formattedEndingDate] = parseAndFormatDate(endingDate)
@@ -61,8 +62,7 @@ export function getDivisionEndingDeceasedTemplate({
     </table>
   `
 
-  return `
-    ${intro}
-    ${tableMarkup}
-  `
+  const markupArr = [intro, content, tableMarkup].filter(isNotEmpty)
+
+  return markupArr.join('')
 }

--- a/libs/shared/dmr-ui/src/lib/island-is/lib/ModalBase.tsx
+++ b/libs/shared/dmr-ui/src/lib/island-is/lib/ModalBase.tsx
@@ -53,12 +53,7 @@ export const ModalBase: FC<ModalBaseProps> = ({
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const [open, setOpen] = useState(initialVisibility)
-  const [mounted, setMounted] = useState(false)
   const isFirstRender = useRef(true)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
 
   const showModal = useCallback(() => {
     const dialog = dialogRef.current
@@ -166,7 +161,7 @@ export const ModalBase: FC<ModalBaseProps> = ({
           'aria-controls': baseId,
         })}
 
-      {renderModal && mounted &&
+      {renderModal &&
         createPortal(
           <dialog
             ref={dialogRef}


### PR DESCRIPTION
Finishing touches for undivided-settlement partner info, plus a few related bug fixes surfaced while testing on dev.

- Persist partner info on create (advert.service.ts): added the partner fields to createAdvert's settlement whitelist — they were being dropped on create (admin + citizen submit).
- Admin edit UI (SettlementFields.tsx): partner name/kennitala/date-of-death inputs for Óskipt dánarbú, with correct row spacing.
- Application preview (preview/application.ts): pass settlement type + partner fields so the preview renders the partner sentence (also fixes the owner preview).
- Skiptalok for dánarbú (division-ending-deceased.ts): render editor content ("Efni auglýsingar"), matching the bankruptcy template.
- Modals not opening (ModalBase.tsx): reverted the DOE-only mounted gate, we need to look into doe now, but this was affecting prod, so im reverting for now.