### PR TITLE
fix(regulations): PDF path cleanup

### DIFF
--- a/apps/regulations-api/src/db/RegulationPdf.ts
+++ b/apps/regulations-api/src/db/RegulationPdf.ts
@@ -315,13 +315,21 @@ const makeRegulationPdf = (
               `  --timeout ${90 * SECOND}` +
               `  --output ${tmpFileName}`,
             (err) => {
-              unlink(htmlFile)
+              // Ignore unlink errors — the file may not have been created.
+              const tryUnlink = (file: string) =>
+                unlink(file).catch(() => {
+                  /* best-effort cleanup */
+                })
+              tryUnlink(htmlFile)
               if (err) {
+                // pagedjs-cli may have written a partial/complete output file
+                // before failing; clean it up so it doesn't leak to disk.
+                tryUnlink(tmpFileName)
                 reject(err)
               } else {
                 resolve(
                   readFile(tmpFileName).then((file) => {
-                    unlink(tmpFileName)
+                    tryUnlink(tmpFileName)
                     return file
                   }),
                 )

--- a/apps/regulations-api/src/db/RegulationPdf.ts
+++ b/apps/regulations-api/src/db/RegulationPdf.ts
@@ -318,7 +318,7 @@ const makeRegulationPdf = (
               // Ignore unlink errors — the file may not have been created.
               const tryUnlink = (file: string) =>
                 unlink(file).catch(() => {
-                  /* best-effort cleanup */
+                  /* best-effort cleanup. */
                 })
               tryUnlink(htmlFile)
               if (err) {

--- a/apps/regulations-api/src/routes/regulationRoutes.ts
+++ b/apps/regulations-api/src/routes/regulationRoutes.ts
@@ -100,6 +100,7 @@ const handleRequest = async <N extends string = RegQueryName>(
     const routePath = req.url
       .replace(/^\/api\/v[0-9]+\/regulation\//, '')
       .split('?')[0]! // remove any potential query strings
+      .replace(/\/+$/, '') // normalize away trailing slashes (ignoreTrailingSlash)
       .replace(/\/pdf$/, '') // and chop off pdf suffixes, if present
 
     const { success, error } = await handler(res, handlerOpts, routePath)


### PR DESCRIPTION
## Fix PDF caching for trailing-slash URLs + temp file leak

### Problem
Requests to PDF endpoints with a trailing slash (e.g. `…/1101-2022/current/pdf/`)
were bypassing the S3 cache and regenerating a PDF on every hit, writing duplicate
objects under a malformed key (`1101-2022--current--pdf--.pdf`). Failed/timed-out
renders also left orphaned temp files on disk, filling up the container.

### Root cause
- Fastify has `ignoreTrailingSlash: true`, so `…/pdf/` still routes to the handler,
  but the `routePath` derivation only stripped a `/pdf` suffix anchored to the end.
  With a trailing slash the suffix wasn't stripped, producing a different S3 cache
  key — every such request missed the cache and regenerated.
- `makeRegulationPdf` only unlinked its `pagedjs-cli` output on the success path;
  on render error/timeout the output file was left behind.

### Changes
- Normalize trailing slashes off the derived `routePath` before stripping the
  `/pdf` suffix, so both URL forms resolve to the same S3 key. Routing is
  unchanged — trailing-slash URLs still work.
- Unlink the render output on the error path as well, and make all temp-file
  unlinks best-effort (ignore failures).

### Notes
- Stale `--pdf--` objects in S3 and orphaned temp files will be cleaned up
  separately (container restart + manual S3 cleanup).