### PR TITLE
feat(doe): outliers grouping

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260616-outlier-groups.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260616-outlier-groups.js
@@ -1,0 +1,127 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- ============================================================
+    -- Outlier groups.
+    --
+    -- The improvement-plan explanation (reason / action / signature)
+    -- moves from the per-outlier row up to a new "outlier group". A
+    -- salary report can have multiple groups; each detected outlier
+    -- belongs to exactly one group (group_id NOT NULL); the explanation
+    -- is written once per group.
+    --
+    -- Every report with detected outliers always has at least one group.
+    -- When a report is submitted with outliers postponed (status =
+    -- POSTPONED) a single default group is created covering every detected
+    -- outlier, with its explanation columns left NULL; the applicant fills
+    -- them in (or replaces the grouping) on resolve. The all-or-none CHECK
+    -- that previously lived on report_employee_outlier therefore moves up
+    -- to the group: all four explanation columns are NULL (postponed / not
+    -- yet filled) or all four are non-empty (explained). The name column is
+    -- always NOT NULL.
+    -- ============================================================
+
+    CREATE TABLE report_outlier_group (
+      id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+      created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+
+      report_id UUID NOT NULL REFERENCES report(id),
+      name TEXT NOT NULL,
+      reason TEXT DEFAULT NULL,
+      action TEXT DEFAULT NULL,
+      signature_name TEXT DEFAULT NULL,
+      signature_role TEXT DEFAULT NULL,
+
+      CONSTRAINT report_outlier_group_explanation_chk CHECK (
+        (
+          reason IS NULL
+          AND action IS NULL
+          AND signature_name IS NULL
+          AND signature_role IS NULL
+        ) OR (
+          reason IS NOT NULL AND reason <> ''
+          AND action IS NOT NULL AND action <> ''
+          AND signature_name IS NOT NULL AND signature_name <> ''
+          AND signature_role IS NOT NULL AND signature_role <> ''
+        )
+      )
+    );
+
+    CREATE INDEX report_outlier_group_report_id_idx
+      ON report_outlier_group (report_id);
+
+    -- ============================================================
+    -- report_employee_outlier becomes a thin join.
+    --
+    --   * gains group_id (NOT NULL — every outlier is always in a group)
+    --   * loses the explanation columns (now owned by the group)
+    --   * loses the all-or-none CHECK constraint
+    --
+    -- Dev only: any existing outlier rows carry no group and cannot be
+    -- backfilled, so they are discarded before the NOT NULL column is added.
+    -- ============================================================
+
+    TRUNCATE TABLE report_employee_outlier;
+
+    ALTER TABLE report_employee_outlier
+      ADD COLUMN group_id UUID NOT NULL REFERENCES report_outlier_group(id);
+
+    CREATE INDEX report_employee_outlier_group_id_idx
+      ON report_employee_outlier (group_id);
+
+    ALTER TABLE report_employee_outlier
+      DROP CONSTRAINT report_employee_outlier_explanation_chk;
+
+    ALTER TABLE report_employee_outlier
+      DROP COLUMN reason,
+      DROP COLUMN action,
+      DROP COLUMN signature_name,
+      DROP COLUMN signature_role;
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- Restore the per-outlier explanation columns + all-or-none CHECK.
+    ALTER TABLE report_employee_outlier
+      ADD COLUMN reason TEXT DEFAULT NULL,
+      ADD COLUMN action TEXT DEFAULT NULL,
+      ADD COLUMN signature_name TEXT DEFAULT NULL,
+      ADD COLUMN signature_role TEXT DEFAULT NULL;
+
+    ALTER TABLE report_employee_outlier
+      ADD CONSTRAINT report_employee_outlier_explanation_chk CHECK (
+        (
+          reason IS NULL
+          AND action IS NULL
+          AND signature_name IS NULL
+          AND signature_role IS NULL
+        ) OR (
+          reason IS NOT NULL AND reason <> ''
+          AND action IS NOT NULL AND action <> ''
+          AND signature_name IS NOT NULL AND signature_name <> ''
+          AND signature_role IS NOT NULL AND signature_role <> ''
+        )
+      );
+
+    DROP INDEX report_employee_outlier_group_id_idx;
+
+    ALTER TABLE report_employee_outlier
+      DROP COLUMN group_id;
+
+    DROP TABLE report_outlier_group;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { ReportEmployeeOutlierModel } from '../modules/report-employee/models/re
 import { ReportEmployeePersonalCriterionStepModel } from '../modules/report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../modules/report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../modules/report-employee/models/report-employee-role-criterion-step.model'
+import { ReportOutlierGroupModel } from '../modules/report-employee/models/report-outlier-group.model'
 import { ReportResultModel } from '../modules/report-result/models/report-result.model'
 import { ReportRoleResultModel } from '../modules/report-result/models/report-role-result.model'
 import { DoeWebSwaggerModule } from '../modules/swagger/doe-web.swagger.module'
@@ -67,6 +68,7 @@ import { HealthController } from './health.controller'
             ReportSubCriterionStepModel,
             ReportEmployeeModel,
             ReportEmployeeOutlierModel,
+            ReportOutlierGroupModel,
             ReportEmployeeRoleCriterionStepModel,
             ReportEmployeePersonalCriterionStepModel,
             ReportResultModel,

--- a/apps/directorate-of-equality-api/src/core/constants.ts
+++ b/apps/directorate-of-equality-api/src/core/constants.ts
@@ -13,6 +13,7 @@ export enum DoeModels {
   REPORT_EMPLOYEE = 'report_employee',
   REPORT_EMPLOYEE_ROLE = 'report_employee_role',
   REPORT_EMPLOYEE_OUTLIER = 'report_employee_outlier',
+  REPORT_OUTLIER_GROUP = 'report_outlier_group',
   REPORT_EMPLOYEE_ROLE_CRITERION_STEP = 'report_employee_role_criterion_step',
   REPORT_EMPLOYEE_PERSONAL_CRITERION_STEP = 'report_employee_personal_criterion_step',
   REPORT_RESULT = 'report_result',
@@ -24,3 +25,12 @@ export enum DoeModels {
   COMPANY_COMMENT = 'company_comment',
   CONFIG = 'config',
 }
+
+/**
+ * Name assigned to the auto-created outlier group when the applicant submits a
+ * salary report without explicitly grouping the detected outliers. `name` is
+ * NOT NULL on `report_outlier_group`; this is the value used for the implicit
+ * single-group case (the frontend may choose to hide the name when there is
+ * only one default group).
+ */
+export const DEFAULT_OUTLIER_GROUP_NAME = 'Sjálfgefinn hópur'

--- a/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/dto/admin-salary-report.dto.ts
@@ -13,7 +13,7 @@ import {
   GenderEnum,
   ReportProviderEnum,
 } from '../../report/models/report.enums'
-import { CreateReportOutlierDto } from '../../report-create/dto/create-report.dto'
+import { CreateReportOutlierGroupDto } from '../../report-create/dto/create-report.dto'
 import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
 
 export class AdminSalaryReportDto {
@@ -62,6 +62,6 @@ export class AdminSalaryReportDto {
   @ApiOptionalBoolean()
   postponed?: boolean
 
-  @ApiOptionalDtoArray(CreateReportOutlierDto)
-  outliers?: CreateReportOutlierDto[]
+  @ApiOptionalDtoArray(CreateReportOutlierGroupDto)
+  outlierGroups?: CreateReportOutlierGroupDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/application/application.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.core.module.ts
@@ -11,6 +11,7 @@ import { ReportCoreModule } from '../report/report.core.module'
 import { ReportCommentCoreModule } from '../report-comment/report-comment.core.module'
 import { ReportCreateCoreModule } from '../report-create/report-create.core.module'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportEventCoreModule } from '../report-event/report-event.core.module'
 import { ReportExcelCoreModule } from '../report-excel/report-excel.core.module'
 import { ReportResultCoreModule } from '../report-result/report-result.core.module'
@@ -31,6 +32,7 @@ import { IApplicationService } from './application.service.interface'
       ReportModel,
       CompanyReportModel,
       ReportEmployeeOutlierModel,
+      ReportOutlierGroupModel,
       ReportEventModel,
     ]),
   ],

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -10,7 +10,10 @@ import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
-import { CompanySizeEnum } from '../company/models/company.enums'
+import {
+  CompanySizeEnum,
+  CompanyStatusEnum,
+} from '../company/models/company.enums'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
 import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
@@ -37,6 +40,7 @@ import { IReportCreateService } from '../report-create/report-create.service.int
 import { ReportCriterionTypeEnum } from '../report-criterion/models/report-criterion.model'
 import { EducationEnum } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { IReportEventService } from '../report-event/report-event.service.interface'
 import { IReportResultService } from '../report-result/report-result.service.interface'
 import { SalaryAnalysisRequestDto } from './dto/salary-analysis.request.dto'
@@ -56,6 +60,9 @@ const COMPANY: CompanyDto = {
   name: 'Acme ehf.',
   employeeCountCategory: CompanySizeEnum.LARGE,
   nationalId: '5501234567',
+  status: CompanyStatusEnum.ACTIVE,
+  address: 'Laugavegur 1',
+  postcodeId: null,
   salaryReportRequired: true,
   salaryReportRequiredOverride: false,
 }
