### PR TITLE
feat(doe): Company comments and events

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260616-company-status-events-comments.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260616-company-status-events-comments.js
@@ -1,0 +1,374 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- ============================================================
+    -- 1. Geography reference tables: region + postcode.
+    --
+    -- Iceland's postcodes (póstnúmer) roll up into eight regions
+    -- (landshlutar). A company links to a postcode; its region is
+    -- reached via company -> postcode -> region, so region is never
+    -- stored on the company directly and can never drift.
+    --
+    -- The eight regions are seeded here (stable, rarely change). The
+    -- canonical ~150-postcode set is loaded by a separate sourced
+    -- seeder; this migration only creates the (empty) postcode table.
+    -- region.code is the stable machine key that seeder resolves against.
+    -- ============================================================
+
+    CREATE TABLE region (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+      code TEXT NOT NULL UNIQUE,
+      name TEXT NOT NULL
+    );
+
+    INSERT INTO region (code, name) VALUES
+      ('CAPITAL',           'Höfuðborgarsvæðið'),
+      ('SUDURNES',          'Suðurnes'),
+      ('VESTURLAND',        'Vesturland'),
+      ('VESTFIRDIR',        'Vestfirðir'),
+      ('NORDURLAND_VESTRA', 'Norðurland vestra'),
+      ('NORDURLAND_EYSTRA', 'Norðurland eystra'),
+      ('AUSTURLAND',        'Austurland'),
+      ('SUDURLAND',         'Suðurland');
+
+    CREATE TABLE postcode (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+      code TEXT NOT NULL UNIQUE,
+      place TEXT NOT NULL,
+      region_id UUID NOT NULL REFERENCES region(id)
+    );
+
+    CREATE INDEX postcode_region_id_idx ON postcode (region_id);
+
+    -- Canonical Icelandic postcodes, mapped to their landshluti. Regions are
+    -- resolved by their stable code, so this does not depend on the generated
+    -- region UUIDs. Cross-range calls worth noting: Vopnafjörður (690/691),
+    -- Höfn í Hornafirði + Öræfi (780/781/785) -> Austurland; Siglufjörður
+    -- (580/581) -> Norðurland eystra (Fjallabyggð); Flatey (345) -> Vesturland.
+    INSERT INTO postcode (code, place, region_id)
+    SELECT v.code, v.place, r.id
+    FROM (VALUES
+      ('101', 'Reykjavík', 'CAPITAL'),
+      ('102', 'Reykjavík', 'CAPITAL'),
+      ('103', 'Reykjavík', 'CAPITAL'),
+      ('104', 'Reykjavík', 'CAPITAL'),
+      ('105', 'Reykjavík', 'CAPITAL'),
+      ('107', 'Reykjavík', 'CAPITAL'),
+      ('108', 'Reykjavík', 'CAPITAL'),
+      ('109', 'Reykjavík', 'CAPITAL'),
+      ('110', 'Reykjavík', 'CAPITAL'),
+      ('111', 'Reykjavík', 'CAPITAL'),
+      ('112', 'Reykjavík', 'CAPITAL'),
+      ('113', 'Reykjavík', 'CAPITAL'),
+      ('116', 'Reykjavík', 'CAPITAL'),
+      ('121', 'Reykjavík', 'CAPITAL'),
+      ('123', 'Reykjavík', 'CAPITAL'),
+      ('124', 'Reykjavík', 'CAPITAL'),
+      ('125', 'Reykjavík', 'CAPITAL'),
+      ('127', 'Reykjavík', 'CAPITAL'),
+      ('128', 'Reykjavík', 'CAPITAL'),
+      ('129', 'Reykjavík', 'CAPITAL'),
+      ('130', 'Reykjavík', 'CAPITAL'),
+      ('132', 'Reykjavík', 'CAPITAL'),
+      ('161', 'Reykjavík', 'CAPITAL'),
+      ('162', 'Reykjavík', 'CAPITAL'),
+      ('170', 'Seltjarnarnes', 'CAPITAL'),
+      ('172', 'Seltjarnarnes', 'CAPITAL'),
+      ('190', 'Vogar', 'SUDURNES'),
+      ('191', 'Vogar', 'SUDURNES'),
+      ('200', 'Kópavogur', 'CAPITAL'),
+      ('201', 'Kópavogur', 'CAPITAL'),
+      ('202', 'Kópavogur', 'CAPITAL'),
+      ('203', 'Kópavogur', 'CAPITAL'),
+      ('206', 'Kópavogur', 'CAPITAL'),
+      ('210', 'Garðabær', 'CAPITAL'),
+      ('212', 'Garðabær', 'CAPITAL'),
+      ('220', 'Hafnarfjörður', 'CAPITAL'),
+      ('221', 'Hafnarfjörður', 'CAPITAL'),
+      ('222', 'Hafnarfjörður', 'CAPITAL'),
+      ('225', 'Garðabær', 'CAPITAL'),
+      ('230', 'Reykjanesbær', 'SUDURNES'),
+      ('232', 'Reykjanesbær', 'SUDURNES'),
+      ('233', 'Reykjanesbær', 'SUDURNES'),
+      ('235', 'Keflavíkurflugvöllur', 'SUDURNES'),
+      ('240', 'Grindavík', 'SUDURNES'),
+      ('241', 'Grindavík', 'SUDURNES'),
+      ('245', 'Sandgerði', 'SUDURNES'),
+      ('246', 'Sandgerði', 'SUDURNES'),
+      ('250', 'Garður', 'SUDURNES'),
+      ('251', 'Garður', 'SUDURNES'),
+      ('260', 'Reykjanesbær', 'SUDURNES'),
+      ('262', 'Reykjanesbær', 'SUDURNES'),
+      ('270', 'Mosfellsbær', 'CAPITAL'),
+      ('271', 'Mosfellsbær', 'CAPITAL'),
+      ('276', 'Kjós', 'VESTURLAND'),
+      ('300', 'Akranes', 'VESTURLAND'),
+      ('301', 'Akranes', 'VESTURLAND'),
+      ('302', 'Akranes', 'VESTURLAND'),
+      ('310', 'Borgarnes', 'VESTURLAND'),
+      ('311', 'Borgarnes', 'VESTURLAND'),
+      ('320', 'Reykholt', 'VESTURLAND'),
+      ('340', 'Stykkishólmur', 'VESTURLAND'),
+      ('341', 'Stykkishólmur', 'VESTURLAND'),
+      ('342', 'Stykkishólmur', 'VESTURLAND'),
+      ('345', 'Flatey', 'VESTURLAND'),
+      ('350', 'Grundarfjörður', 'VESTURLAND'),
+      ('351', 'Grundarfjörður', 'VESTURLAND'),
+      ('355', 'Ólafsvík', 'VESTURLAND'),
+      ('356', 'Snæfellsbær', 'VESTURLAND'),
+      ('360', 'Hellissandur', 'VESTURLAND'),
+      ('370', 'Búðardalur', 'VESTURLAND'),
+      ('371', 'Búðardalur', 'VESTURLAND'),
+      ('380', 'Reykhólahreppur', 'VESTFIRDIR'),
+      ('381', 'Reykhólahreppur', 'VESTFIRDIR'),
+      ('400', 'Ísafjörður', 'VESTFIRDIR'),
+      ('401', 'Ísafjörður', 'VESTFIRDIR'),
+      ('410', 'Hnífsdalur', 'VESTFIRDIR'),
+      ('415', 'Bolungarvík', 'VESTFIRDIR'),
+      ('416', 'Bolungarvík', 'VESTFIRDIR'),
+      ('420', 'Súðavík', 'VESTFIRDIR'),
+      ('421', 'Súðavík', 'VESTFIRDIR'),
+      ('425', 'Flateyri', 'VESTFIRDIR'),
+      ('426', 'Flateyri', 'VESTFIRDIR'),
+      ('430', 'Suðureyri', 'VESTFIRDIR'),
+      ('431', 'Suðureyri', 'VESTFIRDIR'),
+      ('450', 'Patreksfjörður', 'VESTFIRDIR'),
+      ('451', 'Patreksfjörður', 'VESTFIRDIR'),
+      ('460', 'Tálknafjörður', 'VESTFIRDIR'),
+      ('461', 'Tálknafjörður', 'VESTFIRDIR'),
+      ('465', 'Bíldudalur', 'VESTFIRDIR'),
+      ('466', 'Bíldudalur', 'VESTFIRDIR'),
+      ('470', 'Þingeyri', 'VESTFIRDIR'),
+      ('471', 'Þingeyri', 'VESTFIRDIR'),
+      ('500', 'Staður', 'VESTFIRDIR'),
+      ('510', 'Hólmavík', 'VESTFIRDIR'),
+      ('511', 'Hólmavík', 'VESTFIRDIR'),
+      ('512', 'Hólmavík', 'VESTFIRDIR'),
+      ('520', 'Drangsnes', 'VESTFIRDIR'),
+      ('524', 'Árneshreppur', 'VESTFIRDIR'),
+      ('530', 'Hvammstangi', 'NORDURLAND_VESTRA'),
+      ('531', 'Hvammstangi', 'NORDURLAND_VESTRA'),
+      ('540', 'Blönduós', 'NORDURLAND_VESTRA'),
+      ('541', 'Blönduós', 'NORDURLAND_VESTRA'),
+      ('545', 'Skagaströnd', 'NORDURLAND_VESTRA'),
+      ('546', 'Skagaströnd', 'NORDURLAND_VESTRA'),
+      ('550', 'Sauðárkrókur', 'NORDURLAND_VESTRA'),
+      ('551', 'Sauðárkrókur', 'NORDURLAND_VESTRA'),
+      ('560', 'Varmahlíð', 'NORDURLAND_VESTRA'),
+      ('561', 'Varmahlíð', 'NORDURLAND_VESTRA'),
+      ('565', 'Hofsós', 'NORDURLAND_VESTRA'),
+      ('566', 'Hofsós', 'NORDURLAND_VESTRA'),
+      ('570', 'Fljót', 'NORDURLAND_VESTRA'),
+      ('580', 'Siglufjörður', 'NORDURLAND_EYSTRA'),
+      ('581', 'Siglufjörður', 'NORDURLAND_EYSTRA'),
+      ('600', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('601', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('602', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('603', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('604', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('605', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('606', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('607', 'Akureyri', 'NORDURLAND_EYSTRA'),
+      ('610', 'Grenivík', 'NORDURLAND_EYSTRA'),
+      ('611', 'Grímsey', 'NORDURLAND_EYSTRA'),
+      ('616', 'Grenivík', 'NORDURLAND_EYSTRA'),
+      ('620', 'Dalvík', 'NORDURLAND_EYSTRA'),
+      ('621', 'Dalvík', 'NORDURLAND_EYSTRA'),
+      ('625', 'Ólafsfjörður', 'NORDURLAND_EYSTRA'),
+      ('626', 'Ólafsfjörður', 'NORDURLAND_EYSTRA'),
+      ('630', 'Hrísey', 'NORDURLAND_EYSTRA'),
+      ('640', 'Húsavík', 'NORDURLAND_EYSTRA'),
+      ('641', 'Húsavík', 'NORDURLAND_EYSTRA'),
+      ('645', 'Fosshóll', 'NORDURLAND_EYSTRA'),
+      ('650', 'Laugar', 'NORDURLAND_EYSTRA'),
+      ('660', 'Mývatn', 'NORDURLAND_EYSTRA'),
+      ('670', 'Kópasker', 'NORDURLAND_EYSTRA'),
+      ('671', 'Kópasker', 'NORDURLAND_EYSTRA'),
+      ('675', 'Raufarhöfn', 'NORDURLAND_EYSTRA'),
+      ('676', 'Raufarhöfn', 'NORDURLAND_EYSTRA'),
+      ('680', 'Þórshöfn', 'NORDURLAND_EYSTRA'),
+      ('681', 'Þórshöfn', 'NORDURLAND_EYSTRA'),
+      ('685', 'Bakkafjörður', 'NORDURLAND_EYSTRA'),
+      ('686', 'Bakkafjörður', 'NORDURLAND_EYSTRA'),
+      ('690', 'Vopnafjörður', 'AUSTURLAND'),
+      ('691', 'Vopnafjörður', 'AUSTURLAND'),
+      ('700', 'Egilsstaðir', 'AUSTURLAND'),
+      ('701', 'Egilsstaðir', 'AUSTURLAND'),
+      ('710', 'Seyðisfjörður', 'AUSTURLAND'),
+      ('711', 'Seyðisfjörður', 'AUSTURLAND'),
+      ('715', 'Mjóifjörður', 'AUSTURLAND'),
+      ('720', 'Borgarfjörður eystri', 'AUSTURLAND'),
+      ('721', 'Borgarfjörður eystri', 'AUSTURLAND'),
+      ('730', 'Reyðarfjörður', 'AUSTURLAND'),
+      ('731', 'Reyðarfjörður', 'AUSTURLAND'),
+      ('735', 'Eskifjörður', 'AUSTURLAND'),
+      ('736', 'Eskifjörður', 'AUSTURLAND'),
+      ('740', 'Neskaupstaður', 'AUSTURLAND'),
+      ('741', 'Neskaupstaður', 'AUSTURLAND'),
+      ('750', 'Fáskrúðsfjörður', 'AUSTURLAND'),
+      ('751', 'Fáskrúðsfjörður', 'AUSTURLAND'),
+      ('755', 'Stöðvarfjörður', 'AUSTURLAND'),
+      ('756', 'Stöðvarfjörður', 'AUSTURLAND'),
+      ('760', 'Breiðdalsvík', 'AUSTURLAND'),
+      ('761', 'Breiðdalsvík', 'AUSTURLAND'),
+      ('765', 'Djúpivogur', 'AUSTURLAND'),
+      ('766', 'Djúpivogur', 'AUSTURLAND'),
+      ('780', 'Höfn í Hornafirði', 'AUSTURLAND'),
+      ('781', 'Höfn í Hornafirði', 'AUSTURLAND'),
+      ('785', 'Öræfi', 'AUSTURLAND'),
+      ('800', 'Selfoss', 'SUDURLAND'),
+      ('801', 'Selfoss', 'SUDURLAND'),
+      ('802', 'Selfoss', 'SUDURLAND'),
+      ('803', 'Selfoss', 'SUDURLAND'),
+      ('804', 'Selfoss', 'SUDURLAND'),
+      ('805', 'Selfoss', 'SUDURLAND'),
+      ('806', 'Selfoss', 'SUDURLAND'),
+      ('810', 'Hveragerði', 'SUDURLAND'),
+      ('815', 'Þorlákshöfn', 'SUDURLAND'),
+      ('816', 'Ölfus', 'SUDURLAND'),
+      ('820', 'Eyrarbakki', 'SUDURLAND'),
+      ('825', 'Stokkseyri', 'SUDURLAND'),
+      ('840', 'Laugarvatn', 'SUDURLAND'),
+      ('845', 'Flúðir', 'SUDURLAND'),
+      ('846', 'Flúðir', 'SUDURLAND'),
+      ('850', 'Hella', 'SUDURLAND'),
+      ('851', 'Hella', 'SUDURLAND'),
+      ('860', 'Hvolsvöllur', 'SUDURLAND'),
+      ('861', 'Hvolsvöllur', 'SUDURLAND'),
+      ('870', 'Vík', 'SUDURLAND'),
+      ('871', 'Vík', 'SUDURLAND'),
+      ('880', 'Kirkjubæjarklaustur', 'SUDURLAND'),
+      ('881', 'Kirkjubæjarklaustur', 'SUDURLAND'),
+      ('900', 'Vestmannaeyjar', 'SUDURLAND'),
+      ('902', 'Vestmannaeyjar', 'SUDURLAND')
+    ) AS v(code, place, region_code)
+    JOIN region r ON r.code = v.region_code;
+
+    -- ============================================================
+    -- 2. Company lifecycle status + address.
+    --
+    -- Companies gain an ACTIVE/INACTIVE status (defaulting to ACTIVE
+    -- for every existing row), a free-text street address, and a FK to
+    -- their postcode. City/place comes from postcode.place; region from
+    -- postcode.region_id — neither is duplicated on the company. Status
+    -- transitions are recorded on company_event below, so this column
+    -- only ever holds the *current* status.
+    -- ============================================================
+
+    CREATE TYPE company_status_enum AS ENUM ('ACTIVE', 'INACTIVE');
+
+    ALTER TABLE company
+      ADD COLUMN status company_status_enum NOT NULL DEFAULT 'ACTIVE',
+      ADD COLUMN address TEXT DEFAULT NULL,
+      ADD COLUMN postcode_id UUID DEFAULT NULL REFERENCES postcode(id);
+
+    CREATE INDEX company_postcode_id_idx ON company (postcode_id);
+
+    -- ============================================================
+    -- 3. Company timeline events.
+    --
+    -- Immutable, append-only. Mirrors report_event but scoped to the
+    -- company lifecycle. STATUS_CHANGED rows carry from/to status and
+    -- an optional reason (e.g. bankruptcy, merger) — this is the
+    -- explorable status history; no separate history table is needed.
+    -- ============================================================
+
+    CREATE TYPE company_event_type_enum AS ENUM ('STATUS_CHANGED');
+
+    CREATE TABLE company_event (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+      company_id UUID NOT NULL REFERENCES company(id),
+      event_type company_event_type_enum NOT NULL,
+      actor_user_id UUID DEFAULT NULL REFERENCES doe_user(id),
+      status company_status_enum NOT NULL,
+      from_status company_status_enum DEFAULT NULL,
+      to_status company_status_enum DEFAULT NULL,
+      reason TEXT DEFAULT NULL,
+
+      CONSTRAINT company_event_status_changed_chk CHECK (
+        event_type <> 'STATUS_CHANGED' OR (
+          from_status IS NOT NULL
+          AND to_status IS NOT NULL
+          AND status = to_status
+        )
+      )
+    );
+
+    -- ============================================================
+    -- 4. Company comments.
+    --
+    -- Reviewer-internal notes an admin can leave on a company. No
+    -- visibility dimension (companies never see these) and no
+    -- author-kind — the author is always an admin doe_user. Paranoid
+    -- (soft delete) so the timeline stays auditable.
+    -- ============================================================
+
+    CREATE TABLE company_comment (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+      deleted_at TIMESTAMPTZ DEFAULT NULL,
+
+      company_id UUID NOT NULL REFERENCES company(id),
+      author_user_id UUID DEFAULT NULL REFERENCES doe_user(id),
+      body TEXT NOT NULL
+    );
+
+    -- ============================================================
+    -- 5. Indexes (timeline + FK lookups).
+    -- ============================================================
+
+    CREATE INDEX company_event_company_id_idx
+      ON company_event (company_id);
+    CREATE INDEX company_event_actor_user_id_idx
+      ON company_event (actor_user_id);
+    CREATE INDEX company_event_timeline_idx
+      ON company_event (company_id, created_at);
+
+    CREATE INDEX company_comment_company_id_idx
+      ON company_comment (company_id);
+    CREATE INDEX company_comment_author_user_id_idx
+      ON company_comment (author_user_id);
+    CREATE INDEX company_comment_timeline_idx
+      ON company_comment (company_id, created_at)
+      WHERE deleted_at IS NULL;
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    DROP TABLE IF EXISTS company_comment;
+    DROP TABLE IF EXISTS company_event;
+
+    ALTER TABLE company
+      DROP COLUMN IF EXISTS postcode_id,
+      DROP COLUMN IF EXISTS address,
+      DROP COLUMN IF EXISTS status;
+
+    DROP TYPE IF EXISTS company_event_type_enum;
+    DROP TYPE IF EXISTS company_status_enum;
+
+    DROP TABLE IF EXISTS postcode;
+    DROP TABLE IF EXISTS region;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/db/migrations/m-20260616-company-status-events-comments.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260616-company-status-events-comments.js
@@ -284,7 +284,7 @@ module.exports = {
     -- explorable status history; no separate history table is needed.
     -- ============================================================
 
-    CREATE TYPE company_event_type_enum AS ENUM ('STATUS_CHANGED');
+    CREATE TYPE company_event_type_enum AS ENUM ('CREATED', 'STATUS_CHANGED');
 
     CREATE TABLE company_event (
       id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -14,8 +14,12 @@ import { CLSMiddleware, LogRequestMiddleware } from '@dmr.is/shared-middleware'
 
 import { ApplicationApiModule } from '../modules/application/application.api.module'
 import { CompanyModel } from '../modules/company/models/company.model'
+import { CompanyCommentModel } from '../modules/company/models/company-comment.model'
+import { CompanyEventModel } from '../modules/company/models/company-event.model'
 import { CompanyReportModel } from '../modules/company/models/company-report.model'
 import { ConfigModel } from '../modules/config/models/config.model'
+import { PostcodeModel } from '../modules/location/models/postcode.model'
+import { RegionModel } from '../modules/location/models/region.model'
 import { PublicReportModel } from '../modules/public-report/models/public-report.model'
 import { ReportModel } from '../modules/report/models/report.model'
 import { ReportEventModel } from '../modules/report/models/report-event.model'
@@ -52,6 +56,8 @@ import { HealthController } from './health.controller'
           autoLoadModels: false,
           models: [
             UserModel,
+            RegionModel,
+            PostcodeModel,
             CompanyModel,
             ReportEmployeeRoleModel,
             ReportModel,
@@ -68,6 +74,8 @@ import { HealthController } from './health.controller'
             PublicReportModel,
             ReportEventModel,
             ReportCommentModel,
+            CompanyEventModel,
+            CompanyCommentModel,
             ConfigModel,
           ],
         }),

--- a/apps/directorate-of-equality-api/src/core/constants.ts
+++ b/apps/directorate-of-equality-api/src/core/constants.ts
@@ -2,6 +2,8 @@ export const CLS_NAMESPACE = 'directory-of-equality-api:transaction'
 
 export enum DoeModels {
   USER = 'doe_user',
+  REGION = 'region',
+  POSTCODE = 'postcode',
   COMPANY = 'company',
   COMPANY_REPORT = 'company_report',
   REPORT = 'report',
@@ -18,5 +20,7 @@ export enum DoeModels {
   PUBLIC_REPORT = 'public_report',
   REPORT_EVENT = 'report_event',
   REPORT_COMMENT = 'report_comment',
+  COMPANY_EVENT = 'company_event',
+  COMPANY_COMMENT = 'company_comment',
   CONFIG = 'config',
 }

--- a/apps/directorate-of-equality-api/src/core/decorators/current-admin-user.decorator.ts
+++ b/apps/directorate-of-equality-api/src/core/decorators/current-admin-user.decorator.ts
@@ -1,0 +1,30 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common'
+
+import { getLogger } from '@dmr.is/logging'
+
+import { UserModel } from '../../modules/user/models/user.model'
+
+/**
+ * Resolves the acting admin (doe_user) that `AdminGuard` attached to the
+ * request. Use only on routes guarded by `TokenJwtAuthGuard` + `AdminGuard`;
+ * without that guard chain `request.adminUser` is never populated.
+ */
+export const CurrentAdminUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): UserModel => {
+    void data
+
+    const request = ctx.switchToHttp().getRequest()
+    const logger = getLogger('CurrentAdminUserDecorator')
+
+    if (!request?.adminUser) {
+      logger.error('Admin user was not resolved on request')
+      throw new UnauthorizedException()
+    }
+
+    return request.adminUser
+  },
+)

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.core.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { CompanyModel } from '../company/models/company.model'
+import { CompanyCommentModel } from '../company/models/company-comment.model'
+import { CompanyCommentService } from './company-comment.service'
+import { ICompanyCommentService } from './company-comment.service.interface'
+
+@Module({
+  imports: [SequelizeModule.forFeature([CompanyCommentModel, CompanyModel])],
+  providers: [
+    {
+      provide: ICompanyCommentService,
+      useClass: CompanyCommentService,
+    },
+  ],
+  exports: [ICompanyCommentService],
+})
+export class CompanyCommentCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.interface.ts
@@ -1,0 +1,19 @@
+import { CompanyCommentDto } from '../company/dto/company-comment.dto'
+import { CreateCompanyCommentDto } from './dto/create-company-comment.dto'
+
+export interface ICompanyCommentService {
+  /** All non-deleted comments for a company, oldest first. */
+  getByCompanyId(companyId: string): Promise<CompanyCommentDto[]>
+
+  /** Adds an admin-internal note authored by `authorUserId`. */
+  create(
+    companyId: string,
+    authorUserId: string,
+    dto: CreateCompanyCommentDto,
+  ): Promise<CompanyCommentDto>
+
+  /** Soft-deletes a comment on the given company. */
+  delete(companyId: string, commentId: string): Promise<void>
+}
+
+export const ICompanyCommentService = Symbol('ICompanyCommentService')

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.spec.ts
@@ -1,0 +1,115 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { CompanyModel } from '../company/models/company.model'
+import { CompanyCommentModel } from '../company/models/company-comment.model'
+import { CompanyCommentService } from './company-comment.service'
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+describe('CompanyCommentService', () => {
+  let service: CompanyCommentService
+  let commentCreate: jest.Mock
+  let commentFindAll: jest.Mock
+  let commentFindOneOrThrow: jest.Mock
+  let companyFindOneOrThrow: jest.Mock
+
+  beforeEach(async () => {
+    commentCreate = jest.fn()
+    commentFindAll = jest.fn().mockResolvedValue([])
+    commentFindOneOrThrow = jest.fn()
+    companyFindOneOrThrow = jest.fn().mockResolvedValue({ id: 'company-1' })
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CompanyCommentService,
+        { provide: LOGGER_PROVIDER, useValue: mockLogger },
+        {
+          provide: getModelToken(CompanyCommentModel),
+          useValue: {
+            create: commentCreate,
+            findAll: commentFindAll,
+            findOneOrThrow: commentFindOneOrThrow,
+          },
+        },
+        {
+          provide: getModelToken(CompanyModel),
+          useValue: { findOneOrThrow: companyFindOneOrThrow },
+        },
+      ],
+    }).compile()
+
+    service = module.get(CompanyCommentService)
+  })
+
+  it('create trims the body and inserts an admin-authored comment', async () => {
+    commentCreate.mockResolvedValue({ fromModel: () => ({ id: 'comment-1' }) })
+
+    const result = await service.create('company-1', 'admin-1', {
+      body: '  needs follow-up  ',
+    })
+
+    expect(companyFindOneOrThrow).toHaveBeenCalled()
+    expect(commentCreate).toHaveBeenCalledWith({
+      companyId: 'company-1',
+      authorUserId: 'admin-1',
+      body: 'needs follow-up',
+    })
+    expect(result).toEqual({ id: 'comment-1' })
+  })
+
+  it('create rejects an empty body before touching the company', async () => {
+    await expect(
+      service.create('company-1', 'admin-1', { body: '   ' }),
+    ).rejects.toThrow(BadRequestException)
+
+    expect(companyFindOneOrThrow).not.toHaveBeenCalled()
+    expect(commentCreate).not.toHaveBeenCalled()
+  })
+
+  it('create surfaces a NotFound when the company does not exist', async () => {
+    companyFindOneOrThrow.mockRejectedValue(new NotFoundException())
+
+    await expect(
+      service.create('missing', 'admin-1', { body: 'note' }),
+    ).rejects.toThrow(NotFoundException)
+
+    expect(commentCreate).not.toHaveBeenCalled()
+  })
+
+  it('getByCompanyId returns mapped DTOs ordered oldest first', async () => {
+    commentFindAll.mockResolvedValue([
+      { fromModel: () => ({ id: 'c1' }) },
+      { fromModel: () => ({ id: 'c2' }) },
+    ])
+
+    const result = await service.getByCompanyId('company-1')
+
+    expect(commentFindAll).toHaveBeenCalledWith({
+      where: { companyId: 'company-1' },
+      order: [['createdAt', 'ASC']],
+    })
+    expect(result).toEqual([{ id: 'c1' }, { id: 'c2' }])
+  })
+
+  it('delete soft-deletes the comment scoped to its company', async () => {
+    const destroy = jest.fn()
+    commentFindOneOrThrow.mockResolvedValue({ destroy })
+
+    await service.delete('company-1', 'comment-1')
+
+    expect(commentFindOneOrThrow).toHaveBeenCalledWith(
+      { where: { id: 'comment-1', companyId: 'company-1' } },
+      expect.any(String),
+    )
+    expect(destroy).toHaveBeenCalled()
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.spec.ts
@@ -6,6 +6,7 @@ import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyCommentModel } from '../company/models/company-comment.model'
+import { UserModel } from '../user/models/user.model'
 import { CompanyCommentService } from './company-comment.service'
 
 const mockLogger = {
@@ -51,7 +52,10 @@ describe('CompanyCommentService', () => {
   })
 
   it('create trims the body and inserts an admin-authored comment', async () => {
-    commentCreate.mockResolvedValue({ fromModel: () => ({ id: 'comment-1' }) })
+    commentCreate.mockResolvedValue({
+      fromModel: () => ({ id: 'comment-1' }),
+      reload: jest.fn(),
+    })
 
     const result = await service.create('company-1', 'admin-1', {
       body: '  needs follow-up  ',
@@ -96,6 +100,7 @@ describe('CompanyCommentService', () => {
     expect(commentFindAll).toHaveBeenCalledWith({
       where: { companyId: 'company-1' },
       order: [['createdAt', 'ASC']],
+      include: [{ model: UserModel, as: 'author', required: false }],
     })
     expect(result).toEqual([{ id: 'c1' }, { id: 'c2' }])
   })

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.ts
@@ -6,6 +6,7 @@ import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 import { CompanyCommentDto } from '../company/dto/company-comment.dto'
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyCommentModel } from '../company/models/company-comment.model'
+import { UserModel } from '../user/models/user.model'
 import { CreateCompanyCommentDto } from './dto/create-company-comment.dto'
 import { ICompanyCommentService } from './company-comment.service.interface'
 
@@ -29,6 +30,7 @@ export class CompanyCommentService implements ICompanyCommentService {
     const comments = await this.companyCommentModel.findAll({
       where: { companyId },
       order: [['createdAt', 'ASC']],
+      include: [{ model: UserModel, as: 'author', required: false }],
     })
 
     return comments.map((comment) => comment.fromModel())
@@ -60,6 +62,12 @@ export class CompanyCommentService implements ICompanyCommentService {
       companyId,
       authorUserId,
       body,
+    })
+
+    // Reload with the author so the response carries authorName (the freshly
+    // created instance has no association loaded).
+    await comment.reload({
+      include: [{ model: UserModel, as: 'author', required: false }],
     })
 
     return comment.fromModel()

--- a/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/company-comment.service.ts
@@ -1,0 +1,81 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { CompanyCommentDto } from '../company/dto/company-comment.dto'
+import { CompanyModel } from '../company/models/company.model'
+import { CompanyCommentModel } from '../company/models/company-comment.model'
+import { CreateCompanyCommentDto } from './dto/create-company-comment.dto'
+import { ICompanyCommentService } from './company-comment.service.interface'
+
+const LOGGING_CONTEXT = 'CompanyCommentService'
+
+@Injectable()
+export class CompanyCommentService implements ICompanyCommentService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(CompanyCommentModel)
+    private readonly companyCommentModel: typeof CompanyCommentModel,
+    @InjectModel(CompanyModel)
+    private readonly companyModel: typeof CompanyModel,
+  ) {}
+
+  async getByCompanyId(companyId: string): Promise<CompanyCommentDto[]> {
+    this.logger.debug(`Getting comments for company ${companyId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    const comments = await this.companyCommentModel.findAll({
+      where: { companyId },
+      order: [['createdAt', 'ASC']],
+    })
+
+    return comments.map((comment) => comment.fromModel())
+  }
+
+  async create(
+    companyId: string,
+    authorUserId: string,
+    dto: CreateCompanyCommentDto,
+  ): Promise<CompanyCommentDto> {
+    this.logger.info(`Creating comment for company ${companyId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    const body = dto.body.trim()
+
+    if (!body) {
+      throw new BadRequestException('Comment body cannot be empty')
+    }
+
+    // Resolve the company first so a bad id is a clean 404 rather than an FK
+    // violation surfacing as a 500.
+    await this.companyModel.findOneOrThrow(
+      { where: { id: companyId } },
+      `Company "${companyId}" not found`,
+    )
+
+    const comment = await this.companyCommentModel.create({
+      companyId,
+      authorUserId,
+      body,
+    })
+
+    return comment.fromModel()
+  }
+
+  async delete(companyId: string, commentId: string): Promise<void> {
+    this.logger.info(
+      `Deleting comment ${commentId} for company ${companyId}`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    const comment = await this.companyCommentModel.findOneOrThrow(
+      { where: { id: commentId, companyId } },
+      `Comment "${commentId}" not found`,
+    )
+
+    await comment.destroy()
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company-comment/dto/create-company-comment.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-comment/dto/create-company-comment.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty, IsString } from 'class-validator'
+
+import { ApiString } from '@dmr.is/decorators'
+
+export class CreateCompanyCommentDto {
+  @ApiString({ description: 'Plain text comment body' })
+  @IsString()
+  @IsNotEmpty()
+  body!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/company-event/company-event.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-event/company-event.core.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { CompanyEventModel } from '../company/models/company-event.model'
+import { CompanyEventService } from './company-event.service'
+import { ICompanyEventService } from './company-event.service.interface'
+
+@Module({
+  imports: [SequelizeModule.forFeature([CompanyEventModel])],
+  providers: [
+    {
+      provide: ICompanyEventService,
+      useClass: CompanyEventService,
+    },
+  ],
+  exports: [ICompanyEventService],
+})
+export class CompanyEventCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.interface.ts
@@ -1,0 +1,25 @@
+import { CompanyEventDto } from '../company/dto/company-event.dto'
+import { CompanyStatusEnum } from '../company/models/company.enums'
+
+export interface ICompanyEventService {
+  /** Origin event for a freshly registered company. */
+  emitCreated(
+    companyId: string,
+    status: CompanyStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void>
+
+  /** Records an ACTIVE/INACTIVE transition with optional reason. */
+  emitStatusChanged(
+    companyId: string,
+    fromStatus: CompanyStatusEnum,
+    toStatus: CompanyStatusEnum,
+    actorUserId?: string | null,
+    reason?: string | null,
+  ): Promise<void>
+
+  /** All events for a company, oldest first — used to build the timeline. */
+  getByCompanyId(companyId: string): Promise<CompanyEventDto[]>
+}
+
+export const ICompanyEventService = Symbol('ICompanyEventService')

--- a/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.spec.ts
@@ -1,0 +1,88 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { CompanyStatusEnum } from '../company/models/company.enums'
+import {
+  CompanyEventModel,
+  CompanyEventTypeEnum,
+} from '../company/models/company-event.model'
+import { CompanyEventService } from './company-event.service'
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+describe('CompanyEventService', () => {
+  let service: CompanyEventService
+  let create: jest.Mock
+  let findAll: jest.Mock
+
+  beforeEach(async () => {
+    create = jest.fn().mockResolvedValue({})
+    findAll = jest.fn().mockResolvedValue([])
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CompanyEventService,
+        { provide: LOGGER_PROVIDER, useValue: mockLogger },
+        {
+          provide: getModelToken(CompanyEventModel),
+          useValue: { create, findAll },
+        },
+      ],
+    }).compile()
+
+    service = module.get(CompanyEventService)
+  })
+
+  it('emitCreated inserts a CREATED row with the initial status and no transition', async () => {
+    await service.emitCreated('company-1', CompanyStatusEnum.ACTIVE)
+
+    expect(create).toHaveBeenCalledWith({
+      companyId: 'company-1',
+      eventType: CompanyEventTypeEnum.CREATED,
+      actorUserId: null,
+      status: CompanyStatusEnum.ACTIVE,
+    })
+  })
+
+  it('emitStatusChanged snapshots the new status and records from/to + reason', async () => {
+    await service.emitStatusChanged(
+      'company-1',
+      CompanyStatusEnum.ACTIVE,
+      CompanyStatusEnum.INACTIVE,
+      'admin-1',
+      'merger',
+    )
+
+    expect(create).toHaveBeenCalledWith({
+      companyId: 'company-1',
+      eventType: CompanyEventTypeEnum.STATUS_CHANGED,
+      actorUserId: 'admin-1',
+      status: CompanyStatusEnum.INACTIVE,
+      fromStatus: CompanyStatusEnum.ACTIVE,
+      toStatus: CompanyStatusEnum.INACTIVE,
+      reason: 'merger',
+    })
+  })
+
+  it('getByCompanyId returns mapped DTOs ordered oldest first', async () => {
+    findAll.mockResolvedValue([
+      { fromModel: () => ({ id: 'e1' }) },
+      { fromModel: () => ({ id: 'e2' }) },
+    ])
+
+    const result = await service.getByCompanyId('company-1')
+
+    expect(findAll).toHaveBeenCalledWith({
+      where: { companyId: 'company-1' },
+      order: [['createdAt', 'ASC']],
+    })
+    expect(result).toEqual([{ id: 'e1' }, { id: 'e2' }])
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-event/company-event.service.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { CompanyEventDto } from '../company/dto/company-event.dto'
+import { CompanyStatusEnum } from '../company/models/company.enums'
+import {
+  CompanyEventModel,
+  CompanyEventTypeEnum,
+} from '../company/models/company-event.model'
+import { ICompanyEventService } from './company-event.service.interface'
+
+const LOGGING_CONTEXT = 'CompanyEventService'
+
+@Injectable()
+export class CompanyEventService implements ICompanyEventService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(CompanyEventModel)
+    private readonly companyEventModel: typeof CompanyEventModel,
+  ) {}
+
+  async emitCreated(
+    companyId: string,
+    status: CompanyStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void> {
+    this.logger.info(`Emitting CREATED event for company ${companyId}`, {
+      context: LOGGING_CONTEXT,
+      companyId,
+    })
+
+    await this.companyEventModel.create({
+      companyId,
+      eventType: CompanyEventTypeEnum.CREATED,
+      actorUserId: actorUserId ?? null,
+      status,
+    })
+  }
+
+  async emitStatusChanged(
+    companyId: string,
+    fromStatus: CompanyStatusEnum,
+    toStatus: CompanyStatusEnum,
+    actorUserId?: string | null,
+    reason?: string | null,
+  ): Promise<void> {
+    this.logger.info(
+      `Emitting STATUS_CHANGED event for company ${companyId}: ${fromStatus} → ${toStatus}`,
+      { context: LOGGING_CONTEXT, companyId, fromStatus, toStatus },
+    )
+
+    await this.companyEventModel.create({
+      companyId,
+      eventType: CompanyEventTypeEnum.STATUS_CHANGED,
+      actorUserId: actorUserId ?? null,
+      status: toStatus,
+      fromStatus,
+      toStatus,
+      reason: reason ?? null,
+    })
+  }
+
+  async getByCompanyId(companyId: string): Promise<CompanyEventDto[]> {
+    const events = await this.companyEventModel.findAll({
+      where: { companyId },
+      order: [['createdAt', 'ASC']],
+    })
+
+    return events.map((event) => event.fromModel())
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company/company.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.api.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
+import { CompanyCommentCoreModule } from '../company-comment/company-comment.core.module'
 import { CompanyController } from './company.controller'
 import { CompanyCoreModule } from './company.core.module'
 
 @Module({
-  imports: [CompanyCoreModule, AuthorizationCoreModule],
+  imports: [CompanyCoreModule, AuthorizationCoreModule, CompanyCommentCoreModule],
   controllers: [CompanyController],
   providers: [AdminGuard],
 })

--- a/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
@@ -1,11 +1,13 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
   Inject,
   Param,
+  Patch,
   Post,
   Query,
   UseGuards,
@@ -14,14 +16,21 @@ import { ApiBearerAuth, ApiParam, ApiTags } from '@nestjs/swagger'
 
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
+import { CurrentAdminUser } from '../../core/decorators/current-admin-user.decorator'
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { ParseNationalIdPipe } from '../../core/pipes/parse-national-id.pipe'
+import { ICompanyCommentService } from '../company-comment/company-comment.service.interface'
+import { CreateCompanyCommentDto } from '../company-comment/dto/create-company-comment.dto'
+import { UserModel } from '../user/models/user.model'
 import { CompanyDto } from './dto/company.dto'
+import { CompanyCommentDto } from './dto/company-comment.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
+import { CompanyTimelineItemDto } from './dto/company-timeline-item.dto'
 import { CreateCompanyDto } from './dto/create-company.dto'
 import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 import { ICompanyService } from './company.service.interface'
 
 @Controller({
@@ -35,6 +44,8 @@ export class CompanyController {
   constructor(
     @Inject(ICompanyService)
     private readonly companyService: ICompanyService,
+    @Inject(ICompanyCommentService)
+    private readonly companyCommentService: ICompanyCommentService,
   ) {}
 
   @Get()
@@ -63,5 +74,75 @@ export class CompanyController {
   @DoeResponse({ operationId: 'createCompany', status: 201, type: CompanyDto })
   async createCompany(@Body() input: CreateCompanyDto): Promise<CompanyDto> {
     return this.companyService.create(input)
+  }
+
+  @Patch(':id/status')
+  @ApiParam({ name: 'id', type: String })
+  @DoeResponse({
+    operationId: 'updateCompanyStatus',
+    type: CompanyDto,
+    include404: true,
+  })
+  async updateStatus(
+    @Param('id') id: string,
+    @Body() dto: UpdateCompanyStatusDto,
+    @CurrentAdminUser() admin: UserModel,
+  ): Promise<CompanyDto> {
+    return this.companyService.updateStatus(id, dto, admin.id)
+  }
+
+  @Get(':id/timeline')
+  @ApiParam({ name: 'id', type: String })
+  @DoeResponse({
+    operationId: 'getCompanyTimeline',
+    type: [CompanyTimelineItemDto],
+    include404: true,
+  })
+  async getTimeline(
+    @Param('id') id: string,
+  ): Promise<CompanyTimelineItemDto[]> {
+    return this.companyService.getTimeline(id)
+  }
+
+  @Get(':id/comments')
+  @ApiParam({ name: 'id', type: String })
+  @DoeResponse({
+    operationId: 'getCompanyComments',
+    type: [CompanyCommentDto],
+    include404: true,
+  })
+  async getComments(
+    @Param('id') id: string,
+  ): Promise<CompanyCommentDto[]> {
+    return this.companyCommentService.getByCompanyId(id)
+  }
+
+  @Post(':id/comments')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiParam({ name: 'id', type: String })
+  @DoeResponse({
+    operationId: 'createCompanyComment',
+    status: 201,
+    type: CompanyCommentDto,
+    include404: true,
+  })
+  async createComment(
+    @Param('id') id: string,
+    @Body() dto: CreateCompanyCommentDto,
+    @CurrentAdminUser() admin: UserModel,
+  ): Promise<CompanyCommentDto> {
+    return this.companyCommentService.create(id, admin.id, dto)
+  }
+
+  @Delete(':id/comments/:commentId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiParam({ name: 'id', type: String })
+  @ApiParam({ name: 'commentId', type: String })
+  @DoeResponse({ operationId: 'deleteCompanyComment', include404: true })
+  async deleteComment(
+    @Param('id') id: string,
+    @Param('commentId') commentId: string,
+  ): Promise<void> {
+    return this.companyCommentService.delete(id, commentId)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
@@ -3,12 +3,19 @@ import { SequelizeModule } from '@nestjs/sequelize'
 
 import { NationalRegistryModule } from '@dmr.is/clients-national-registry'
 
+import { CompanyCommentCoreModule } from '../company-comment/company-comment.core.module'
+import { CompanyEventCoreModule } from '../company-event/company-event.core.module'
 import { CompanyModel } from './models/company.model'
 import { CompanyService } from './company.service'
 import { ICompanyService } from './company.service.interface'
 
 @Module({
-  imports: [SequelizeModule.forFeature([CompanyModel]), NationalRegistryModule],
+  imports: [
+    SequelizeModule.forFeature([CompanyModel]),
+    NationalRegistryModule,
+    CompanyEventCoreModule,
+    CompanyCommentCoreModule,
+  ],
   providers: [
     {
       provide: ICompanyService,

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
@@ -1,10 +1,12 @@
 import { CompanyDto } from './dto/company.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
+import { CompanyTimelineItemDto } from './dto/company-timeline-item.dto'
 import { CreateCompanyInput } from './dto/create-company-input.dto'
 import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
 import { SubsidiaryReportSnapshotLookup } from './dto/subsidiary-report-snapshot-lookup.dto'
 import { SubsidiaryReportSnapshotSourceDto } from './dto/subsidiary-report-snapshot-source.dto'
+import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 
 export {
   CreateCompanyInput,
@@ -27,6 +29,12 @@ export interface ICompanyService {
   getOrCreateSubsidiaryReportSnapshotSource(
     input: SubsidiaryReportSnapshotLookup,
   ): Promise<SubsidiaryReportSnapshotSourceDto>
+  updateStatus(
+    id: string,
+    dto: UpdateCompanyStatusDto,
+    actorUserId: string,
+  ): Promise<CompanyDto>
+  getTimeline(id: string): Promise<CompanyTimelineItemDto[]>
 }
 
 export const ICompanyService = Symbol('ICompanyService')

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -8,7 +8,10 @@ import {
 } from '@dmr.is/clients-national-registry'
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
-import { CompanySizeEnum } from './models/company.enums'
+import { ICompanyCommentService } from '../company-comment/company-comment.service.interface'
+import { ICompanyEventService } from '../company-event/company-event.service.interface'
+import { CompanyTimelineItemKindEnum } from './dto/company-timeline-item.dto'
+import { CompanySizeEnum, CompanyStatusEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
 import { CompanyService } from './company.service'
 
@@ -25,12 +28,20 @@ describe('CompanyService', () => {
   let findOne: jest.Mock
   let create: jest.Mock
   let getEntityByNationalId: jest.Mock
+  let emitCreated: jest.Mock
+  let emitStatusChanged: jest.Mock
+  let eventsByCompanyId: jest.Mock
+  let commentsByCompanyId: jest.Mock
 
   beforeEach(async () => {
     findOneOrThrow = jest.fn()
     findOne = jest.fn()
     create = jest.fn()
     getEntityByNationalId = jest.fn()
+    emitCreated = jest.fn()
+    emitStatusChanged = jest.fn()
+    eventsByCompanyId = jest.fn().mockResolvedValue([])
+    commentsByCompanyId = jest.fn().mockResolvedValue([])
 
     const module = await Test.createTestingModule({
       providers: [
@@ -43,6 +54,18 @@ describe('CompanyService', () => {
         {
           provide: getModelToken(CompanyModel),
           useValue: { findOneOrThrow, findOne, create },
+        },
+        {
+          provide: ICompanyEventService,
+          useValue: {
+            emitCreated,
+            emitStatusChanged,
+            getByCompanyId: eventsByCompanyId,
+          },
+        },
+        {
+          provide: ICompanyCommentService,
+          useValue: { getByCompanyId: commentsByCompanyId },
         },
       ],
     }).compile()
@@ -272,6 +295,132 @@ describe('CompanyService', () => {
 
       expect(findOne).not.toHaveBeenCalled()
       expect(create).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('create', () => {
+    it('emits a CREATED event after inserting the company', async () => {
+      findOne.mockResolvedValue(null)
+      create.mockResolvedValue(
+        makeCompanyModel({
+          id: 'company-9',
+          status: CompanyStatusEnum.ACTIVE,
+        }),
+      )
+
+      await service.create({
+        name: 'New ehf.',
+        nationalId: '5501234567',
+        employeeCountCategory: CompanySizeEnum.SMALL,
+      })
+
+      expect(emitCreated).toHaveBeenCalledWith(
+        'company-9',
+        CompanyStatusEnum.ACTIVE,
+      )
+    })
+  })
+
+  describe('updateStatus', () => {
+    it('updates the status and emits STATUS_CHANGED with the reason', async () => {
+      const update = jest.fn()
+      let current = CompanyStatusEnum.ACTIVE
+      const company = {
+        id: 'company-1',
+        get status() {
+          return current
+        },
+        update: update.mockImplementation(async ({ status }) => {
+          current = status
+        }),
+        fromModel: () => ({ id: 'company-1', status: current }),
+      }
+      findOneOrThrow.mockResolvedValue(company)
+
+      const result = await service.updateStatus(
+        'company-1',
+        { status: CompanyStatusEnum.INACTIVE, reason: 'bankruptcy' },
+        'admin-1',
+      )
+
+      expect(update).toHaveBeenCalledWith({
+        status: CompanyStatusEnum.INACTIVE,
+      })
+      expect(emitStatusChanged).toHaveBeenCalledWith(
+        'company-1',
+        CompanyStatusEnum.ACTIVE,
+        CompanyStatusEnum.INACTIVE,
+        'admin-1',
+        'bankruptcy',
+      )
+      expect(result.status).toBe(CompanyStatusEnum.INACTIVE)
+    })
+
+    it('is a no-op when the status is unchanged', async () => {
+      const update = jest.fn()
+      findOneOrThrow.mockResolvedValue({
+        id: 'company-1',
+        status: CompanyStatusEnum.ACTIVE,
+        update,
+        fromModel: () => ({ id: 'company-1', status: CompanyStatusEnum.ACTIVE }),
+      })
+
+      await service.updateStatus(
+        'company-1',
+        { status: CompanyStatusEnum.ACTIVE },
+        'admin-1',
+      )
+
+      expect(update).not.toHaveBeenCalled()
+      expect(emitStatusChanged).not.toHaveBeenCalled()
+    })
+
+    it('throws NotFoundException when the company does not exist', async () => {
+      findOneOrThrow.mockRejectedValue(new NotFoundException())
+
+      await expect(
+        service.updateStatus(
+          'missing',
+          { status: CompanyStatusEnum.INACTIVE },
+          'admin-1',
+        ),
+      ).rejects.toThrow(NotFoundException)
+
+      expect(emitStatusChanged).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getTimeline', () => {
+    it('merges events and comments sorted ascending by createdAt', async () => {
+      findOneOrThrow.mockResolvedValue(makeCompanyModel({ id: 'company-1' }))
+      eventsByCompanyId.mockResolvedValue([
+        { id: 'e1', companyId: 'company-1', createdAt: new Date('2026-01-01') },
+      ])
+      commentsByCompanyId.mockResolvedValue([
+        { id: 'c1', companyId: 'company-1', createdAt: new Date('2026-02-01') },
+      ])
+
+      const timeline = await service.getTimeline('company-1')
+
+      expect(timeline).toHaveLength(2)
+      expect(timeline[0]).toMatchObject({
+        kind: CompanyTimelineItemKindEnum.EVENT,
+        event: { id: 'e1' },
+        comment: null,
+      })
+      expect(timeline[1]).toMatchObject({
+        kind: CompanyTimelineItemKindEnum.COMMENT,
+        comment: { id: 'c1' },
+        event: null,
+      })
+    })
+
+    it('throws NotFoundException when the company does not exist', async () => {
+      findOneOrThrow.mockRejectedValue(new NotFoundException())
+
+      await expect(service.getTimeline('missing')).rejects.toThrow(
+        NotFoundException,
+      )
     })
   })
 })

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -15,13 +15,20 @@ import {
   getLimitAndOffset,
 } from '@dmr.is/utils-server/serverUtils'
 
+import { ICompanyCommentService } from '../company-comment/company-comment.service.interface'
+import { ICompanyEventService } from '../company-event/company-event.service.interface'
 import { CompanyDto } from './dto/company.dto'
 import { CompanyLookupDto } from './dto/company-lookup.dto'
+import {
+  CompanyTimelineItemDto,
+  CompanyTimelineItemKindEnum,
+} from './dto/company-timeline-item.dto'
 import {
   CompanySortByEnum,
   CompanySortDirectionEnum,
 } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 import { CompanySizeEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
 import { buildCompanyExpiryWhere, buildCompanyStatusWhere } from './utils/filters'
@@ -43,6 +50,10 @@ export class CompanyService implements ICompanyService {
     private readonly nationalRegistryService: INationalRegistryService,
     @InjectModel(CompanyModel)
     private readonly companyModel: typeof CompanyModel,
+    @Inject(ICompanyEventService)
+    private readonly companyEventService: ICompanyEventService,
+    @Inject(ICompanyCommentService)
+    private readonly companyCommentService: ICompanyCommentService,
   ) {}
 
   async getAll(query: GetCompaniesQueryDto): Promise<GetCompaniesResponseDto> {
@@ -161,6 +172,8 @@ export class CompanyService implements ICompanyService {
       employeeCountCategory: input.employeeCountCategory,
     })
 
+    await this.companyEventService.emitCreated(company.id, company.status)
+
     return company.fromModel()
   }
 
@@ -211,6 +224,8 @@ export class CompanyService implements ICompanyService {
       employeeCountCategory: CompanySizeEnum.UNKNOWN,
     })
 
+    await this.companyEventService.emitCreated(company.id, company.status)
+
     return company.fromModel()
   }
 
@@ -236,13 +251,15 @@ export class CompanyService implements ICompanyService {
       where: { nationalId: input.nationalId },
     })
 
-    const company =
-      existingCompany ??
-      (await this.companyModel.create({
+    let company = existingCompany
+    if (!company) {
+      company = await this.companyModel.create({
         name: registry.entity.nafn,
         nationalId: input.nationalId,
         employeeCountCategory: CompanySizeEnum.UNKNOWN,
-      }))
+      })
+      await this.companyEventService.emitCreated(company.id, company.status)
+    }
 
     return {
       companyId: company.id,
@@ -253,5 +270,70 @@ export class CompanyService implements ICompanyService {
       postcode: registry.entity.postaritun,
       isatCategory: '',
     }
+  }
+
+  async updateStatus(
+    id: string,
+    dto: UpdateCompanyStatusDto,
+    actorUserId: string,
+  ): Promise<CompanyDto> {
+    const company = await this.companyModel.findOneOrThrow(
+      { where: { id } },
+      `Company "${id}" not found`,
+    )
+
+    // No-op when the status is unchanged — avoids a spurious STATUS_CHANGED
+    // event with from === to (which the DB check constraint would anyway need).
+    if (company.status === dto.status) {
+      return company.fromModel()
+    }
+
+    const fromStatus = company.status
+
+    this.logger.info(
+      `Updating company ${id} status: ${fromStatus} → ${dto.status}`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    await company.update({ status: dto.status })
+    await this.companyEventService.emitStatusChanged(
+      id,
+      fromStatus,
+      dto.status,
+      actorUserId,
+      dto.reason ?? null,
+    )
+
+    return company.fromModel()
+  }
+
+  async getTimeline(id: string): Promise<CompanyTimelineItemDto[]> {
+    await this.companyModel.findOneOrThrow(
+      { where: { id } },
+      `Company "${id}" not found`,
+    )
+
+    const [events, comments] = await Promise.all([
+      this.companyEventService.getByCompanyId(id),
+      this.companyCommentService.getByCompanyId(id),
+    ])
+
+    const eventItems: CompanyTimelineItemDto[] = events.map((event) => ({
+      kind: CompanyTimelineItemKindEnum.EVENT,
+      createdAt: event.createdAt,
+      event,
+      comment: null,
+    }))
+
+    const commentItems: CompanyTimelineItemDto[] = comments.map((comment) => ({
+      kind: CompanyTimelineItemKindEnum.COMMENT,
+      createdAt: comment.createdAt,
+      event: null,
+      comment,
+    }))
+
+    return [...eventItems, ...commentItems].sort(
+      (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+    )
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-comment.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-comment.dto.ts
@@ -1,0 +1,23 @@
+import {
+  ApiDateTime,
+  ApiOptionalUuid,
+  ApiString,
+  ApiUUId,
+} from '@dmr.is/decorators'
+
+export class CompanyCommentDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiUUId()
+  companyId!: string
+
+  @ApiOptionalUuid({ nullable: true })
+  authorUserId!: string | null
+
+  @ApiString({ description: 'Plain text comment body' })
+  body!: string
+
+  @ApiDateTime()
+  createdAt!: Date
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-comment.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-comment.dto.ts
@@ -1,5 +1,6 @@
 import {
   ApiDateTime,
+  ApiOptionalString,
   ApiOptionalUuid,
   ApiString,
   ApiUUId,
@@ -14,6 +15,12 @@ export class CompanyCommentDto {
 
   @ApiOptionalUuid({ nullable: true })
   authorUserId!: string | null
+
+  @ApiOptionalString({
+    nullable: true,
+    description: 'Full name of the admin who authored the comment.',
+  })
+  authorName!: string | null
 
   @ApiString({ description: 'Plain text comment body' })
   body!: string

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-event.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-event.dto.ts
@@ -1,0 +1,46 @@
+import {
+  ApiDateTime,
+  ApiEnum,
+  ApiOptionalEnum,
+  ApiOptionalString,
+  ApiOptionalUuid,
+  ApiUUId,
+} from '@dmr.is/decorators'
+
+import { CompanyStatusEnum } from '../models/company.enums'
+import { CompanyEventTypeEnum } from '../models/company-event.model'
+
+export class CompanyEventDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiUUId()
+  companyId!: string
+
+  @ApiEnum(CompanyEventTypeEnum, { enumName: 'CompanyEventTypeEnum' })
+  eventType!: CompanyEventTypeEnum
+
+  @ApiOptionalUuid({ nullable: true })
+  actorUserId!: string | null
+
+  @ApiEnum(CompanyStatusEnum, { enumName: 'CompanyStatusEnum' })
+  status!: CompanyStatusEnum
+
+  @ApiOptionalEnum(CompanyStatusEnum, {
+    enumName: 'CompanyStatusEnum',
+    nullable: true,
+  })
+  fromStatus!: CompanyStatusEnum | null
+
+  @ApiOptionalEnum(CompanyStatusEnum, {
+    enumName: 'CompanyStatusEnum',
+    nullable: true,
+  })
+  toStatus!: CompanyStatusEnum | null
+
+  @ApiOptionalString({ nullable: true })
+  reason!: string | null
+
+  @ApiDateTime()
+  createdAt!: Date
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company-timeline-item.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company-timeline-item.dto.ts
@@ -1,0 +1,25 @@
+import { ApiDateTime, ApiEnum, ApiOptionalDto } from '@dmr.is/decorators'
+
+import { CompanyCommentDto } from './company-comment.dto'
+import { CompanyEventDto } from './company-event.dto'
+
+export enum CompanyTimelineItemKindEnum {
+  EVENT = 'EVENT',
+  COMMENT = 'COMMENT',
+}
+
+export class CompanyTimelineItemDto {
+  @ApiEnum(CompanyTimelineItemKindEnum, {
+    enumName: 'CompanyTimelineItemKindEnum',
+  })
+  kind!: CompanyTimelineItemKindEnum
+
+  @ApiDateTime()
+  createdAt!: Date
+
+  @ApiOptionalDto(CompanyEventDto, { nullable: true })
+  event!: CompanyEventDto | null
+
+  @ApiOptionalDto(CompanyCommentDto, { nullable: true })
+  comment!: CompanyCommentDto | null
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
@@ -1,6 +1,13 @@
-import { ApiBoolean, ApiEnum, ApiString, ApiUUId } from '@dmr.is/decorators'
+import {
+  ApiBoolean,
+  ApiEnum,
+  ApiOptionalString,
+  ApiOptionalUuid,
+  ApiString,
+  ApiUUId,
+} from '@dmr.is/decorators'
 
-import { CompanySizeEnum } from '../models/company.enums'
+import { CompanySizeEnum, CompanyStatusEnum } from '../models/company.enums'
 
 export class CompanyDto {
   @ApiUUId()
@@ -14,6 +21,15 @@ export class CompanyDto {
 
   @ApiString()
   nationalId!: string
+
+  @ApiEnum(CompanyStatusEnum, { enumName: 'CompanyStatusEnum' })
+  status!: CompanyStatusEnum
+
+  @ApiOptionalString({ nullable: true })
+  address!: string | null
+
+  @ApiOptionalUuid({ nullable: true })
+  postcodeId!: string | null
 
   @ApiBoolean()
   salaryReportRequired!: boolean

--- a/apps/directorate-of-equality-api/src/modules/company/dto/update-company-status.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/update-company-status.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator'
+
+import { ApiEnum, ApiOptionalString } from '@dmr.is/decorators'
+
+import { CompanyStatusEnum } from '../models/company.enums'
+
+export class UpdateCompanyStatusDto {
+  @ApiEnum(CompanyStatusEnum, { enumName: 'CompanyStatusEnum' })
+  @IsEnum(CompanyStatusEnum)
+  status!: CompanyStatusEnum
+
+  @ApiOptionalString({
+    nullable: true,
+    description: 'Optional reason for the change, e.g. bankruptcy or merger.',
+  })
+  @IsOptional()
+  @IsString()
+  reason?: string | null
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company-comment.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company-comment.model.ts
@@ -1,0 +1,63 @@
+import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
+
+import { ParanoidModel, ParanoidTable } from '@dmr.is/shared-models-base'
+
+import { DoeModels } from '../../../core/constants'
+import { UserModel } from '../../user/models/user.model'
+import type { CompanyCommentDto } from '../dto/company-comment.dto'
+import { CompanyModel } from './company.model'
+
+/**
+ * Internal, admin-authored note attached to a company. Unlike report comments
+ * there is no visibility dimension — company comments are reviewer-internal
+ * only (companies never see them), so there is no author-kind/visibility
+ * column. Paranoid: deletes are soft so the timeline stays auditable.
+ */
+type CompanyCommentAttributes = {
+  companyId: string
+  authorUserId: string | null
+  body: string
+}
+
+type CompanyCommentCreateAttributes = {
+  companyId: string
+  authorUserId?: string | null
+  body: string
+}
+
+@ParanoidTable({ tableName: DoeModels.COMPANY_COMMENT })
+export class CompanyCommentModel extends ParanoidModel<
+  CompanyCommentAttributes,
+  CompanyCommentCreateAttributes
+> {
+  @ForeignKey(() => CompanyModel)
+  @Column({ type: DataType.UUID, allowNull: false, field: 'company_id' })
+  companyId!: string
+
+  @ForeignKey(() => UserModel)
+  @Column({ type: DataType.UUID, allowNull: true, field: 'author_user_id' })
+  authorUserId!: string | null
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  body!: string
+
+  @BelongsTo(() => CompanyModel, { foreignKey: 'companyId', as: 'company' })
+  company?: CompanyModel
+
+  @BelongsTo(() => UserModel, { foreignKey: 'authorUserId', as: 'author' })
+  author?: UserModel | null
+
+  static fromModel(model: CompanyCommentModel): CompanyCommentDto {
+    return {
+      id: model.id,
+      companyId: model.companyId,
+      authorUserId: model.authorUserId,
+      body: model.body,
+      createdAt: model.createdAt,
+    }
+  }
+
+  fromModel(): CompanyCommentDto {
+    return CompanyCommentModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company-comment.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company-comment.model.ts
@@ -52,6 +52,9 @@ export class CompanyCommentModel extends ParanoidModel<
       id: model.id,
       companyId: model.companyId,
       authorUserId: model.authorUserId,
+      authorName: model.author
+        ? `${model.author.firstName} ${model.author.lastName}`
+        : null,
       body: model.body,
       createdAt: model.createdAt,
     }

--- a/apps/directorate-of-equality-api/src/modules/company/models/company-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company-event.model.ts
@@ -12,10 +12,13 @@ import { CompanyModel } from './company.model'
  * Timeline event types for a company. Mirrors the report-event pattern but
  * scoped to the company lifecycle.
  *
+ *   CREATED        → the company was registered. Origin point of the timeline;
+ *                    no from/to status (status holds the initial status).
  *   STATUS_CHANGED → an admin moved the company between ACTIVE/INACTIVE.
  *                    Carries from/to status and an optional reason.
  */
 export enum CompanyEventTypeEnum {
+  CREATED = 'CREATED',
   STATUS_CHANGED = 'STATUS_CHANGED',
 }
 

--- a/apps/directorate-of-equality-api/src/modules/company/models/company-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company-event.model.ts
@@ -1,0 +1,108 @@
+import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
+
+import { ImmutableModel, ImmutableTable } from '@dmr.is/shared-models-base'
+
+import { DoeModels } from '../../../core/constants'
+import { UserModel } from '../../user/models/user.model'
+import type { CompanyEventDto } from '../dto/company-event.dto'
+import { CompanyStatusEnum } from './company.enums'
+import { CompanyModel } from './company.model'
+
+/**
+ * Timeline event types for a company. Mirrors the report-event pattern but
+ * scoped to the company lifecycle.
+ *
+ *   STATUS_CHANGED → an admin moved the company between ACTIVE/INACTIVE.
+ *                    Carries from/to status and an optional reason.
+ */
+export enum CompanyEventTypeEnum {
+  STATUS_CHANGED = 'STATUS_CHANGED',
+}
+
+type CompanyEventAttributes = {
+  companyId: string
+  eventType: CompanyEventTypeEnum
+  actorUserId: string | null
+  status: CompanyStatusEnum
+  fromStatus: CompanyStatusEnum | null
+  toStatus: CompanyStatusEnum | null
+  reason: string | null
+}
+
+type CompanyEventCreateAttributes = {
+  companyId: string
+  eventType: CompanyEventTypeEnum
+  actorUserId?: string | null
+  status: CompanyStatusEnum
+  fromStatus?: CompanyStatusEnum | null
+  toStatus?: CompanyStatusEnum | null
+  reason?: string | null
+}
+
+@ImmutableTable({ tableName: DoeModels.COMPANY_EVENT })
+export class CompanyEventModel extends ImmutableModel<
+  CompanyEventAttributes,
+  CompanyEventCreateAttributes
+> {
+  @ForeignKey(() => CompanyModel)
+  @Column({ type: DataType.UUID, allowNull: false, field: 'company_id' })
+  companyId!: string
+
+  @Column({
+    type: DataType.ENUM(...Object.values(CompanyEventTypeEnum)),
+    allowNull: false,
+    field: 'event_type',
+  })
+  eventType!: CompanyEventTypeEnum
+
+  @ForeignKey(() => UserModel)
+  @Column({ type: DataType.UUID, allowNull: true, field: 'actor_user_id' })
+  actorUserId!: string | null
+
+  @Column({
+    type: DataType.ENUM(...Object.values(CompanyStatusEnum)),
+    allowNull: false,
+  })
+  status!: CompanyStatusEnum
+
+  @Column({
+    type: DataType.ENUM(...Object.values(CompanyStatusEnum)),
+    allowNull: true,
+    field: 'from_status',
+  })
+  fromStatus!: CompanyStatusEnum | null
+
+  @Column({
+    type: DataType.ENUM(...Object.values(CompanyStatusEnum)),
+    allowNull: true,
+    field: 'to_status',
+  })
+  toStatus!: CompanyStatusEnum | null
+
+  @Column({ type: DataType.TEXT, allowNull: true })
+  reason!: string | null
+
+  @BelongsTo(() => CompanyModel, { foreignKey: 'companyId', as: 'company' })
+  company?: CompanyModel
+
+  @BelongsTo(() => UserModel, { foreignKey: 'actorUserId', as: 'actor' })
+  actor?: UserModel | null
+
+  static fromModel(model: CompanyEventModel): CompanyEventDto {
+    return {
+      id: model.id,
+      companyId: model.companyId,
+      eventType: model.eventType,
+      actorUserId: model.actorUserId,
+      status: model.status,
+      fromStatus: model.fromStatus,
+      toStatus: model.toStatus,
+      reason: model.reason,
+      createdAt: model.createdAt,
+    }
+  }
+
+  fromModel(): CompanyEventDto {
+    return CompanyEventModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
@@ -27,3 +27,20 @@ export enum CompanySizeEnum {
   MEDIUM = 'MEDIUM',
   LARGE = 'LARGE',
 }
+
+/**
+ * Lifecycle status of a company in the DoE register.
+ *
+ *   ACTIVE   → operating; subject to the usual reporting obligations.
+ *   INACTIVE → no longer operating (e.g. bankruptcy, merged into another
+ *              company). Set by an admin; the reason is captured on the
+ *              `company_event` STATUS_CHANGED row, not here.
+ *
+ * Status changes are recorded as `company_event` STATUS_CHANGED events
+ * (with from/to status + optional reason), so the full history is explorable
+ * via the company timeline rather than a separate status-history table.
+ */
+export enum CompanyStatusEnum {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
@@ -1,16 +1,20 @@
-import { Column, DataType } from 'sequelize-typescript'
+import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
 
 import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 
 import { DoeModels } from '../../../core/constants'
+import { PostcodeModel } from '../../location/models/postcode.model'
 import type { CreateReportCompanySnapshotDto } from '../../report-create/dto/create-report.dto'
 import type { CompanyDto } from '../dto/company.dto'
-import { CompanySizeEnum } from './company.enums'
+import { CompanySizeEnum, CompanyStatusEnum } from './company.enums'
 
 type CompanyAttributes = {
   name: string
   employeeCountCategory: CompanySizeEnum
   nationalId: string
+  status: CompanyStatusEnum
+  address: string | null
+  postcodeId: string | null
   salaryReportRequired: boolean
   salaryReportRequiredOverride: boolean
 }
@@ -19,6 +23,9 @@ type CompanyCreateAttributes = {
   name: string
   employeeCountCategory: CompanySizeEnum
   nationalId: string
+  status?: CompanyStatusEnum
+  address?: string | null
+  postcodeId?: string | null
   salaryReportRequired?: boolean
   salaryReportRequiredOverride?: boolean
 }
@@ -42,6 +49,23 @@ export class CompanyModel extends MutableModel<
   nationalId!: string
 
   @Column({
+    type: DataType.ENUM(...Object.values(CompanyStatusEnum)),
+    allowNull: false,
+    defaultValue: CompanyStatusEnum.ACTIVE,
+  })
+  status!: CompanyStatusEnum
+
+  @Column({ type: DataType.TEXT, allowNull: true })
+  address!: string | null
+
+  @ForeignKey(() => PostcodeModel)
+  @Column({ type: DataType.UUID, allowNull: true, field: 'postcode_id' })
+  postcodeId!: string | null
+
+  @BelongsTo(() => PostcodeModel, { foreignKey: 'postcodeId', as: 'postcode' })
+  postcode?: PostcodeModel | null
+
+  @Column({
     type: DataType.BOOLEAN,
     allowNull: false,
     defaultValue: false,
@@ -63,6 +87,9 @@ export class CompanyModel extends MutableModel<
       name: model.name,
       employeeCountCategory: model.employeeCountCategory,
       nationalId: model.nationalId,
+      status: model.status,
+      address: model.address,
+      postcodeId: model.postcodeId,
       salaryReportRequired: model.salaryReportRequired,
       salaryReportRequiredOverride: model.salaryReportRequiredOverride,
     }

--- a/apps/directorate-of-equality-api/src/modules/location/dto/postcode.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/location/dto/postcode.dto.ts
@@ -1,0 +1,15 @@
+import { ApiString, ApiUUId } from '@dmr.is/decorators'
+
+export class PostcodeDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiString({ description: 'Three-digit Icelandic postcode, e.g. 101' })
+  code!: string
+
+  @ApiString({ description: 'Locality / place name, e.g. Reykjavík' })
+  place!: string
+
+  @ApiUUId()
+  regionId!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/location/dto/region.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/location/dto/region.dto.ts
@@ -1,0 +1,12 @@
+import { ApiString, ApiUUId } from '@dmr.is/decorators'
+
+export class RegionDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiString({ description: 'Stable machine key for the region, e.g. CAPITAL' })
+  code!: string
+
+  @ApiString({ description: 'Display name (Icelandic), e.g. Höfuðborgarsvæðið' })
+  name!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/location/models/postcode.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/location/models/postcode.model.ts
@@ -1,0 +1,58 @@
+import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
+
+import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
+
+import { DoeModels } from '../../../core/constants'
+import type { PostcodeDto } from '../dto/postcode.dto'
+import { RegionModel } from './region.model'
+
+/**
+ * An Icelandic postcode (póstnúmer, e.g. "101"), mapping a 3-digit code to its
+ * place/locality and the region it belongs to. Reference data — the canonical
+ * ~150-row set is loaded by a separate sourced seeder; this migration only
+ * creates the table. `place` carries the locality name (e.g. "Reykjavík"), so
+ * companies do not need a free-text city of their own.
+ */
+type PostcodeAttributes = {
+  code: string
+  place: string
+  regionId: string
+}
+
+type PostcodeCreateAttributes = {
+  code: string
+  place: string
+  regionId: string
+}
+
+@MutableTable({ tableName: DoeModels.POSTCODE })
+export class PostcodeModel extends MutableModel<
+  PostcodeAttributes,
+  PostcodeCreateAttributes
+> {
+  @Column({ type: DataType.TEXT, allowNull: false })
+  code!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  place!: string
+
+  @ForeignKey(() => RegionModel)
+  @Column({ type: DataType.UUID, allowNull: false, field: 'region_id' })
+  regionId!: string
+
+  @BelongsTo(() => RegionModel, { foreignKey: 'regionId', as: 'region' })
+  region?: RegionModel
+
+  static fromModel(model: PostcodeModel): PostcodeDto {
+    return {
+      id: model.id,
+      code: model.code,
+      place: model.place,
+      regionId: model.regionId,
+    }
+  }
+
+  fromModel(): PostcodeDto {
+    return PostcodeModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/location/models/region.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/location/models/region.model.ts
@@ -1,0 +1,53 @@
+import { Column, DataType, HasMany } from 'sequelize-typescript'
+
+import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
+
+import { DoeModels } from '../../../core/constants'
+import type { RegionDto } from '../dto/region.dto'
+import { PostcodeModel } from './postcode.model'
+
+/**
+ * One of Iceland's eight landshlutar (regions). Reference data — the canonical
+ * set is seeded by migration and rarely changes. Postcodes roll up into a
+ * region, so a company's region is reached via `company → postcode → region`;
+ * the region is never stored on the company directly.
+ *
+ * `code` is the stable machine key (e.g. CAPITAL) used by downstream seeders
+ * (postcodes) to resolve a region without depending on a generated UUID.
+ */
+type RegionAttributes = {
+  code: string
+  name: string
+}
+
+type RegionCreateAttributes = {
+  code: string
+  name: string
+}
+
+@MutableTable({ tableName: DoeModels.REGION })
+export class RegionModel extends MutableModel<
+  RegionAttributes,
+  RegionCreateAttributes
+> {
+  @Column({ type: DataType.TEXT, allowNull: false })
+  code!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  name!: string
+
+  @HasMany(() => PostcodeModel, { foreignKey: 'regionId', as: 'postcodes' })
+  postcodes?: PostcodeModel[]
+
+  static fromModel(model: RegionModel): RegionDto {
+    return {
+      id: model.id,
+      code: model.code,
+      name: model.name,
+    }
+  }
+
+  fromModel(): RegionDto {
+    return RegionModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-comment/dto/report-comment.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/dto/report-comment.dto.ts
@@ -1,6 +1,7 @@
 import {
   ApiDateTime,
   ApiEnum,
+  ApiOptionalString,
   ApiOptionalUuid,
   ApiString,
   ApiUUId,
@@ -24,6 +25,13 @@ export class ReportCommentDto {
 
   @ApiOptionalUuid({ nullable: true })
   authorUserId!: string | null
+
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      'Full name of the authoring reviewer. Null for company-authored comments (no individual person).',
+  })
+  authorName!: string | null
 
   @ApiEnum(CommentVisibilityEnum, { enumName: 'CommentVisibilityEnum' })
   visibility!: CommentVisibilityEnum

--- a/apps/directorate-of-equality-api/src/modules/report-comment/models/report-comment.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/models/report-comment.model.ts
@@ -80,6 +80,9 @@ export class ReportCommentModel extends ParanoidModel<
       reportId: model.reportId,
       authorKind: model.authorKind,
       authorUserId: model.authorUserId,
+      authorName: model.author
+        ? `${model.author.firstName} ${model.author.lastName}`
+        : null,
       visibility: model.visibility,
       body: model.body,
       reportStatus: model.reportStatus,

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.spec.ts
@@ -4,6 +4,7 @@ import {
   type ReportResourceContext,
   ReportRoleEnum,
 } from '../report/types/report-resource-context'
+import { UserModel } from '../user/models/user.model'
 import { CreateReportCommentDto } from './dto/create-report-comment.dto'
 import { CommentVisibilityEnum } from './models/report-comment.model'
 import { ReportCommentService } from './report-comment.service'
@@ -62,7 +63,11 @@ describe('ReportCommentService', () => {
 
   it('creates a reviewer comment with the current report status snapshot', async () => {
     const commentDto = { id: 'comment-1' }
-    const commentRecord = { id: 'comment-1', fromModel: () => commentDto }
+    const commentRecord = {
+      id: 'comment-1',
+      fromModel: () => commentDto,
+      reload: jest.fn(),
+    }
 
     reportCommentModel.create.mockResolvedValue(commentRecord)
 
@@ -101,6 +106,7 @@ describe('ReportCommentService', () => {
         visibility: CommentVisibilityEnum.EXTERNAL,
       },
       order: [['createdAt', 'ASC']],
+      include: [{ model: UserModel, as: 'author', required: false }],
     })
     expect(result).toEqual([commentDto])
   })
@@ -111,6 +117,7 @@ describe('ReportCommentService', () => {
     reportCommentModel.create.mockResolvedValue({
       id: 'comment-2',
       fromModel: () => commentDto,
+      reload: jest.fn(),
     })
 
     const result = await service.create(companyContext, {
@@ -155,6 +162,7 @@ describe('ReportCommentService', () => {
     const commentRecord = {
       id: 'comment-3',
       fromModel: () => ({ id: 'comment-3' }),
+      reload: jest.fn(),
     }
     const reportRecord = { id: 'report-1' }
 
@@ -177,6 +185,7 @@ describe('ReportCommentService', () => {
     reportCommentModel.create.mockResolvedValue({
       id: 'comment-4',
       fromModel: () => ({ id: 'comment-4' }),
+      reload: jest.fn(),
     })
 
     await service.create(reviewerContext, {
@@ -192,6 +201,7 @@ describe('ReportCommentService', () => {
     reportCommentModel.create.mockResolvedValue({
       id: 'comment-5',
       fromModel: () => ({ id: 'comment-5' }),
+      reload: jest.fn(),
     })
 
     await service.create(companyContext, {
@@ -207,6 +217,7 @@ describe('ReportCommentService', () => {
     reportCommentModel.create.mockResolvedValue({
       id: 'comment-6',
       fromModel: () => ({ id: 'comment-6' }),
+      reload: jest.fn(),
     })
     reportModel.findByPk.mockResolvedValue(null)
 

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.ts
@@ -14,6 +14,7 @@ import {
   type ReportResourceContext,
   ReportRoleEnum,
 } from '../report/types/report-resource-context'
+import { UserModel } from '../user/models/user.model'
 import { CreateReportCommentDto } from './dto/create-report-comment.dto'
 import { ReportCommentDto } from './dto/report-comment.dto'
 import {
@@ -52,6 +53,7 @@ export class ReportCommentService implements IReportCommentService {
               visibility: CommentVisibilityEnum.EXTERNAL,
             },
       order: [['createdAt', 'ASC']],
+      include: [{ model: UserModel, as: 'author', required: false }],
     })
 
     return comments.map((comment) => comment.fromModel())
@@ -109,6 +111,12 @@ export class ReportCommentService implements IReportCommentService {
         await this.mailService.sendExternalCommentNotification(report, comment)
       }
     }
+
+    // Reload with the author so the response carries authorName (the freshly
+    // created instance has no association loaded).
+    await comment.reload({
+      include: [{ model: UserModel, as: 'author', required: false }],
+    })
 
     return comment.fromModel()
   }

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -142,6 +142,7 @@ type ReportCreateAttributes = {
         required: false,
         separate: true,
         order: [['createdAt', 'DESC']],
+        include: [{ model: UserModel, as: 'author', required: false }],
       },
       // Salary-only aggregate — null for equality reports. Per-role
       // breakdown + employee outliers are loaded via separate queries


### PR DESCRIPTION
## What

  Adds a documentation/audit layer to companies, mirroring what reports already have, plus normalized geography reference data.

  Schema (m-20260616-company-status-events-comments.js)
  - region (8 landshlutar, seeded in the migration) and postcode (193 Icelandic postcodes → region) reference tables.
  - company: new status (ACTIVE/INACTIVE, default ACTIVE), free-text address, and a postcode_id FK. Region/place are derived via company → postcode → region (not duplicated on the
  company).
  - company_event (immutable: CREATED, STATUS_CHANGED with from/to + optional reason) and company_comment (paranoid, admin-internal notes).

  Services & API (admin-only, on CompanyController)
  - CompanyEventService emits CREATED at every company-creation site and STATUS_CHANGED on status updates.
  - CompanyCommentService for internal note CRUD.
  - CompanyService.updateStatus (no-op when unchanged) and getTimeline (merged events + comments, sorted by createdAt).
  - Endpoints: PATCH :id/status, GET :id/timeline, GET|POST :id/comments, DELETE :id/comments/:commentId.
  - New @CurrentAdminUser() decorator to stamp the acting admin.

  Comment author name
  - ReportCommentDto and CompanyCommentDto now expose authorName, resolved from the author association; read/create paths load the author so it's populated.

 ## Why

  - Admins asked to document companies the same way they can reports — an explorable timeline of status changes (e.g. bankruptcy, merger) and internal notes.
  - Status history is captured as STATUS_CHANGED events rather than a separate history table, so there's a single, consistent timeline mechanism (matches the report pattern).
  - Normalizing region/postcode into reference tables enables querying companies by region/postcode and computing salary statistics across them later.
  - Surfacing authorName saves clients an extra user lookup and makes timelines/comment lists readable at a glance.

 ## Notes

  - Migration has not been run against a live DB yet — validated by syntax + typecheck + tests only.
  - CompanyEventTypeEnum ships with CREATED/STATUS_CHANGED; more types are an ALTER TYPE away.
  - A few postcode→region assignments are deliberate cross-range calls (Vopnafjörður, Hornafjörður/Öræfi → Austurland; Siglufjörður → Norðurland eystra) — flagged in the migration.
  - CompanyModel.toSnapshot() still hardcodes empty address/city/postcode; wiring it to the real values is left for the frontend/integration pass