@@ -74,6 +81,9 @@ describe('ApplicationService', () => {
   let outlierFindAndCountAll: jest.Mock
   let outlierCount: jest.Mock
   let outlierUpdate: jest.Mock
+  let outlierGroupCreate: jest.Mock
+  let outlierGroupFindAll: jest.Mock
+  let outlierGroupDestroy: jest.Mock
   let eventFindOne: jest.Mock
   let getCommentsByReportId: jest.Mock
   let createComment: jest.Mock
@@ -99,6 +109,13 @@ describe('ApplicationService', () => {
     outlierFindAndCountAll = jest.fn().mockResolvedValue({ rows: [], count: 0 })
     outlierCount = jest.fn().mockResolvedValue(0)
     outlierUpdate = jest.fn().mockResolvedValue([1])
+    let groupSeq = 0
+    outlierGroupCreate = jest.fn(async (row) => ({
+      ...row,
+      id: `group-${groupSeq++}`,
+    }))
+    outlierGroupFindAll = jest.fn().mockResolvedValue([])
+    outlierGroupDestroy = jest.fn().mockResolvedValue(0)
     eventFindOne = jest.fn().mockResolvedValue(null)
     getCommentsByReportId = jest.fn().mockResolvedValue([])
     createComment = jest.fn()
@@ -162,6 +179,14 @@ describe('ApplicationService', () => {
             findAndCountAll: outlierFindAndCountAll,
             count: outlierCount,
             update: outlierUpdate,
+          },
+        },
+        {
+          provide: getModelToken(ReportOutlierGroupModel),
+          useValue: {
+            create: outlierGroupCreate,
+            findAll: outlierGroupFindAll,
+            destroy: outlierGroupDestroy,
           },
         },
         {
@@ -274,7 +299,7 @@ describe('ApplicationService', () => {
         parsed: input.parsed,
         companies: [makeCompanySnapshot()],
         outliersPostponed: undefined,
-        outliers: undefined,
+        outlierGroups: undefined,
       })
       expect(result).toEqual({ reportId: 'report-1' })
     })
@@ -1017,15 +1042,16 @@ describe('ApplicationService', () => {
     const detectedSnapshot = (ordinals: number[]) =>
       makeReportResultDto(REPORT_ID, ordinals)
 
-    const validRow = (ordinal: number) => ({
-      employeeOrdinal: ordinal,
+    const validGroup = (...ordinals: number[]) => ({
+      name: 'Group',
       reason: 'Parental leave, salary frozen',
       action: 'No adjustment, frozen for the period',
       signatureName: 'Anna Admin',
       signatureRole: 'HR',
+      employeeOrdinals: ordinals,
     })
 
-    it('POSTPONED → SUBMITTED resolution: updates outliers, flips status, emits STATUS_CHANGED + EDITED', async () => {
+    it('POSTPONED → SUBMITTED resolution: replaces groups, re-points rows, flips status, emits STATUS_CHANGED + EDITED', async () => {
       const postponedSalary = makeReportRow({
         id: REPORT_ID,
         providerId: PROVIDER_ID,
@@ -1052,23 +1078,36 @@ describe('ApplicationService', () => {
           reportEmployee: { id: 'emp-1', ordinal: 1 },
         },
       ])
+      // The postponed default group that gets replaced.
+      outlierGroupFindAll.mockResolvedValueOnce([{ id: 'old-group-1' }])
       getCommentsByReportId.mockResolvedValueOnce([])
 
       await service.editOutliers(
         PROVIDER_ID,
-        { outliers: [validRow(1)] },
+        { groups: [validGroup(1)] },
         COMPANY,
       )
 
-      expect(outlierUpdate).toHaveBeenCalledWith(
+      // New group created with the explanation...
+      expect(outlierGroupCreate).toHaveBeenCalledWith(
         expect.objectContaining({
+          reportId: REPORT_ID,
+          name: 'Group',
           reason: 'Parental leave, salary frozen',
           action: 'No adjustment, frozen for the period',
           signatureName: 'Anna Admin',
           signatureRole: 'HR',
         }),
+      )
+      // ...outlier row re-pointed at it...
+      expect(outlierUpdate).toHaveBeenCalledWith(
+        { groupId: 'group-0' },
         { where: { id: 'outlier-1' } },
       )
+      // ...and the old group deleted.
+      expect(outlierGroupDestroy).toHaveBeenCalledWith({
+        where: { id: ['old-group-1'] },
+      })
       expect(reportUpdate).toHaveBeenCalledWith(
         { status: ReportStatusEnum.SUBMITTED },
         { where: { id: REPORT_ID } },
@@ -1086,7 +1125,7 @@ describe('ApplicationService', () => {
       )
     })
 
-    it('IN_REVIEW correction: updates outliers, preserves status, emits EDITED only', async () => {
+    it('IN_REVIEW correction: replaces groups, preserves status, emits EDITED only', async () => {
       const inReviewSalary = makeReportRow({
         id: REPORT_ID,
         providerId: PROVIDER_ID,
@@ -1106,16 +1145,18 @@ describe('ApplicationService', () => {
           reportEmployee: { id: 'emp-1', ordinal: 1 },
         },
       ])
+      outlierGroupFindAll.mockResolvedValueOnce([{ id: 'old-group-1' }])
       getCommentsByReportId.mockResolvedValueOnce([])
 
       await service.editOutliers(
         PROVIDER_ID,
-        { outliers: [validRow(1)] },
+        { groups: [validGroup(1)] },
         COMPANY,
       )
 
+      expect(outlierGroupCreate).toHaveBeenCalledTimes(1)
       expect(outlierUpdate).toHaveBeenCalledTimes(1)
-      // Status is NOT updated — only outlier rows are.
+      // Status is NOT updated — only the grouping is.
       expect(reportUpdate).not.toHaveBeenCalled()
       expect(emitStatusChanged).not.toHaveBeenCalled()
       expect(emitEdited).toHaveBeenCalledWith(
@@ -1142,15 +1183,16 @@ describe('ApplicationService', () => {
       await expect(
         service.editOutliers(
           PROVIDER_ID,
-          { outliers: [validRow(1), validRow(2)] },
+          { groups: [validGroup(1, 2)] },
           COMPANY,
         ),
       ).rejects.toBeInstanceOf(BadRequestException)
+      expect(outlierGroupCreate).not.toHaveBeenCalled()
       expect(outlierUpdate).not.toHaveBeenCalled()
       expect(reportUpdate).not.toHaveBeenCalled()
     })
 
-    it('rejects missing (detected ordinal not in submitted)', async () => {
+    it('rejects missing (detected ordinal not covered by any group)', async () => {
       reportFindOne.mockResolvedValueOnce(
         makeReportRow({
           id: REPORT_ID,
@@ -1165,12 +1207,13 @@ describe('ApplicationService', () => {
       getResultByReportId.mockResolvedValueOnce(detectedSnapshot([1, 2]))
 
       await expect(
-        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
+        service.editOutliers(PROVIDER_ID, { groups: [validGroup(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
+      expect(outlierGroupCreate).not.toHaveBeenCalled()
       expect(outlierUpdate).not.toHaveBeenCalled()
     })
 
-    it('rejects duplicates (same ordinal submitted twice)', async () => {
+    it('rejects an ordinal that appears in more than one group', async () => {
       reportFindOne.mockResolvedValueOnce(
         makeReportRow({
           id: REPORT_ID,
@@ -1186,10 +1229,11 @@ describe('ApplicationService', () => {
       await expect(
         service.editOutliers(
           PROVIDER_ID,
-          { outliers: [validRow(1), validRow(1)] },
+          { groups: [validGroup(1), validGroup(1)] },
           COMPANY,
         ),
       ).rejects.toBeInstanceOf(BadRequestException)
+      expect(outlierGroupCreate).not.toHaveBeenCalled()
       expect(outlierUpdate).not.toHaveBeenCalled()
     })
 
@@ -1207,7 +1251,7 @@ describe('ApplicationService', () => {
       ])
 
       await expect(
-        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
+        service.editOutliers(PROVIDER_ID, { groups: [validGroup(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
 
@@ -1225,7 +1269,7 @@ describe('ApplicationService', () => {
       ])
 
       await expect(
-        service.editOutliers(PROVIDER_ID, { outliers: [validRow(1)] }, COMPANY),
+        service.editOutliers(PROVIDER_ID, { groups: [validGroup(1)] }, COMPANY),
       ).rejects.toBeInstanceOf(BadRequestException)
     })
   })
@@ -1472,10 +1516,15 @@ function makeOutlierRow(
   return {
     id: 'outlier-1',
     reportEmployeeId: 'employee-1',
-    reason: 'Reason',
-    action: 'Action',
-    signatureName: 'Anna Admin',
-    signatureRole: 'HR',
+    groupId: 'group-1',
+    group: {
+      id: 'group-1',
+      name: 'Group',
+      reason: 'Reason',
+      action: 'Action',
+      signatureName: 'Anna Admin',
+      signatureRole: 'HR',
+    },
     reportEmployee: {
       gender: GenderEnum.FEMALE,
       role: { title: 'Manager' },

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -16,6 +16,7 @@ import {
   getLimitAndOffset,
 } from '@dmr.is/utils-server/serverUtils'
 
+import { DEFAULT_OUTLIER_GROUP_NAME } from '../../core/constants'
 import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
 import { CompanyReportModel } from '../company/models/company-report.model'
@@ -58,6 +59,7 @@ import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { IReportEventService } from '../report-event/report-event.service.interface'
 import type { ReportResultDto } from '../report-result/dto/report-result.dto'
 import { IReportResultService } from '../report-result/report-result.service.interface'
@@ -118,6 +120,8 @@ export class ApplicationService implements IApplicationService {
     private readonly companyReportModel: typeof CompanyReportModel,
     @InjectModel(ReportEmployeeOutlierModel)
     private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
+    @InjectModel(ReportOutlierGroupModel)
+    private readonly reportOutlierGroupModel: typeof ReportOutlierGroupModel,
     @InjectModel(ReportEventModel)
     private readonly reportEventModel: typeof ReportEventModel,
   ) {}
@@ -440,7 +444,7 @@ export class ApplicationService implements IApplicationService {
   }
 
   /**
-   * In-place edit of a SALARY report's outlier explanations.
+   * In-place edit of a SALARY report's outlier groups (replace-all).
    *
    * Allowed in two statuses:
    *   - `POSTPONED` (primary path): applicant is resolving postponement.
@@ -449,10 +453,13 @@ export class ApplicationService implements IApplicationService {
    *   - `IN_REVIEW` (correction path): reviewer asked for corrections via
    *     comment. Status is preserved; only `EDITED` is emitted.
    *
-   * The submitted set must match the canonical detected outliers on the
-   * report (read from `report_result.outlierAnalysisSnapshot.employees`
-   * filtered to `isOutlier = true`) — every detected ordinal must appear
-   * exactly once, and no extras are allowed.
+   * The union of every group's `employeeOrdinals` must match the canonical
+   * detected outliers on the report (read from
+   * `report_result.outlierAnalysisSnapshot.employees` filtered to
+   * `isOutlier = true`) — every detected ordinal covered exactly once, no
+   * extras, no missing, no ordinal in two groups. The report's existing groups
+   * are replaced wholesale: the outlier rows are re-pointed at freshly created
+   * groups and the old groups are deleted.
    */
   async editOutliers(
     providerId: string,
@@ -485,17 +492,20 @@ export class ApplicationService implements IApplicationService {
       )
     }
 
-    // 1. Pure request validation — detect duplicate ordinals before any DB
-    //    fetch. Failing fast keeps the error message specific to the input
-    //    and avoids unnecessary work.
+    // 1. Pure request validation — flatten the groups into a single ordinal
+    //    set, rejecting any ordinal that appears in more than one group (an
+    //    outlier belongs to exactly one group). Failing fast keeps the error
+    //    message specific to the input and avoids unnecessary work.
     const submittedOrdinals = new Set<number>()
-    for (const submitted of input.outliers) {
-      if (submittedOrdinals.has(submitted.employeeOrdinal)) {
-        throw new BadRequestException(
-          `Duplicate outlier row for employee ordinal ${submitted.employeeOrdinal}`,
-        )
+    for (const group of input.groups) {
+      for (const ordinal of group.employeeOrdinals) {
+        if (submittedOrdinals.has(ordinal)) {
+          throw new BadRequestException(
+            `Employee ordinal ${ordinal} appears in more than one outlier group`,
+          )
+        }
+        submittedOrdinals.add(ordinal)
       }
-      submittedOrdinals.add(submitted.employeeOrdinal)
     }
 
     // 2. Canonical detected set, frozen at submit time on the report_result.
@@ -511,7 +521,7 @@ export class ApplicationService implements IApplicationService {
     )
     if (extras.length > 0) {
       throw new BadRequestException(
-        `Outlier row(s) submitted for non-outlier employee ordinal(s): ${extras.join(', ')}`,
+        `Outlier group(s) reference non-outlier employee ordinal(s): ${extras.join(', ')}`,
       )
     }
 
@@ -520,7 +530,7 @@ export class ApplicationService implements IApplicationService {
     )
     if (missing.length > 0) {
       throw new BadRequestException(
-        `Detected outlier(s) missing acknowledgement for employee ordinal(s): ${missing.join(', ')}`,
+        `Detected outlier(s) missing from the outlier groups for employee ordinal(s): ${missing.join(', ')}`,
       )
     }
 
@@ -544,26 +554,45 @@ export class ApplicationService implements IApplicationService {
       }
     }
 
-    // 4. Update each outlier row's explanation fields. The set-match
-    //    validation above guarantees every submitted ordinal resolves.
-    for (const submitted of input.outliers) {
-      const row = outlierByOrdinal.get(submitted.employeeOrdinal)
-      if (!row) {
-        // Shouldn't happen — detected set is read from report_result which
-        // is built from the same employees that have outlier rows. Defensive.
-        throw new InternalServerErrorException(
-          `Outlier row missing for detected employee ordinal ${submitted.employeeOrdinal}`,
+    // 4. Replace-all. Capture the report's current groups, create the new
+    //    ones, re-point each outlier row at its new group, then delete the
+    //    old groups (now unreferenced — group_id is NOT NULL, so the
+    //    re-point must happen before the delete).
+    const previousGroups = await this.reportOutlierGroupModel.findAll({
+      where: { reportId: report.id },
+      attributes: ['id'],
+    })
+
+    for (const group of input.groups) {
+      const groupRow = await this.reportOutlierGroupModel.create({
+        reportId: report.id,
+        name: group.name?.trim() || DEFAULT_OUTLIER_GROUP_NAME,
+        reason: group.reason,
+        action: group.action,
+        signatureName: group.signatureName,
+        signatureRole: group.signatureRole,
+      })
+
+      for (const ordinal of group.employeeOrdinals) {
+        const row = outlierByOrdinal.get(ordinal)
+        if (!row) {
+          // Shouldn't happen — detected set is read from report_result which
+          // is built from the same employees that have outlier rows. Defensive.
+          throw new InternalServerErrorException(
+            `Outlier row missing for detected employee ordinal ${ordinal}`,
+          )
+        }
+        await this.reportEmployeeOutlierModel.update(
+          { groupId: groupRow.id },
+          { where: { id: row.id } },
         )
       }
-      await this.reportEmployeeOutlierModel.update(
-        {
-          reason: submitted.reason,
-          action: submitted.action,
-          signatureName: submitted.signatureName,
-          signatureRole: submitted.signatureRole,
-        },
-        { where: { id: row.id } },
-      )
+    }
+
+    if (previousGroups.length > 0) {
+      await this.reportOutlierGroupModel.destroy({
+        where: { id: previousGroups.map((group) => group.id) },
+      })
     }
 
     // 5. If we were resolving postponement, transition POSTPONED → SUBMITTED.
@@ -647,7 +676,7 @@ export class ApplicationService implements IApplicationService {
       parsed: input.parsed,
       companies,
       outliersPostponed: input.outliersPostponed,
-      outliers: input.outliers,
+      outlierGroups: input.outlierGroups,
     }
   }
 
@@ -835,6 +864,19 @@ export class ApplicationService implements IApplicationService {
                 required: false,
               },
             ],
+          },
+          {
+            model: ReportOutlierGroupModel,
+            as: 'group',
+            attributes: [
+              'id',
+              'name',
+              'reason',
+              'action',
+              'signatureName',
+              'signatureRole',
+            ],
+            required: true,
           },
         ],
         order: [

--- a/apps/directorate-of-equality-api/src/modules/application/dto/edit-outliers.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/edit-outliers.dto.ts
@@ -1,18 +1,25 @@
-import { ArrayMinSize } from 'class-validator'
+import { ArrayMinSize, IsInt } from 'class-validator'
 
-import { ApiDtoArray, ApiNumber, ApiString } from '@dmr.is/decorators'
+import {
+  ApiArray,
+  ApiDtoArray,
+  ApiOptionalString,
+  ApiString,
+} from '@dmr.is/decorators'
 
 /**
- * One row per outlier in the edit payload. The applicant supplies all four
- * explanation fields; non-empty strings are required (the service enforces
- * the required-after-resolve invariant before persisting).
+ * One outlier group in the edit payload. The applicant supplies the shared
+ * explanation (all four fields, non-empty) plus the ordinals of the detected
+ * outliers this group covers. Across the whole payload every detected outlier
+ * must be covered by exactly one group (the service enforces the set-match and
+ * no-ordinal-in-two-groups invariants before persisting).
  */
-export class EditOutlierDto {
-  @ApiNumber({
+export class EditOutlierGroupDto {
+  @ApiOptionalString({
     description:
-      "Ordinal of the outlier employee within the parent report's parsed payload (1-indexed, matches the `report_employee.ordinal` snapshot). Resolved against the canonical detected set from `report_result.outlier_analysis_snapshot`.",
+      'Applicant-supplied label for the group. Not required to be unique. When omitted (the implicit single-group case) the server assigns a default name.',
   })
-  employeeOrdinal!: number
+  name?: string
 
   @ApiString({ minLength: 1 })
   reason!: string
@@ -25,23 +32,34 @@ export class EditOutlierDto {
 
   @ApiString({ minLength: 1 })
   signatureRole!: string
+
+  @ApiArray({
+    type: [Number],
+    description:
+      "Ordinals of the outlier employees in this group (1-indexed, matches the `report_employee.ordinal` snapshot). Resolved against the canonical detected set from `report_result.outlier_analysis_snapshot`.",
+  })
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  employeeOrdinals!: number[]
 }
 
 /**
  * Body for `PUT /api/v1/application/reports/:providerId/outliers`.
  *
- * All-or-none. The submitted set must match the canonical detected outlier
- * set (one row per detected outlier, no extras, no missing). When the report
- * is in status `POSTPONED`, a successful edit transitions it to `SUBMITTED`
- * and emits both an `EDITED` event and a `STATUS_CHANGED (POSTPONED →
- * SUBMITTED)` event. When the report is in status `IN_REVIEW` (correction
- * path), status is preserved and only an `EDITED` event is emitted.
+ * Group-based all-or-none. The union of `employeeOrdinals` across all groups
+ * must match the canonical detected outlier set exactly (every detected
+ * ordinal covered once, no extras, no missing, no ordinal in two groups).
+ * The edit replaces the report's grouping wholesale. When the report is in
+ * status `POSTPONED`, a successful edit transitions it to `SUBMITTED` and emits
+ * both an `EDITED` event and a `STATUS_CHANGED (POSTPONED → SUBMITTED)` event.
+ * When the report is in status `IN_REVIEW` (correction path), status is
+ * preserved and only an `EDITED` event is emitted.
  */
 export class EditOutliersDto {
-  @ApiDtoArray(EditOutlierDto, {
+  @ApiDtoArray(EditOutlierGroupDto, {
     description:
-      'One row per outlier on the report. Must include every detected outlier and nothing else.',
+      'Outlier groups for the report. The union of their employee ordinals must cover every detected outlier exactly once.',
   })
   @ArrayMinSize(1)
-  outliers!: EditOutlierDto[]
+  groups!: EditOutlierGroupDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/application/dto/submit-salary-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/submit-salary-report.dto.ts
@@ -10,7 +10,7 @@ import {
 } from '@dmr.is/decorators'
 
 import { GenderEnum } from '../../report/models/report.enums'
-import { CreateReportOutlierDto } from '../../report-create/dto/create-report.dto'
+import { CreateReportOutlierGroupDto } from '../../report-create/dto/create-report.dto'
 import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
 import {
   SubmitReportCompanyDto,
@@ -78,6 +78,6 @@ export class SubmitSalaryReportDto {
   })
   outliersPostponed?: boolean
 
-  @ApiOptionalDtoArray(CreateReportOutlierDto)
-  outliers?: CreateReportOutlierDto[]
+  @ApiOptionalDtoArray(CreateReportOutlierGroupDto)
+  outlierGroups?: CreateReportOutlierGroupDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/report-create/dto/create-report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/dto/create-report.dto.ts
@@ -1,6 +1,7 @@
-import { ArrayMinSize } from 'class-validator'
+import { ArrayMinSize, IsInt } from 'class-validator'
 
 import {
+  ApiArray,
   ApiBoolean,
   ApiDto,
   ApiDtoArray,
@@ -21,46 +22,47 @@ import {
 import { ParsedReportDto } from '../../report-excel/dto/parsed-report.dto'
 
 /**
- * One row per employee flagged as a salary outlier. Populated by the company
- * after the salary-analysis preview step (see `db/README.md` Notes / open
- * questions). Persisted into `report_employee_outlier`.
+ * One outlier group the company defined after the salary-analysis preview step
+ * (see `db/README.md` Notes / open questions). Persisted into
+ * `report_outlier_group`, with one `report_employee_outlier` row per covered
+ * employee pointing at it.
  *
- * Postponement is an all-or-none property of the parent report — see
- * `CreateReportDto.outliersPostponed`. When the parent is postponed, this
- * row's explanation fields are ignored and persisted as NULL. When the parent
- * is not postponed, all four explanation fields are required (validated
- * server-side and at the DB CHECK constraint).
+ * Only used when the parent report is NOT postponed — see
+ * `CreateReportDto.outliersPostponed`. The applicant supplies the shared
+ * explanation (all four fields required, non-empty) plus the ordinals of the
+ * detected outliers this group covers. Across all groups every detected
+ * outlier must be covered by exactly one group (validated server-side). When
+ * the parent is postponed, no groups are created — the outlier rows are
+ * written with `group_id = NULL` and resolved later via the outliers edit
+ * endpoint.
  */
-export class CreateReportOutlierDto {
-  @ApiNumber({
-    description:
-      'Ordinal of the employee in `parsed.employees[]` this outlier justification applies to.',
-  })
-  employeeOrdinal!: number
-
+export class CreateReportOutlierGroupDto {
   @ApiOptionalString({
     description:
-      'Required when the parent report is not postponed; ignored when it is.',
+      'Applicant-supplied label for the group. Not required to be unique. When omitted (the implicit single-group case) the server assigns a default name.',
   })
-  reason?: string
+  name?: string
 
-  @ApiOptionalString({
-    description:
-      'Required when the parent report is not postponed; ignored when it is.',
-  })
-  action?: string
+  @ApiString({ minLength: 1 })
+  reason!: string
 
-  @ApiOptionalString({
-    description:
-      'Required when the parent report is not postponed; ignored when it is.',
-  })
-  signatureName?: string
+  @ApiString({ minLength: 1 })
+  action!: string
 
-  @ApiOptionalString({
+  @ApiString({ minLength: 1 })
+  signatureName!: string
+
+  @ApiString({ minLength: 1 })
+  signatureRole!: string
+
+  @ApiArray({
+    type: [Number],
     description:
-      'Required when the parent report is not postponed; ignored when it is.',
+      'Ordinals of the employees in `parsed.employees[]` this group covers.',
   })
-  signatureRole?: string
+  @ArrayMinSize(1)
+  @IsInt({ each: true })
+  employeeOrdinals!: number[]
 }
 
 export class CreateReportCompanySnapshotDto {
@@ -161,9 +163,10 @@ export class CreateReportDto {
 
   /**
    * All-or-none. When true, the company is acknowledging every detected
-   * outlier but deferring the explanations — explanation fields on each
-   * `outliers[]` row are ignored and persisted as NULL. When false (default)
-   * each `outliers[]` row must carry all four explanation fields.
+   * outlier but deferring the explanations — `outlierGroups` is ignored and no
+   * groups are created. The outlier rows are written with `group_id = NULL`
+   * and resolved later via the outliers edit endpoint. When false (default),
+   * `outlierGroups` must cover every detected outlier exactly once.
    */
   @ApiOptionalBoolean({
     description:
@@ -172,10 +175,12 @@ export class CreateReportDto {
   outliersPostponed?: boolean
 
   /**
-   * Salary outliers the company has justified. Optional — empty/undefined is
-   * fine when no outliers were flagged. Each entry references its employee
-   * by `ordinal` from `parsed.employees[]`.
+   * Outlier groups the company has defined. Required (non-empty) when the
+   * report has detected outliers and is not postponed: the union of each
+   * group's `employeeOrdinals` must cover every detected outlier exactly once.
+   * Ignored when `outliersPostponed` is true. Omit when no outliers were
+   * detected.
    */
-  @ApiOptionalDtoArray(CreateReportOutlierDto)
-  outliers?: CreateReportOutlierDto[]
+  @ApiOptionalDtoArray(CreateReportOutlierGroupDto)
+  outlierGroups?: CreateReportOutlierGroupDto[]
 }

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.core.module.ts
@@ -14,6 +14,7 @@ import { ReportEmployeeOutlierModel } from '../report-employee/models/report-emp
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportResultCoreModule } from '../report-result/report-result.core.module'
 import { ReportCreateService } from './report-create.service'
 import { IReportCreateService } from './report-create.service.interface'
@@ -28,6 +29,7 @@ import { IReportCreateService } from './report-create.service.interface'
       ReportEmployeeRoleModel,
       ReportEmployeeModel,
       ReportEmployeeOutlierModel,
+      ReportOutlierGroupModel,
       ReportEmployeeRoleCriterionStepModel,
       ReportEmployeePersonalCriterionStepModel,
       ReportCriterionModel,

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -8,6 +8,7 @@ import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { DEFAULT_OUTLIER_GROUP_NAME } from '../../core/constants'
 import { CompanySizeEnum } from '../company/models/company.enums'
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
@@ -30,6 +31,7 @@ import { ReportEmployeeOutlierModel } from '../report-employee/models/report-emp
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { IReportResultService } from '../report-result/report-result.service.interface'
 import { CreateEqualityReportDto } from './dto/create-equality-report.dto'
 import { CreateReportDto } from './dto/create-report.dto'
@@ -64,6 +66,7 @@ describe('ReportCreateService', () => {
   let roleStepBulkCreate: jest.Mock
   let personalStepBulkCreate: jest.Mock
   let outlierBulkCreate: jest.Mock
+  let outlierGroupCreate: jest.Mock
   let criterionCreate: jest.Mock
   let subCriterionCreate: jest.Mock
   let subCriterionStepBulkCreate: jest.Mock
@@ -103,6 +106,11 @@ describe('ReportCreateService', () => {
     outlierBulkCreate = jest.fn(async (rows) =>
       rows.map((r: object, i: number) => ({ ...r, id: `dev-${i}` })),
     )
+    let groupSeq = 0
+    outlierGroupCreate = jest.fn(async (row) => ({
+      ...row,
+      id: `group-${groupSeq++}`,
+    }))
     criterionCreate = jest.fn(async (input) => ({
       ...input,
       id: `cri-${Date.now()}-${Math.random()}`,
@@ -176,6 +184,10 @@ describe('ReportCreateService', () => {
         {
           provide: getModelToken(ReportEmployeeOutlierModel),
           useValue: { bulkCreate: outlierBulkCreate },
+        },
+        {
+          provide: getModelToken(ReportOutlierGroupModel),
+          useValue: { create: outlierGroupCreate },
         },
         {
           provide: getModelToken(ReportCriterionModel),
@@ -361,22 +373,24 @@ describe('ReportCreateService', () => {
 
   it('skips the outlier insert when none are flagged', async () => {
     const input = makeInput()
-    input.outliers = []
+    input.outlierGroups = []
 
     await service.createSalary(input)
 
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
     expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
-  it('persists outliers resolving employeeOrdinal to the new employee id', async () => {
+  it('persists a group + outlier rows resolving employeeOrdinal to the new employee id', async () => {
     const input = makeInputWithDetectedOutlier()
-    input.outliers = [
+    input.outlierGroups = [
       {
-        employeeOrdinal: 1,
+        name: 'Parental leave',
         reason: 'On parental leave for 6 months',
         action: 'No adjustment, salary frozen for the period',
         signatureName: 'Anna Admin',
         signatureRole: 'HR Manager',
+        employeeOrdinals: [1],
       },
     ]
 
@@ -388,108 +402,135 @@ describe('ReportCreateService', () => {
     expect(reportCreate.mock.calls[0][0]).not.toHaveProperty(
       'outliersPostponed',
     )
-    expect(outlierBulkCreate).toHaveBeenCalledTimes(1)
-    expect(outlierBulkCreate.mock.calls[0][0]).toEqual([
+
+    // One group row carrying the explanation...
+    expect(outlierGroupCreate).toHaveBeenCalledTimes(1)
+    expect(outlierGroupCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        reportEmployeeId: 'emp-0',
+        reportId: REPORT_ID,
+        name: 'Parental leave',
         reason: 'On parental leave for 6 months',
         action: 'No adjustment, salary frozen for the period',
         signatureName: 'Anna Admin',
         signatureRole: 'HR Manager',
       }),
-    ])
-    expect(outlierBulkCreate.mock.calls[0][0][0]).not.toHaveProperty(
-      'postponed',
     )
+
+    // ...and one thin outlier row pointing at that group.
+    expect(outlierBulkCreate).toHaveBeenCalledTimes(1)
+    expect(outlierBulkCreate.mock.calls[0][0]).toEqual([
+      { reportEmployeeId: 'emp-0', groupId: 'group-0' },
+    ])
   })
 
-  it('rejects outliers referencing an unknown employee ordinal', async () => {
-    const input = makeInput()
-    input.outliers = [
+  it('defaults the group name when none is supplied', async () => {
+    const input = makeInputWithDetectedOutlier()
+    input.outlierGroups = [
       {
-        employeeOrdinal: 999,
         reason: 'r',
         action: 'a',
         signatureName: 'n',
         signatureRole: 'role',
+        employeeOrdinals: [1],
       },
     ]
 
-    await expect(service.createSalary(input)).rejects.toThrow(
-      BadRequestException,
+    await service.createSalary(input)
+
+    expect(outlierGroupCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: DEFAULT_OUTLIER_GROUP_NAME }),
     )
-    expect(reportCreate).not.toHaveBeenCalled()
-    expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
-  it('rejects an outlier row submitted for a non-outlier employee (extras)', async () => {
-    // The single-employee fixture has no detected outliers — submitting one
-    // row should be rejected as an extra by the submit-side guard.
+  it('rejects a group referencing a non-outlier employee ordinal (extras)', async () => {
+    // The single-employee fixture has no detected outliers — referencing one
+    // should be rejected as an extra by the submit-side guard.
     const input = makeInput()
-    input.outliers = [
+    input.outlierGroups = [
       {
-        employeeOrdinal: 1,
         reason: 'r',
         action: 'a',
         signatureName: 'n',
         signatureRole: 'role',
+        employeeOrdinals: [1],
       },
     ]
 
     await expect(service.createSalary(input)).rejects.toThrow(
       /non-outlier employee ordinal/,
     )
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
     expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
-  it('rejects when a detected outlier has no acknowledgement row (missing)', async () => {
+  it('rejects when detected outliers are present but no groups are provided', async () => {
     const input = makeInputWithDetectedOutlier()
-    input.outliers = []
+    input.outlierGroups = []
 
     await expect(service.createSalary(input)).rejects.toThrow(
-      /missing acknowledgement/,
+      /no outlier groups were provided/,
     )
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
+    expect(outlierBulkCreate).not.toHaveBeenCalled()
+  })
+
+  it('rejects an ordinal that appears in more than one group', async () => {
+    const input = makeInputWithDetectedOutlier()
+    input.outlierGroups = [
+      {
+        reason: 'r',
+        action: 'a',
+        signatureName: 'n',
+        signatureRole: 'role',
+        employeeOrdinals: [1],
+      },
+      {
+        reason: 'r2',
+        action: 'a2',
+        signatureName: 'n2',
+        signatureRole: 'role2',
+        employeeOrdinals: [1],
+      },
+    ]
+
+    await expect(service.createSalary(input)).rejects.toThrow(
+      /appears in more than one outlier group/,
+    )
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
     expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
   it('rejects postponement when the salary report has no detected outliers', async () => {
     const input = makeInput()
     input.outliersPostponed = true
-    input.outliers = []
+    input.outlierGroups = []
 
     await expect(service.createSalary(input)).rejects.toThrow(
       'Cannot postpone outlier explanations because this salary report has no detected outliers.',
     )
     expect(reportCreate).not.toHaveBeenCalled()
-    expect(outlierBulkCreate).not.toHaveBeenCalled()
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
   })
 
   it('submits a zero-outlier salary report normally when postponement is not requested', async () => {
     const input = makeInput()
     input.outliersPostponed = false
-    input.outliers = []
+    input.outlierGroups = []
 
     await service.createSalary(input)
 
     expect(reportCreate).toHaveBeenCalledWith(
       expect.objectContaining({ status: ReportStatusEnum.SUBMITTED }),
     )
+    expect(outlierGroupCreate).not.toHaveBeenCalled()
     expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
-  it('persists every outlier with NULL explanation columns when the report is postponed', async () => {
+  it('creates a single default group with NULL explanation when postponed', async () => {
     const input = makeInputWithDetectedOutlier()
     input.outliersPostponed = true
-    input.outliers = [
-      {
-        employeeOrdinal: 1,
-        // Explanation fields supplied here are ignored when the report is postponed.
-        reason: 'should be discarded',
-        action: 'should be discarded',
-        signatureName: 'should be discarded',
-        signatureRole: 'should be discarded',
-      },
-    ]
+    // Any supplied groups are ignored on the postpone path.
+    input.outlierGroups = undefined
 
     await service.createSalary(input)
 
@@ -499,14 +540,23 @@ describe('ReportCreateService', () => {
     expect(reportCreate.mock.calls[0][0]).not.toHaveProperty(
       'outliersPostponed',
     )
-    expect(outlierBulkCreate).toHaveBeenCalledWith([
+
+    // Single default group with all explanation fields NULL...
+    expect(outlierGroupCreate).toHaveBeenCalledTimes(1)
+    expect(outlierGroupCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        reportEmployeeId: 'emp-0',
+        reportId: REPORT_ID,
+        name: DEFAULT_OUTLIER_GROUP_NAME,
         reason: null,
         action: null,
         signatureName: null,
         signatureRole: null,
       }),
+    )
+
+    // ...covering the detected outlier via a thin row.
+    expect(outlierBulkCreate).toHaveBeenCalledWith([
+      { reportEmployeeId: 'emp-0', groupId: 'group-0' },
     ])
 
     // The SUBMITTED audit event snapshots the actual landing status —
@@ -519,42 +569,6 @@ describe('ReportCreateService', () => {
         reportStatus: ReportStatusEnum.POSTPONED,
       }),
     )
-  })
-
-  it('accepts a postponed report with bare acknowledgement rows (no explanations supplied)', async () => {
-    const input = makeInputWithDetectedOutlier()
-    input.outliersPostponed = true
-    input.outliers = [{ employeeOrdinal: 1 }]
-
-    await service.createSalary(input)
-
-    expect(outlierBulkCreate).toHaveBeenCalledWith([
-      expect.objectContaining({
-        reportEmployeeId: 'emp-0',
-        reason: null,
-        action: null,
-        signatureName: null,
-        signatureRole: null,
-      }),
-    ])
-  })
-
-  it('rejects a non-postponed outlier with missing explanation fields', async () => {
-    const input = makeInputWithDetectedOutlier()
-    input.outliers = [
-      {
-        employeeOrdinal: 1,
-        reason: '',
-        action: 'something',
-        signatureName: 'somebody',
-        signatureRole: '',
-      },
-    ]
-
-    await expect(service.createSalary(input)).rejects.toThrow(
-      /Outlier for employee ordinal .* missing required field\(s\): reason, signatureRole/,
-    )
-    expect(outlierBulkCreate).not.toHaveBeenCalled()
   })
 
   // ── createEquality path ────────────────────────────────────────────

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -12,6 +12,7 @@ import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { DEFAULT_OUTLIER_GROUP_NAME } from '../../core/constants'
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
@@ -39,6 +40,7 @@ import { ReportEmployeeOutlierModel } from '../report-employee/models/report-emp
 import { ReportEmployeePersonalCriterionStepModel } from '../report-employee/models/report-employee-personal-criterion-step.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
 import { ReportEmployeeRoleCriterionStepModel } from '../report-employee/models/report-employee-role-criterion-step.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ParsedStepAssignmentDto } from '../report-excel/dto/parsed-report.dto'
 import { IReportResultService } from '../report-result/report-result.service.interface'
 import { CreateEqualityReportDto } from './dto/create-equality-report.dto'
@@ -73,6 +75,8 @@ export class ReportCreateService implements IReportCreateService {
     private readonly personalStepModel: typeof ReportEmployeePersonalCriterionStepModel,
     @InjectModel(ReportEmployeeOutlierModel)
     private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
+    @InjectModel(ReportOutlierGroupModel)
+    private readonly reportOutlierGroupModel: typeof ReportOutlierGroupModel,
     @InjectModel(ReportCriterionModel)
     private readonly reportCriterionModel: typeof ReportCriterionModel,
     @InjectModel(ReportSubCriterionModel)
@@ -114,8 +118,11 @@ export class ReportCreateService implements IReportCreateService {
 
     const stepScoreByKey = assertParsedPayloadIntegrity(input.parsed)
     const employeeScores = computeEmployeeScores(input.parsed, stepScoreByKey)
-    this.assertOutliersReferenceParsedEmployees(input)
-    await this.assertOutliersMatchDetectedOutliers(input, employeeScores)
+    const detectedOrdinals = await this.computeDetectedOutlierOrdinals(
+      input,
+      employeeScores,
+    )
+    this.assertOutlierGroupsMatchDetected(input, detectedOrdinals)
 
     await this.assertEqualityReportApproved(input.equalityReportId)
 
@@ -256,33 +263,57 @@ export class ReportCreateService implements IReportCreateService {
       await this.personalStepModel.bulkCreate(personalStepRows)
     }
 
-    // 8. Salary outliers — only employees the company flagged
-    //    via the outlier-preview flow get a row here. When the report is
-    //    postponed (status = POSTPONED), every row's explanation columns
-    //    are written as NULL; the applicant fills them in later via
-    //    PUT /application/reports/:providerId/outliers.
-    if (input.outliers && input.outliers.length > 0) {
+    // 8. Outlier groups + outlier rows. Every detected outlier belongs to
+    //    exactly one group (group_id NOT NULL):
+    //      - postponed → one default group with a NULL explanation covering
+    //        every detected outlier; the applicant fills it in (or splits it)
+    //        later via PUT /application/reports/:providerId/outliers.
+    //      - not postponed → the groups the company defined; the union of
+    //        their ordinals covers the detected set exactly (validated above).
+    if (detectedOrdinals.length > 0) {
       const employeeOrdinalToId = new Map<number, string>()
       input.parsed.employees.forEach((employee, index) => {
         employeeOrdinalToId.set(employee.ordinal, employeeRows[index].id)
       })
 
-      await this.reportEmployeeOutlierModel.bulkCreate(
-        input.outliers.map((outlier) => ({
-          // Pre-flight already verified every ordinal resolves.
-          reportEmployeeId: employeeOrdinalToId.get(
-            outlier.employeeOrdinal,
-          ) as string,
-          reason: outliersPostponed ? null : (outlier.reason ?? null),
-          action: outliersPostponed ? null : (outlier.action ?? null),
-          signatureName: outliersPostponed
-            ? null
-            : (outlier.signatureName ?? null),
-          signatureRole: outliersPostponed
-            ? null
-            : (outlier.signatureRole ?? null),
-        })),
-      )
+      const groupsToCreate = outliersPostponed
+        ? [
+            {
+              name: DEFAULT_OUTLIER_GROUP_NAME,
+              reason: null,
+              action: null,
+              signatureName: null,
+              signatureRole: null,
+              employeeOrdinals: detectedOrdinals,
+            },
+          ]
+        : (input.outlierGroups ?? []).map((group) => ({
+            name: group.name?.trim() || DEFAULT_OUTLIER_GROUP_NAME,
+            reason: group.reason,
+            action: group.action,
+            signatureName: group.signatureName,
+            signatureRole: group.signatureRole,
+            employeeOrdinals: group.employeeOrdinals,
+          }))
+
+      for (const group of groupsToCreate) {
+        const groupRow = await this.reportOutlierGroupModel.create({
+          reportId: report.id,
+          name: group.name,
+          reason: group.reason,
+          action: group.action,
+          signatureName: group.signatureName,
+          signatureRole: group.signatureRole,
+        })
+
+        await this.reportEmployeeOutlierModel.bulkCreate(
+          group.employeeOrdinals.map((ordinal: number) => ({
+            // Validation above guarantees every ordinal resolves.
+            reportEmployeeId: employeeOrdinalToId.get(ordinal) as string,
+            groupId: groupRow.id,
+          })),
+        )
+      }
     }
 
     // 9. Persisted snapshot — reviewers need the computed aggregates available
@@ -589,47 +620,17 @@ export class ReportCreateService implements IReportCreateService {
     )
   }
 
-/**
-   * Each `outliers[].employeeOrdinal` must match an `ordinal` in the parsed
-   * employees array. The submit-side guard below verifies the submitted set
-   * against the canonical regression-based detection result.
-   */
-  private assertOutliersReferenceParsedEmployees(input: CreateReportDto) {
-    if (!input.outliers || input.outliers.length === 0) {
-      return
-    }
-    const knownOrdinals = new Set(input.parsed.employees.map((e) => e.ordinal))
-    for (const outlier of input.outliers) {
-      if (!knownOrdinals.has(outlier.employeeOrdinal)) {
-        throw new BadRequestException(
-          `Outlier references unknown employee ordinal ${outlier.employeeOrdinal}`,
-        )
-      }
-    }
-  }
-
   /**
-   * Submit-side outlier guard. Recomputes the canonical outlier set with
-   * `detectOutliers` (same helper the application-side preview uses) and
-   * asserts:
-   *
-   * - Every detected outlier has an `outliers[]` row. Missing rows reject —
-   *   postponement is acknowledgement-with-deferred-explanation, not skip-
-   *   the-row.
-   * - Every `outliers[]` row references a detected outlier. Extras reject.
-   * - When `outliersPostponed` is false, every row has all four explanation
-   *   columns filled. When true, explanation fields are ignored.
-   *
-   * Threshold is re-read from `config` here, so a tiny drift between preview
-   * and submit is possible — rejection in that case just means "re-run
-   * preview".
+   * Recompute the canonical detected outlier set with `detectOutliers` (the
+   * same helper the application-side preview uses) and return the detected
+   * ordinals. Threshold is re-read from `config` here, so a tiny drift between
+   * preview and submit is possible — a downstream rejection in that case just
+   * means "re-run preview".
    */
-  private async assertOutliersMatchDetectedOutliers(
+  private async computeDetectedOutlierOrdinals(
     input: CreateReportDto,
     employeeScores: number[],
-  ) {
-    const submittedOutliers = input.outliers ?? []
-    const outliersPostponed = input.outliersPostponed ?? false
+  ): Promise<number[]> {
     const thresholdPercent = await this.getSalaryDifferenceThresholdPercent()
 
     const detected = detectOutliers({
@@ -643,52 +644,70 @@ export class ReportCreateService implements IReportCreateService {
       thresholdPercent,
     })
 
-    const detectedOrdinals = new Set(detected.map((d) => d.ordinal))
-    const submittedOrdinals = new Set(
-      submittedOutliers.map((o) => o.employeeOrdinal),
-    )
+    return detected.map((d) => d.ordinal)
+  }
 
-    if (outliersPostponed && detectedOrdinals.size === 0) {
-      throw new BadRequestException(
-        'Cannot postpone outlier explanations because this salary report has no detected outliers.',
-      )
-    }
-
-    const extras = [...submittedOrdinals].filter(
-      (ordinal) => !detectedOrdinals.has(ordinal),
-    )
-    if (extras.length > 0) {
-      throw new BadRequestException(
-        `Outlier row(s) submitted for non-outlier employee ordinal(s): ${extras.join(', ')}`,
-      )
-    }
-
-    const missing = [...detectedOrdinals].filter(
-      (ordinal) => !submittedOrdinals.has(ordinal),
-    )
-    if (missing.length > 0) {
-      throw new BadRequestException(
-        `Detected outlier(s) missing acknowledgement for employee ordinal(s): ${missing.join(', ')}`,
-      )
-    }
+  /**
+   * Submit-side outlier-group guard, given the canonical detected ordinals:
+   *
+   * - Postponed: there must be at least one detected outlier (can't postpone
+   *   nothing). `outlierGroups` is ignored — a single default group with a NULL
+   *   explanation is created at persist time.
+   * - Not postponed: the union of every group's `employeeOrdinals` must cover
+   *   the detected set exactly — no extras, no missing, and no ordinal in two
+   *   groups. Explanation completeness (all four fields non-empty) is enforced
+   *   by the DTO.
+   */
+  private assertOutlierGroupsMatchDetected(
+    input: CreateReportDto,
+    detectedOrdinals: number[],
+  ) {
+    const outliersPostponed = input.outliersPostponed ?? false
+    const detectedSet = new Set(detectedOrdinals)
 
     if (outliersPostponed) {
+      if (detectedSet.size === 0) {
+        throw new BadRequestException(
+          'Cannot postpone outlier explanations because this salary report has no detected outliers.',
+        )
+      }
       return
     }
 
-    for (const outlier of submittedOutliers) {
-      const missingFields = [
-        ['reason', outlier.reason],
-        ['action', outlier.action],
-        ['signatureName', outlier.signatureName],
-        ['signatureRole', outlier.signatureRole],
-      ].filter(([, value]) => !value || (value as string).length === 0)
+    const groups = input.outlierGroups ?? []
 
-      if (missingFields.length > 0) {
-        throw new BadRequestException(
-          `Outlier for employee ordinal ${outlier.employeeOrdinal} is missing required field(s): ${missingFields.map(([name]) => name).join(', ')}`,
-        )
+    if (detectedSet.size > 0 && groups.length === 0) {
+      throw new BadRequestException(
+        'This salary report has detected outliers but no outlier groups were provided.',
+      )
+    }
+
+    // Union of ordinals across all groups, rejecting any ordinal that appears
+    // in more than one group (an outlier belongs to exactly one group).
+    const submittedOrdinals = new Set<number>()
+    for (const group of groups) {
+      for (const ordinal of group.employeeOrdinals) {
+        if (submittedOrdinals.has(ordinal)) {
+          throw new BadRequestException(
+            `Employee ordinal ${ordinal} appears in more than one outlier group`,
+          )
+        }
+        submittedOrdinals.add(ordinal)
       }
+    }
+
+    const extras = [...submittedOrdinals].filter((o) => !detectedSet.has(o))
+    if (extras.length > 0) {
+      throw new BadRequestException(
+        `Outlier group(s) reference non-outlier employee ordinal(s): ${extras.join(', ')}`,
+      )
+    }
+
+    const missing = [...detectedSet].filter((o) => !submittedOrdinals.has(o))
+    if (missing.length > 0) {
+      throw new BadRequestException(
+        `Detected outlier(s) missing from the outlier groups for employee ordinal(s): ${missing.join(', ')}`,
+      )
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-employee-outlier.dto.ts
@@ -30,10 +30,23 @@ export class ReportEmployeeOutlierDto {
   @ApiOptionalNumber({ nullable: true })
   score!: number | null
 
+  @ApiUUId({
+    description:
+      'Id of the outlier group this outlier belongs to. Every outlier always belongs to exactly one group.',
+  })
+  groupId!: string
+
   @ApiOptionalString({
     nullable: true,
     description:
-      'Null only when the parent report has `status = POSTPONED`. Otherwise required and non-empty.',
+      'Name of the outlier group this outlier belongs to. Denormalized from the group for convenient client-side grouping/labeling.',
+  })
+  groupName!: string | null
+
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      'Explanation shared by the group. Denormalized from the outlier group — every outlier in the same group carries the same value. Null only while the parent report has `status = POSTPONED`.',
   })
   reason!: string | null
 

--- a/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-outlier-group.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/dto/report-outlier-group.dto.ts
@@ -1,0 +1,39 @@
+import { ApiOptionalString, ApiString, ApiUUId } from '@dmr.is/decorators'
+
+/**
+ * An outlier group owns the improvement-plan explanation shared by every
+ * detected outlier assigned to it. A salary report can have multiple groups;
+ * each detected outlier belongs to exactly one. Every report with detected
+ * outliers has at least one group — when the report is postponed a single
+ * default group exists with NULL explanation fields until the applicant
+ * resolves it.
+ */
+export class ReportOutlierGroupDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiUUId()
+  reportId!: string
+
+  @ApiString({
+    description:
+      'Applicant-supplied label for the group. Non-empty. The implicit single group created when no grouping is provided uses a default name.',
+  })
+  name!: string
+
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      'Null only while the parent report is postponed (explanation not yet filled). Otherwise non-empty.',
+  })
+  reason!: string | null
+
+  @ApiOptionalString({ nullable: true })
+  action!: string | null
+
+  @ApiOptionalString({ nullable: true })
+  signatureName!: string | null
+
+  @ApiOptionalString({ nullable: true })
+  signatureRole!: string | null
+}

--- a/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/models/report-employee-outlier.model.ts
@@ -5,6 +5,7 @@ import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 import { DoeModels } from '../../../core/constants'
 import type { ReportEmployeeOutlierDto } from '../dto/report-employee-outlier.dto'
 import { ReportEmployeeModel } from './report-employee.model'
+import { ReportOutlierGroupModel } from './report-outlier-group.model'
 
 /**
  * Shape of the per-employee entry on the canonical outlier analysis. Defined
@@ -26,18 +27,12 @@ export type OutlierAnalysisEntry = {
 
 type ReportEmployeeOutlierAttributes = {
   reportEmployeeId: string
-  reason: string | null
-  action: string | null
-  signatureName: string | null
-  signatureRole: string | null
+  groupId: string
 }
 
 type ReportEmployeeOutlierCreateAttributes = {
   reportEmployeeId: string
-  reason?: string | null
-  action?: string | null
-  signatureName?: string | null
-  signatureRole?: string | null
+  groupId: string
 }
 
 @MutableTable({ tableName: DoeModels.REPORT_EMPLOYEE_OUTLIER })
@@ -53,17 +48,12 @@ export class ReportEmployeeOutlierModel extends MutableModel<
   })
   reportEmployeeId!: string
 
-  @Column({ type: DataType.TEXT, allowNull: true })
-  reason!: string | null
-
-  @Column({ type: DataType.TEXT, allowNull: true })
-  action!: string | null
-
-  @Column({ type: DataType.TEXT, allowNull: true, field: 'signature_name' })
-  signatureName!: string | null
-
-  @Column({ type: DataType.TEXT, allowNull: true, field: 'signature_role' })
-  signatureRole!: string | null
+  // Every outlier always belongs to a group. When a report is submitted with
+  // outliers postponed the rows point at a single default group whose
+  // explanation fields are NULL until the applicant resolves them.
+  @ForeignKey(() => ReportOutlierGroupModel)
+  @Column({ type: DataType.UUID, allowNull: false, field: 'group_id' })
+  groupId!: string
 
   @BelongsTo(() => ReportEmployeeModel, {
     foreignKey: 'reportEmployeeId',
@@ -71,10 +61,21 @@ export class ReportEmployeeOutlierModel extends MutableModel<
   })
   reportEmployee?: ReportEmployeeModel
 
+  @BelongsTo(() => ReportOutlierGroupModel, {
+    foreignKey: 'groupId',
+    as: 'group',
+  })
+  group?: ReportOutlierGroupModel
+
   /**
-   * Project an outlier row to its DTO. The persisted row only carries the
-   * applicant's improvement-plan response (reason / action / signature). The
-   * analysis numbers (`adjustedBaseSalary`, regression prediction, score
+   * Project an outlier row to its DTO. The persisted row is a thin join
+   * `(report_employee_id, group_id)`. The improvement-plan explanation
+   * (reason / action / signature) lives on the joined group and is
+   * denormalized onto each outlier in the projection — pass the row with its
+   * `group` association loaded. While the report's outliers are still postponed
+   * the group exists but its explanation fields are null.
+   *
+   * The analysis numbers (`adjustedBaseSalary`, regression prediction, score
    * bucket, direction, etc.) live in `report_result.outlier_analysis_snapshot`
    * as the canonical "what the engine detected at submit time" — callers are
    * expected to look that up by the joined `reportEmployee.ordinal` and pass
@@ -92,10 +93,12 @@ export class ReportEmployeeOutlierModel extends MutableModel<
       gender: model.reportEmployee?.gender ?? null,
       roleTitle: model.reportEmployee?.role?.title ?? null,
       score: model.reportEmployee?.score ?? null,
-      reason: model.reason,
-      action: model.action,
-      signatureName: model.signatureName,
-      signatureRole: model.signatureRole,
+      groupId: model.groupId,
+      groupName: model.group?.name ?? null,
+      reason: model.group?.reason ?? null,
+      action: model.group?.action ?? null,
+      signatureName: model.group?.signatureName ?? null,
+      signatureRole: model.group?.signatureRole ?? null,
       adjustedBaseSalary: analysis?.adjustedBaseSalary ?? null,
       predictedBaseSalary: analysis?.predictedBaseSalary ?? null,
       scoreBucketRangeFrom: analysis?.scoreBucketRangeFrom ?? null,

--- a/apps/directorate-of-equality-api/src/modules/report-employee/models/report-outlier-group.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-employee/models/report-outlier-group.model.ts
@@ -1,0 +1,89 @@
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  ForeignKey,
+  HasMany,
+} from 'sequelize-typescript'
+
+import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
+
+import { DoeModels } from '../../../core/constants'
+import { ReportModel } from '../../report/models/report.model'
+import type { ReportOutlierGroupDto } from '../dto/report-outlier-group.dto'
+import { ReportEmployeeOutlierModel } from './report-employee-outlier.model'
+
+type ReportOutlierGroupAttributes = {
+  reportId: string
+  name: string
+  reason: string | null
+  action: string | null
+  signatureName: string | null
+  signatureRole: string | null
+}
+
+type ReportOutlierGroupCreateAttributes = {
+  reportId: string
+  name: string
+  reason?: string | null
+  action?: string | null
+  signatureName?: string | null
+  signatureRole?: string | null
+}
+
+/**
+ * Owns the improvement-plan explanation (reason / action / signature) shared by
+ * the detected outliers assigned to it. See `report-outlier-group.dto.ts` for
+ * the lifecycle. The four explanation columns are all-or-none (DB CHECK): all
+ * NULL while the report is postponed / not yet filled, or all non-empty once
+ * explained. `name` is always set.
+ */
+@MutableTable({ tableName: DoeModels.REPORT_OUTLIER_GROUP })
+export class ReportOutlierGroupModel extends MutableModel<
+  ReportOutlierGroupAttributes,
+  ReportOutlierGroupCreateAttributes
+> {
+  @ForeignKey(() => ReportModel)
+  @Column({ type: DataType.UUID, allowNull: false, field: 'report_id' })
+  reportId!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  name!: string
+
+  @Column({ type: DataType.TEXT, allowNull: true })
+  reason!: string | null
+
+  @Column({ type: DataType.TEXT, allowNull: true })
+  action!: string | null
+
+  @Column({ type: DataType.TEXT, allowNull: true, field: 'signature_name' })
+  signatureName!: string | null
+
+  @Column({ type: DataType.TEXT, allowNull: true, field: 'signature_role' })
+  signatureRole!: string | null
+
+  @BelongsTo(() => ReportModel, { foreignKey: 'reportId', as: 'report' })
+  report?: ReportModel
+
+  @HasMany(() => ReportEmployeeOutlierModel, {
+    foreignKey: 'groupId',
+    as: 'outliers',
+  })
+  outliers?: ReportEmployeeOutlierModel[]
+
+  static fromModel(model: ReportOutlierGroupModel): ReportOutlierGroupDto {
+    return {
+      id: model.id,
+      reportId: model.reportId,
+      name: model.name,
+      reason: model.reason,
+      action: model.action,
+      signatureName: model.signatureName,
+      signatureRole: model.signatureRole,
+    }
+  }
+
+  fromModel(): ReportOutlierGroupDto {
+    return ReportOutlierGroupModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
@@ -4,7 +4,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 import { ApplicationSystemCoreModule } from '../application-system/application-system.core.module'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportModel } from '../report/models/report.model'
-import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportEventCoreModule } from '../report-event/report-event.core.module'
 import { UserModel } from '../user/models/user.model'
 import { ReportWorkflowService } from './report-workflow.service'
@@ -16,7 +16,7 @@ import { IReportWorkflowService } from './report-workflow.service.interface'
       ReportModel,
       CompanyReportModel,
       UserModel,
-      ReportEmployeeOutlierModel,
+      ReportOutlierGroupModel,
     ]),
     ReportEventCoreModule,
     ApplicationSystemCoreModule,

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -49,7 +49,7 @@ describe('ReportWorkflowService', () => {
     findOne: jest.fn(),
   }
 
-  const reportEmployeeOutlierModel = {
+  const reportOutlierGroupModel = {
     findOne: jest.fn(),
   }
 
@@ -78,7 +78,7 @@ describe('ReportWorkflowService', () => {
       reportModel as never,
       companyReportModel as never,
       userModel as never,
-      reportEmployeeOutlierModel as never,
+      reportOutlierGroupModel as never,
     )
   })
 
@@ -448,7 +448,7 @@ describe('ReportWorkflowService', () => {
     })
 
     it('notifies the application system on approval of an island.is report', async () => {
-      reportEmployeeOutlierModel.findOne.mockResolvedValue(null)
+      reportOutlierGroupModel.findOne.mockResolvedValue(null)
       reportModel.update.mockResolvedValue([1])
       reportModel.findOne
         // supersede type lookup
@@ -484,9 +484,9 @@ describe('ReportWorkflowService', () => {
       ).rejects.toBeInstanceOf(ForbiddenException)
     })
 
-    it('rejects when any outlier row on the report still has null explanation fields', async () => {
-      reportEmployeeOutlierModel.findOne.mockResolvedValueOnce({
-        id: 'outlier-1',
+    it('rejects when any outlier group on the report still has a null explanation', async () => {
+      reportOutlierGroupModel.findOne.mockResolvedValueOnce({
+        id: 'group-1',
       })
 
       await expect(
@@ -498,8 +498,8 @@ describe('ReportWorkflowService', () => {
       expect(reportEventService.emitStatusChanged).not.toHaveBeenCalled()
     })
 
-    it('proceeds with approval when no outlier row has missing explanations (EQUALITY no-op or SALARY resolved)', async () => {
-      reportEmployeeOutlierModel.findOne.mockResolvedValueOnce(null)
+    it('proceeds with approval when no outlier group has a missing explanation (EQUALITY no-op or SALARY resolved)', async () => {
+      reportOutlierGroupModel.findOne.mockResolvedValueOnce(null)
       reportModel.update.mockResolvedValue([1])
       reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.EQUALITY })
       reportModel.findAll.mockResolvedValue([])
@@ -510,7 +510,7 @@ describe('ReportWorkflowService', () => {
       await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
 
       // Gate ran first, then the APPROVED update.
-      expect(reportEmployeeOutlierModel.findOne).toHaveBeenCalledTimes(1)
+      expect(reportOutlierGroupModel.findOne).toHaveBeenCalledTimes(1)
       expect(reportModel.update).toHaveBeenCalledWith(
         expect.objectContaining({ status: ReportStatusEnum.APPROVED }),
         { where: { id: 'report-1' } },

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -1,5 +1,3 @@
-import { Op } from 'sequelize'
-
 import {
   BadRequestException,
   ForbiddenException,
@@ -22,8 +20,7 @@ import {
   type ReportResourceContext,
   ReportRoleEnum,
 } from '../report/types/report-resource-context'
-import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
-import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { IReportEventService } from '../report-event/report-event.service.interface'
 import { UserModel } from '../user/models/user.model'
 import { AssignReportDto } from './dto/assign-report.dto'
@@ -46,8 +43,8 @@ export class ReportWorkflowService implements IReportWorkflowService {
     private readonly companyReportModel: typeof CompanyReportModel,
     @InjectModel(UserModel)
     private readonly userModel: typeof UserModel,
-    @InjectModel(ReportEmployeeOutlierModel)
-    private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
+    @InjectModel(ReportOutlierGroupModel)
+    private readonly reportOutlierGroupModel: typeof ReportOutlierGroupModel,
   ) {}
 
   async assign(
@@ -300,38 +297,23 @@ export class ReportWorkflowService implements IReportWorkflowService {
   }
 
   /**
-   * Belt-and-suspenders gate: a SALARY report whose outlier rows still carry
-   * null explanation fields (i.e. was submitted with `outliersPostponed = true`
-   * and the applicant has not resolved them via the outliers edit endpoint)
-   * cannot be approved. EQUALITY reports have no outlier rows, so the query
-   * is a cheap no-op for them.
+   * Belt-and-suspenders gate: a SALARY report with an outlier group whose
+   * explanation has not been filled in (i.e. was submitted with
+   * `outliersPostponed = true` and the applicant has not resolved it via the
+   * outliers edit endpoint) cannot be approved. EQUALITY reports have no
+   * outlier groups, so the query is a cheap no-op for them.
    *
-   * The submit-side guard already enforces "every detected outlier has a row"
-   * and the all-or-none invariant on rows themselves. This check enforces the
-   * additional lifecycle invariant: status can leave POSTPONED only after the
-   * resolve path has filled every row.
+   * The explanation lives on the outlier group, and the group's columns are
+   * all-or-none, so "unresolved" means a group with a null `reason` (postponed
+   * default group, not yet filled). This enforces the lifecycle invariant:
+   * status can leave POSTPONED only after every group has a complete
+   * explanation.
    */
   private async assertOutlierExplanationsResolved(
     reportId: string,
   ): Promise<void> {
-    const unresolved = await this.reportEmployeeOutlierModel.findOne({
-      include: [
-        {
-          model: ReportEmployeeModel,
-          as: 'reportEmployee',
-          where: { reportId },
-          required: true,
-          attributes: [],
-        },
-      ],
-      where: {
-        [Op.or]: [
-          { reason: null },
-          { action: null },
-          { signatureName: null },
-          { signatureRole: null },
-        ],
-      },
+    const unresolved = await this.reportOutlierGroupModel.findOne({
+      where: { reportId, reason: null },
       attributes: ['id'],
     })
 

--- a/apps/directorate-of-equality-api/src/modules/report/report.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.core.module.ts
@@ -4,6 +4,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportCommentModel } from '../report-comment/models/report-comment.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { ReportModel } from './models/report.model'
 import { ReportEventModel } from './models/report-event.model'
@@ -17,6 +18,7 @@ import { IReportService } from './report.service.interface'
       ReportEventModel,
       ReportRoleResultModel,
       ReportEmployeeOutlierModel,
+      ReportOutlierGroupModel,
       ReportCommentModel,
       CompanyReportModel,
     ]),

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -864,10 +864,15 @@ describe('ReportService.getOutliers', () => {
   ) => ({
     id: 'outlier-1',
     reportEmployeeId: 'employee-1',
-    reason: 'Tenure premium',
-    action: 'Reviewed',
-    signatureName: 'Reviewer',
-    signatureRole: 'HR',
+    groupId: 'group-1',
+    group: {
+      id: 'group-1',
+      name: 'Tenure',
+      reason: 'Tenure premium',
+      action: 'Reviewed',
+      signatureName: 'Reviewer',
+      signatureRole: 'HR',
+    },
     reportEmployee: {
       id: 'employee-1',
       ordinal: 1,
@@ -888,16 +893,19 @@ describe('ReportService.getOutliers', () => {
       const r = this as unknown as Record<string, unknown>
       const re = r.reportEmployee as Record<string, unknown> | undefined
       const role = re?.role as Record<string, unknown> | undefined
+      const group = r.group as Record<string, unknown> | undefined
       return {
         id: r.id,
         reportEmployeeId: r.reportEmployeeId,
         employeeOrdinal: re?.ordinal ?? null,
         gender: re?.gender ?? null,
         roleTitle: role?.title ?? null,
-        reason: r.reason,
-        action: r.action,
-        signatureName: r.signatureName,
-        signatureRole: r.signatureRole,
+        groupId: r.groupId,
+        groupName: group?.name ?? null,
+        reason: group?.reason ?? null,
+        action: group?.action ?? null,
+        signatureName: group?.signatureName ?? null,
+        signatureRole: group?.signatureRole ?? null,
         adjustedBaseSalary: analysis?.adjustedBaseSalary ?? null,
         predictedBaseSalary: analysis?.predictedBaseSalary ?? null,
         scoreBucketRangeFrom: analysis?.scoreBucketRangeFrom ?? null,
@@ -931,6 +939,8 @@ describe('ReportService.getOutliers', () => {
         employeeOrdinal: 1,
         roleTitle: 'Engineer',
         gender: 'FEMALE',
+        groupId: 'group-1',
+        groupName: 'Tenure',
         reason: 'Tenure premium',
         adjustedBaseSalary: 950000,
         predictedBaseSalary: 1000000,

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -33,6 +33,7 @@ import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-
 import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
 import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
 import { ReportEmployeeRoleModel } from '../report-employee/models/report-employee-role.model'
+import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportRoleResultModel } from '../report-result/models/report-role-result.model'
 import { UserModel } from '../user/models/user.model'
 import { EqualityReportDto } from './dto/equality-report.dto'
@@ -657,6 +658,19 @@ export class ReportService implements IReportService {
               required: false,
             },
           ],
+        },
+        {
+          model: ReportOutlierGroupModel,
+          as: 'group',
+          attributes: [
+            'id',
+            'name',
+            'reason',
+            'action',
+            'signatureName',
+            'signatureRole',
+          ],
+          required: true,
         },
       ],
       order: this.buildOutlierOrder(query),

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -452,6 +452,361 @@
         "tags": ["Companies"]
       }
     },
+    "/api/v1/companies/{id}/status": {
+      "patch": {
+        "operationId": "updateCompanyStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCompanyStatusDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/timeline": {
+      "get": {
+        "operationId": "getCompanyTimeline",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CompanyTimelineItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/comments": {
+      "get": {
+        "operationId": "getCompanyComments",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CompanyCommentDto" }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      },
+      "post": {
+        "operationId": "createCompanyComment",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCompanyCommentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyCommentDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/comments/{commentId}": {
+      "delete": {
+        "operationId": "deleteCompanyComment",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "commentId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
     "/api/v1/users/me": {
       "get": {
         "operationId": "getMyUser",
@@ -2360,6 +2715,72 @@
         "summary": "",
         "tags": ["Report Statistics"]
       }
+    },
+    "/api/v1/reports/{reportId}/pdf": {
+      "get": {
+        "operationId": "getReportPdf",
+        "parameters": [
+          {
+            "name": "reportId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generates and returns the report as a PDF. The layout (\"Jafnlaunaúttekt\" or \"Jafnréttisáætlun\") is chosen from the report type.",
+            "content": {
+              "application/pdf": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Report PDF"]
+      }
     }
   },
   "info": {
@@ -2545,31 +2966,30 @@
         },
         "required": ["statusCode", "timestamp"]
       },
-      "CreateReportOutlierDto": {
+      "CreateReportOutlierGroupDto": {
         "type": "object",
         "properties": {
-          "employeeOrdinal": {
-            "type": "number",
-            "description": "Ordinal of the employee in `parsed.employees[]` this outlier justification applies to."
-          },
-          "reason": {
+          "name": {
             "type": "string",
-            "description": "Required when the parent report is not postponed; ignored when it is."
+            "description": "Applicant-supplied label for the group. Not required to be unique. When omitted (the implicit single-group case) the server assigns a default name."
           },
-          "action": {
-            "type": "string",
-            "description": "Required when the parent report is not postponed; ignored when it is."
-          },
-          "signatureName": {
-            "type": "string",
-            "description": "Required when the parent report is not postponed; ignored when it is."
-          },
-          "signatureRole": {
-            "type": "string",
-            "description": "Required when the parent report is not postponed; ignored when it is."
+          "reason": { "type": "string", "minLength": 1 },
+          "action": { "type": "string", "minLength": 1 },
+          "signatureName": { "type": "string", "minLength": 1 },
+          "signatureRole": { "type": "string", "minLength": 1 },
+          "employeeOrdinals": {
+            "description": "Ordinals of the employees in `parsed.employees[]` this group covers.",
+            "type": "array",
+            "items": { "type": "number" }
           }
         },
-        "required": ["employeeOrdinal"]
+        "required": [
+          "reason",
+          "action",
+          "signatureName",
+          "signatureRole",
+          "employeeOrdinals"
+        ]
       },
       "AdminSalaryReportDto": {
         "type": "object",
@@ -2597,9 +3017,11 @@
             "allOf": [{ "$ref": "#/components/schemas/ParsedReportDto" }]
           },
           "postponed": { "type": "boolean" },
-          "outliers": {
+          "outlierGroups": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/CreateReportOutlierDto" }
+            "items": {
+              "$ref": "#/components/schemas/CreateReportOutlierGroupDto"
+            }
           }
         },
         "required": [
@@ -2684,6 +3106,7 @@
         "enum": ["name", "employeeCount"]
       },
       "CompanySortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
+      "CompanyStatusEnum": { "type": "string", "enum": ["ACTIVE", "INACTIVE"] },
       "CompanyDto": {
         "type": "object",
         "properties": {
@@ -2693,6 +3116,15 @@
             "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
           },
           "nationalId": { "type": "string" },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "address": { "type": "string", "nullable": true },
+          "postcodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "salaryReportRequired": { "type": "boolean" },
           "salaryReportRequiredOverride": { "type": "boolean" }
         },
@@ -2701,6 +3133,7 @@
           "name",
           "employeeCountCategory",
           "nationalId",
+          "status",
           "salaryReportRequired",
           "salaryReportRequiredOverride"
         ]
@@ -2762,6 +3195,119 @@
           }
         },
         "required": ["nationalId", "name", "employeeCountCategory"]
+      },
+      "UpdateCompanyStatusDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional reason for the change, e.g. bankruptcy or merger."
+          }
+        },
+        "required": ["status"]
+      },
+      "CompanyTimelineItemKindEnum": {
+        "type": "string",
+        "enum": ["EVENT", "COMMENT"]
+      },
+      "CompanyEventTypeEnum": {
+        "type": "string",
+        "enum": ["CREATED", "STATUS_CHANGED"]
+      },
+      "CompanyEventDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "companyId": { "type": "string", "format": "uuid" },
+          "eventType": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyEventTypeEnum" }]
+          },
+          "actorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "fromStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "toStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "reason": { "type": "string", "nullable": true },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": ["id", "companyId", "eventType", "status", "createdAt"]
+      },
+      "CompanyCommentDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "companyId": { "type": "string", "format": "uuid" },
+          "authorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "authorName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full name of the admin who authored the comment."
+          },
+          "body": {
+            "type": "string",
+            "description": "Plain text comment body"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": ["id", "companyId", "body", "createdAt"]
+      },
+      "CompanyTimelineItemDto": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CompanyTimelineItemKindEnum" }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          },
+          "event": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyEventDto" }]
+          },
+          "comment": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyCommentDto" }]
+          }
+        },
+        "required": ["kind", "createdAt"]
+      },
+      "CreateCompanyCommentDto": {
+        "type": "object",
+        "properties": {
+          "body": { "type": "string", "description": "Plain text comment body" }
+        },
+        "required": ["body"]
       },
       "UserDto": {
         "type": "object",
@@ -3179,6 +3725,11 @@
             "format": "uuid",
             "nullable": true
           },
+          "authorName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full name of the authoring reviewer. Null for company-authored comments (no individual person)."
+          },
           "visibility": {
             "allOf": [{ "$ref": "#/components/schemas/CommentVisibilityEnum" }]
           },
@@ -3576,10 +4127,20 @@
           },
           "roleTitle": { "type": "string", "nullable": true },
           "score": { "type": "number", "nullable": true },
+          "groupId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Id of the outlier group this outlier belongs to. Every outlier always belongs to exactly one group."
+          },
+          "groupName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Name of the outlier group this outlier belongs to. Denormalized from the group for convenient client-side grouping/labeling."
+          },
           "reason": {
             "type": "string",
             "nullable": true,
-            "description": "Null only when the parent report has `status = POSTPONED`. Otherwise required and non-empty."
+            "description": "Explanation shared by the group. Denormalized from the outlier group — every outlier in the same group carries the same value. Null only while the parent report has `status = POSTPONED`."
           },
           "action": { "type": "string", "nullable": true },
           "signatureName": { "type": "string", "nullable": true },
@@ -3612,7 +4173,7 @@
             "description": "Half-threshold band (in percent) used to flag this row as an outlier — i.e. the report-wide allowed deviation at submission time."
           }
         },
-        "required": ["id", "reportEmployeeId"]
+        "required": ["id", "reportEmployeeId", "groupId"]
       },
       "GetReportOutliersResponseDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
@@ -51,6 +51,12 @@ const columns: ColumnDef<ReportEmployeeOutlierDto>[] = [
     enableSorting: true,
   },
   {
+    id: 'groupName',
+    header: o.groupHeader,
+    cell: ({ row }) => row.original.groupName ?? dash,
+    enableSorting: false,
+  },
+  {
     id: 'gender',
     header: o.genderHeader,
     accessorFn: (row) => (row.gender ? (genderMap[row.gender] ?? '') : ''),
@@ -81,6 +87,7 @@ const ExpandedRow = ({ row }: { row: ReportEmployeeOutlierDto }) => (
             ? `${formatSalary(row.predictedBaseSalary)} kr.`
             : null,
       },
+      { label: o.groupLabel, value: row.groupName },
       { label: o.reasonLabel, value: row.reason },
       { label: o.actionLabel, value: row.action },
       { label: o.signatureNameLabel, value: row.signatureName },

--- a/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
@@ -141,36 +141,24 @@ export const CreateSalaryReportDrawer = () => {
     }
 
     try {
+      // A postponed submit needs no outlier payload — the API recomputes the
+      // detected set server-side and creates a single default outlier group
+      // (explanation deferred). The admin tool has no per-outlier explanation
+      // UI, so when outliers are detected the report must be postponed.
       await submitMutation.mutateAsync({ path: { companyId }, body })
       onSuccess()
     } catch (firstError) {
       const message = firstError instanceof Error ? firstError.message : ''
       const ordinals = parseOutlierOrdinals(message)
 
-      if (!ordinals) {
-        toast.error(s.form.errorToast)
-        return
-      }
-
-      if (!postpone) {
+      if (ordinals && !postpone) {
         toast.error(
           `Frávik fundust fyrir ${ordinals.length} starfsmenn. Merktu "Fresta skilum frávika" og gefðu ástæðu til að senda inn.`,
         )
         return
       }
 
-      try {
-        await submitMutation.mutateAsync({
-          path: { companyId },
-          body: {
-            ...body,
-            outliers: ordinals.map((employeeOrdinal) => ({ employeeOrdinal })),
-          },
-        })
-        onSuccess()
-      } catch {
-        toast.error(s.form.errorToast)
-      }
+      toast.error(s.form.errorToast)
     }
   }
 

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -188,6 +188,8 @@ export const reportText = {
       roleHeader: 'Starf',
       genderHeader: 'Kyn',
       deviationHeader: 'Launafrávik',
+      groupHeader: 'Hópur',
+      groupLabel: 'Hópur',
       reasonLabel: 'Ástæða',
       actionLabel: 'Aðgerð',
       signatureNameLabel: 'Nafn undirritanda',


### PR DESCRIPTION
## Outlier groups: explanation per group, not per outlier

Moves the outlier improvement-plan explanation (`reason`, `action`, `signatureName`, `signatureRole`) off the per-outlier row and onto a new `report_outlier_group`. A salary report can now have multiple groups; each detected outlier belongs to exactly one group, and the explanation is written once per group.

### Changes
- **DB:** new `report_outlier_group` table (name + nullable explanation with all-or-none CHECK); `report_employee_outlier` becomes a thin join with a `NOT NULL group_id`; explanation columns dropped. Destructive migration (dev only).
- **Submit:** validates the union of each group's `employeeOrdinals` covers the detected set exactly (no extras/missing/duplicates).
- **Postpone:** still creates one default group (NULL explanation) covering all detected outliers — outliers are never ungrouped.
- **Edit/resolve:** replace-all — new groups created, rows re-pointed, old groups deleted.
- **Read:** flat + paginated, each row carries `groupId` + `groupName`.
- **Web (admin):** regenerated OpenAPI client; added group column/label; dropped the obsolete postpone retry.

### ⚠️ Breaking API change
`PUT /api/v1/application/reports/:providerId/outliers` body is now `{ groups: [{ name?, reason, action, signatureName, signatureRole, employeeOrdinals[] }] }` (was `{ outliers: [...] }`). The island.is application UI will update their end to match.

### Notes
- Run `yarn nx run directorate-of-equality-api:migrate` after pulling.