### PR TITLE
feat(doe): Company multi import + isat handling

### DIFF
--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -322,15 +322,19 @@ DoE staff (reviewers). Matches convention used by other apps in the repo (e.g. `
 
 ### `company`
 
-| Column                            | Type      |
-| --------------------------------- | --------- |
-| `id`                              | `uuid` PK |
-| `name`                            | `text`    |
-| `average_employee_count_from_rsk` | `int`     |
-| `national_id`                     | `text`    |
-| `salary_report_required`          | `boolean` |
-| `salary_report_required_override` | `boolean` |
-| `isat_category_code`              | `text` `fk → isat_category(code)` (nullable) |
+| Column                            | Type                                                |
+| --------------------------------- | --------------------------------------------------- |
+| `id`                              | `uuid` PK                                           |
+| `name`                            | `text`                                              |
+| `employee_count_category`         | `company_size_enum` (`UNKNOWN`/`SMALL`/`MEDIUM`/`LARGE`) |
+| `national_id`                     | `text` (unique)                                     |
+| `status`                          | `company_status_enum` (`ACTIVE`/`INACTIVE`/`UNKNOWN`) |
+| `salary_report_required`          | `boolean`                                           |
+| `salary_report_required_override` | `boolean`                                           |
+| `isat_category_code`              | `text` `fk → isat_category(code)` (nullable)        |
+
+`status = UNKNOWN` is set by the company import for a company we hold that is absent
+from the authoritative register (see [Company import](#company-import-annual-register)).
 
 ### `isat_category`
 

--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -39,6 +39,38 @@ Every company must submit an `EQUALITY` report — no gating column, no exceptio
 
 `salary_report_required_override` marks rows whose flag has been set manually (e.g. institutions that must report regardless of headcount, or any other case where the law-by-headcount rule doesn't apply). When `salary_report_required_override = true`, the trigger skips the row entirely — the manual value stands even as the RSK count crosses the 50-threshold in either direction.
 
+## Industry classification (ÍSAT2008)
+
+Companies carry an industry classification using the Icelandic ÍSAT2008 standard (Hagstofan), stored on `company.isat_category_code` as a FK into the `isat_category` reference table. This is **statistics data** — it powers industry breakdowns of approved reports — and is **not** part of the report-submission or eligibility flow.
+
+How we handle it:
+
+- **Leaf codes only.** `isat_category` is seeded with the 665 leaf (5-digit, two-dot) ÍSAT2008 codes. A company is always classified at its own leaf — sections, divisions, groups, and classes are not stored. The 2-digit division is recoverable from the leaf prefix (`01110` → `01`); the section letter (`A`) is not numerically derivable and is intentionally dropped.
+- **Normalized code is the key.** `isat_category.code` is the normalized 5-digit form (`01110`). The dotted form (`01.11.0`) is kept alongside for display only. Company-level classification is always the normalized code.
+- **Admin-owned.** `company.isat_category_code` is set and kept current by DoE admins, in the same spirit as the `salary_report_required*` flags — not supplied by company admins at submission. It is refreshed by a **manual job run once a year** against an admin-uploaded company-info file.
+- **Snapshot independence.** `company.isat_category_code` and `company_report.isat_category` are unrelated. The latter is a free-text dotted code frozen at submission (a snapshot is just a snapshot); the former is the live admin-maintained classification. The submission flow never reads from or writes to the company-level value, and `company_report` is never updated when the company's classification changes.
+
+> **Subject to change.** This is an interim design while the feature is in development. The long-term intent is to source classification directly from the RSK API once we have access; until then, the annual admin-uploaded file is the source of truth. The stored format (normalized leaf code) and admin ownership may change when that integration lands.
+
+## Company import (annual register)
+
+Company records are refreshed from an authoritative `.xlsx` register an admin uploads once a year (columns: kennitala, name, address, postcode, ÍSAT, size bucket). The file is the **source of truth**; the import reconciles `company` against it, matched on `national_id`. Endpoints run **preview → confirm**: `POST /companies/import/preview` returns the diff and writes nothing; `POST /companies/import/apply` commits in one transaction. Both return the same categorized summary so the admin UI can show exactly what happened.
+
+Per company:
+
+- **In file, not in DB** → created (status `ACTIVE`).
+- **In file + DB, fields differ** → the differing authoritative fields (`name`, `address`, `postcodeId`, `isat_category_code`, `employee_count_category`) are updated.
+- **In file + DB, identical** → unchanged.
+- **In DB, absent from file** → status set to **`UNKNOWN`** ("should be in the list — something is off"). `INACTIVE` companies are left as-is (deliberate deactivation is not overridden); already-`UNKNOWN` rows are untouched.
+- **Reappears in file** after `UNKNOWN`/`INACTIVE` → reactivated to `ACTIVE`.
+- **Invalid rows** (bad kennitala, unknown ÍSAT code, duplicate kennitala in file) → reported, never applied.
+
+Size comes from the `LAUNAFLOKKUR` column (`50+`→`LARGE`, `25-49`→`MEDIUM`, else→`SMALL`); `salary_report_required` is then derived by the usual DB trigger. ÍSAT codes are normalized to 5 digits and validated against `isat_category`. A postcode that doesn't resolve is a soft note, not a rejection.
+
+Only the status transitions the import performs (`ACTIVE→UNKNOWN`, `UNKNOWN/INACTIVE→ACTIVE`) emit `company_event` rows; field edits are audited via the import summary and a structured log line, not per-company events. (A first-class import-audit table — `system_event` — is a possible future addition.)
+
+> **Subject to change.** Interim design; in development. Same RSK-API caveat as above — the annual upload is expected to be replaced by a direct RSK feed eventually.
+
 ## Report lifecycle
 
 `report.status` drives every transition. Resubmissions are new rows; there is no FK chain back to the prior submission.
@@ -298,6 +330,18 @@ DoE staff (reviewers). Matches convention used by other apps in the repo (e.g. `
 | `national_id`                     | `text`    |
 | `salary_report_required`          | `boolean` |
 | `salary_report_required_override` | `boolean` |
+| `isat_category_code`              | `text` `fk → isat_category(code)` (nullable) |
+
+### `isat_category`
+
+Reference table of ÍSAT2008 industry classifications, seeded from `ISAT_2008.json` (665 leaf codes — see [Industry classification](#industry-classification-ísat2008)). Read-only at runtime; refreshed only when the standard changes. `company.isat_category_code` FKs into `code`.
+
+| Column           | Type                                |
+| ---------------- | ----------------------------------- |
+| `code`           | `text` PK (normalized, e.g. `01110`) |
+| `code_dotted`    | `text` (display form, e.g. `01.11.0`) |
+| `description`    | `text` (Icelandic)                  |
+| `description_en` | `text` (English)                    |
 
 ### `company_report`
 

--- a/apps/directorate-of-equality-api/db/migrations/m-20260619-doe-company-isat-category.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260619-doe-company-isat-category.js
@@ -1,0 +1,49 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    -- ============================================================
+    -- isat_category reference table + company.isat_category_code
+    --
+    -- ÍSAT2008 industry classification (Hagstofan). Seeded with the 665 leaf
+    -- (5-digit / two-dot) codes only — a company is always classified at its
+    -- own leaf. 'code' is the normalized form (e.g. '01110'); 'code_dotted'
+    -- (e.g. '01.11.0') is kept for display.
+    --
+    -- company.isat_category_code is admin-owned statistics data, refreshed by a
+    -- manual annual job. It is independent of company_report.isat_category,
+    -- which remains a free-text submission snapshot. See db/README.md.
+    -- ============================================================
+
+    CREATE TABLE isat_category (
+      code TEXT PRIMARY KEY,
+      code_dotted TEXT NOT NULL,
+      description TEXT NOT NULL,
+      description_en TEXT NOT NULL
+    );
+
+    ALTER TABLE company
+      ADD COLUMN isat_category_code TEXT DEFAULT NULL
+        REFERENCES isat_category(code) ON DELETE RESTRICT;
+
+    COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`
+    BEGIN;
+
+    ALTER TABLE company
+      DROP COLUMN isat_category_code;
+
+    DROP TABLE isat_category;
+
+    COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/db/migrations/m-20260619-doe-company-status-unknown.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260619-doe-company-status-unknown.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // Add UNKNOWN to the company lifecycle status. Set by the annual company
+    // import when a company we hold is absent from the authoritative register:
+    // "should be in the list — something is off, but we don't know what".
+    // Distinct from INACTIVE (a deliberate admin deactivation, e.g. bankruptcy
+    // or merger).
+    //
+    // ALTER TYPE ... ADD VALUE must be committed before the new value can be
+    // referenced (Postgres forbids using it in the same transaction), so it
+    // runs on its own here.
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_status_enum ADD VALUE IF NOT EXISTS 'UNKNOWN';
+    `)
+  },
+
+  async down() {
+    // Postgres has no DROP VALUE — removing 'UNKNOWN' would require recreating
+    // company_status_enum and rewriting every dependent column. The value is
+    // left in place; no-op.
+  },
+}

--- a/apps/directorate-of-equality-api/db/seeders/data/isat-2008.json
+++ b/apps/directorate-of-equality-api/db/seeders/data/isat-2008.json
@@ -1,0 +1,3992 @@
+[
+  {
+    "isat2008_normalized": "01110",
+    "description": "Kornrækt (að undanskildum hrísgrjónum), ræktun belgjurta og olíufræja",
+    "isat2008": "01.11.0",
+    "description_en": "Growing of cereals (except rice), leguminous crops and oil seeds"
+  },
+  {
+    "isat2008_normalized": "01120",
+    "description": "Hrísgrjónarækt",
+    "isat2008": "01.12.0",
+    "description_en": "Growing of rice"
+  },
+  {
+    "isat2008_normalized": "01131",
+    "description": "Ræktun á aldingrænmeti og papriku",
+    "isat2008": "01.13.1",
+    "description_en": "Growing of fruit bearing vegatables and capsicum"
+  },
+  {
+    "isat2008_normalized": "01132",
+    "description": "Ræktun á kartöflum",
+    "isat2008": "01.13.2",
+    "description_en": "Growing of potatoes"
+  },
+  {
+    "isat2008_normalized": "01139",
+    "description": "Ræktun á öðru ótöldu grænmeti, rótum og hnýði",
+    "isat2008": "01.13.9",
+    "description_en": "Growing of other vegatable, roots and tubers"
+  },
+  {
+    "isat2008_normalized": "01140",
+    "description": "Ræktun sykurreyrs",
+    "isat2008": "01.14.0",
+    "description_en": "Growing of sugar cane"
+  },
+  {
+    "isat2008_normalized": "01150",
+    "description": "Tóbaksræktun",
+    "isat2008": "01.15.0",
+    "description_en": "Growing of tobacco"
+  },
+  {
+    "isat2008_normalized": "01160",
+    "description": "Ræktun trefjajurta",
+    "isat2008": "01.16.0",
+    "description_en": "Growing of fibre crops"
+  },
+  {
+    "isat2008_normalized": "01191",
+    "description": "Blómarækt",
+    "isat2008": "01.19.1",
+    "description_en": "Growing of flowers"
+  },
+  {
+    "isat2008_normalized": "01199",
+    "description": "Önnur ótalin ræktun nytjajurta sem ekki eru fjölærar",
+    "isat2008": "01.19.9",
+    "description_en": "Growing of other non-perennial crops n.e.c."
+  },
+  {
+    "isat2008_normalized": "01210",
+    "description": "Ræktun á þrúgum",
+    "isat2008": "01.21.0",
+    "description_en": "Growing of grapes"
+  },
+  {
+    "isat2008_normalized": "01220",
+    "description": "Ræktun ávaxta frá hitabeltinu og heittempraða beltinu",
+    "isat2008": "01.22.0",
+    "description_en": "Growing of tropical and subtropical fruits"
+  },
+  {
+    "isat2008_normalized": "01230",
+    "description": "Ræktun sítrusávaxta",
+    "isat2008": "01.23.0",
+    "description_en": "Growing of citrus fruits"
+  },
+  {
+    "isat2008_normalized": "01240",
+    "description": "Ræktun kjarnaávaxta og steinaldina",
+    "isat2008": "01.24.0",
+    "description_en": "Growing of pome fruits and stone fruits"
+  },
+  {
+    "isat2008_normalized": "01250",
+    "description": "Ræktun annarra ávaxta og hneta af trjám og runnum",
+    "isat2008": "01.25.0",
+    "description_en": "Growing of other tree and bush fruits and nuts"
+  },
+  {
+    "isat2008_normalized": "01260",
+    "description": "Ræktun olíuríkra ávaxta",
+    "isat2008": "01.26.0",
+    "description_en": "Growing of oleaginous fruits"
+  },
+  {
+    "isat2008_normalized": "01270",
+    "description": "Ræktun jurta til drykkjargerðar",
+    "isat2008": "01.27.0",
+    "description_en": "Growing of beverage crops"
+  },
+  {
+    "isat2008_normalized": "01280",
+    "description": "Ræktun krydd- , ilm- og lyfjajurta",
+    "isat2008": "01.28.0",
+    "description_en": "Growing of spices, aromatic, drug and pharmaceutical crops"
+  },
+  {
+    "isat2008_normalized": "01290",
+    "description": "Ræktun annarra fjölærra nytjajurta",
+    "isat2008": "01.29.0",
+    "description_en": "Growing of other perennial crops"
+  },
+  {
+    "isat2008_normalized": "01300",
+    "description": "Plöntufjölgun",
+    "isat2008": "01.30.0",
+    "description_en": "Plant propagation"
+  },
+  {
+    "isat2008_normalized": "01410",
+    "description": "Ræktun mjólkurkúa",
+    "isat2008": "01.41.0",
+    "description_en": "Raising of dairy cattle"
+  },
+  {
+    "isat2008_normalized": "01420",
+    "description": "Önnur nautgriparækt",
+    "isat2008": "01.42.0",
+    "description_en": "Raising of other cattle and buffaloes"
+  },
+  {
+    "isat2008_normalized": "01430",
+    "description": "Hrossarækt og ræktun annarra dýra af hrossaætt",
+    "isat2008": "01.43.0",
+    "description_en": "Raising of horses and other equines"
+  },
+  {
+    "isat2008_normalized": "01440",
+    "description": "Úlfaldarækt og ræktun dýra af úlfaldaætt",
+    "isat2008": "01.44.0",
+    "description_en": "Raising of camels and camelids"
+  },
+  {
+    "isat2008_normalized": "01450",
+    "description": "Sauðfjár- og geitarækt",
+    "isat2008": "01.45.0",
+    "description_en": "Raising of sheep and  goats"
+  },
+  {
+    "isat2008_normalized": "01460",
+    "description": "Svínarækt",
+    "isat2008": "01.46.0",
+    "description_en": "Raising of swine/pigs"
+  },
+  {
+    "isat2008_normalized": "01471",
+    "description": "Alifuglarækt",
+    "isat2008": "01.47.1",
+    "description_en": "Raising of poultry"
+  },
+  {
+    "isat2008_normalized": "01472",
+    "description": "Eggjaframleiðsla",
+    "isat2008": "01.47.2",
+    "description_en": "Egg production"
+  },
+  {
+    "isat2008_normalized": "01491",
+    "description": "Loðdýrabú",
+    "isat2008": "01.49.1",
+    "description_en": "Raising of fur animals"
+  },
+  {
+    "isat2008_normalized": "01492",
+    "description": "Æðarrækt og æðardúnstekja",
+    "isat2008": "01.49.2",
+    "description_en": "Gathering of eiderdown"
+  },
+  {
+    "isat2008_normalized": "01499",
+    "description": "Ræktun annarra ótalinna dýra",
+    "isat2008": "01.49.9",
+    "description_en": "Raising of other animals n.e.c."
+  },
+  {
+    "isat2008_normalized": "01500",
+    "description": "Blandaður búskapur",
+    "isat2008": "01.50.0",
+    "description_en": "Mixed farming"
+  },
+  {
+    "isat2008_normalized": "01610",
+    "description": "Þjónustustarfsemi við ræktun nytjajurta",
+    "isat2008": "01.61.0",
+    "description_en": "Support activities for crop production"
+  },
+  {
+    "isat2008_normalized": "01620",
+    "description": "Þjónustustarfsemi við búfjárrækt",
+    "isat2008": "01.62.0",
+    "description_en": "Support activities for animal production"
+  },
+  {
+    "isat2008_normalized": "01630",
+    "description": "Starfsemi að lokinni uppskeru",
+    "isat2008": "01.63.0",
+    "description_en": "Post-harvest crop activities"
+  },
+  {
+    "isat2008_normalized": "01640",
+    "description": "Vinnsla fræja fyrir sáningu",
+    "isat2008": "01.64.0",
+    "description_en": "Seed processing for propagation"
+  },
+  {
+    "isat2008_normalized": "01700",
+    "description": "Veiðar og tengd þjónustustarfsemi",
+    "isat2008": "01.70.0",
+    "description_en": "Hunting, trapping and related service activities"
+  },
+  {
+    "isat2008_normalized": "02101",
+    "description": "Rekstur gróðrastöðva fyrir skógartré",
+    "isat2008": "02.10.1",
+    "description_en": "Operation of forest tree nurseries"
+  },
+  {
+    "isat2008_normalized": "02109",
+    "description": "Skógrækt og önnur ótalin starfsemi tengd henni",
+    "isat2008": "02.10.9",
+    "description_en": "Silviculture and other forestry activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "02200",
+    "description": "Skógarhögg",
+    "isat2008": "02.20.0",
+    "description_en": "Logging"
+  },
+  {
+    "isat2008_normalized": "02300",
+    "description": "Söfnun afurða sem vaxa villtar en eru ekki tré",
+    "isat2008": "02.30.0",
+    "description_en": "Gathering of wild growing non-wood products"
+  },
+  {
+    "isat2008_normalized": "02400",
+    "description": "Þjónustustarfsemi við skógrækt",
+    "isat2008": "02.40.0",
+    "description_en": "Support services to forestry"
+  },
+  {
+    "isat2008_normalized": "03111",
+    "description": "Útgerð smábáta",
+    "isat2008": "03.11.1",
+    "description_en": "Operation fishing boats smaller than 15 GT"
+  },
+  {
+    "isat2008_normalized": "03112",
+    "description": "Útgerð fiskiskipa",
+    "isat2008": "03.11.2",
+    "description_en": "Operation of fishing vessels larger than 15 GT"
+  },
+  {
+    "isat2008_normalized": "03113",
+    "description": "Hvalveiðar",
+    "isat2008": "03.11.3",
+    "description_en": "Whaling"
+  },
+  {
+    "isat2008_normalized": "03120",
+    "description": "Ferskvatnsveiði",
+    "isat2008": "03.12.0",
+    "description_en": "Freshwater fishing"
+  },
+  {
+    "isat2008_normalized": "03210",
+    "description": "Eldi og ræktun í sjó",
+    "isat2008": "03.21.0",
+    "description_en": "Marine aquaculture"
+  },
+  {
+    "isat2008_normalized": "03220",
+    "description": "Eldi og ræktun í ferskvatni",
+    "isat2008": "03.22.0",
+    "description_en": "Freshwater aquaculture"
+  },
+  {
+    "isat2008_normalized": "05100",
+    "description": "Steinkolanám",
+    "isat2008": "05.10.0",
+    "description_en": "Mining of hard coal"
+  },
+  {
+    "isat2008_normalized": "05200",
+    "description": "Brúnkolanám",
+    "isat2008": "05.20.0",
+    "description_en": "Mining of lignite"
+  },
+  {
+    "isat2008_normalized": "06100",
+    "description": "Vinnsla á hráolíu",
+    "isat2008": "06.10.0",
+    "description_en": "Extraction of crude petroleum"
+  },
+  {
+    "isat2008_normalized": "06200",
+    "description": "Vinnsla á jarðgasi",
+    "isat2008": "06.20.0",
+    "description_en": "Extraction of natural gas"
+  },
+  {
+    "isat2008_normalized": "07100",
+    "description": "Járnnám",
+    "isat2008": "07.10.0",
+    "description_en": "Mining of iron ores"
+  },
+  {
+    "isat2008_normalized": "07210",
+    "description": "Nám á úran- og þórínmálmgrýti",
+    "isat2008": "07.21.0",
+    "description_en": "Mining of uranium and thorium ores"
+  },
+  {
+    "isat2008_normalized": "07290",
+    "description": "Nám annarra málma en járns",
+    "isat2008": "07.29.0",
+    "description_en": "Mining of other non-ferrous metal ores"
+  },
+  {
+    "isat2008_normalized": "08110",
+    "description": "Grjótnám til skrautsteinagerðar og til bygginga, kalksteins-, gifs-, krítar- og flögubergsnám",
+    "isat2008": "08.11.0",
+    "description_en": "Quarrying of ornamental and building stone, limestone, gypsum, chalk and slate"
+  },
+  {
+    "isat2008_normalized": "08120",
+    "description": "Malar-, sand- og leirnám",
+    "isat2008": "08.12.0",
+    "description_en": "Operation of gravel and sand pits; mining of clays and kaolin"
+  },
+  {
+    "isat2008_normalized": "08910",
+    "description": "Nám og vinnsla á steinefnum til efnaiðnaðar og áburðargerðar",
+    "isat2008": "08.91.0",
+    "description_en": "Mining of chemical and fertiliser minerals"
+  },
+  {
+    "isat2008_normalized": "08920",
+    "description": "Mótekja",
+    "isat2008": "08.92.0",
+    "description_en": "Extraction of peat"
+  },
+  {
+    "isat2008_normalized": "08930",
+    "description": "Saltnám",
+    "isat2008": "08.93.0",
+    "description_en": "Extraction of salt"
+  },
+  {
+    "isat2008_normalized": "08990",
+    "description": "Nám og vinnsla annarra ótalinna hráefna úr jörðu",
+    "isat2008": "08.99.0",
+    "description_en": "Other mining and quarrying n.e.c."
+  },
+  {
+    "isat2008_normalized": "09100",
+    "description": "Þjónustustarfsemi við námuvinnslu á jarðolíu og jarðgasi",
+    "isat2008": "09.10.0",
+    "description_en": "Support activities for petroleum and natural gas extraction"
+  },
+  {
+    "isat2008_normalized": "09900",
+    "description": "Þjónustustarfsemi fyrir vinnslu annarra hráefna úr jörðu",
+    "isat2008": "09.90.0",
+    "description_en": "Support activities for other mining and quarrying"
+  },
+  {
+    "isat2008_normalized": "10110",
+    "description": "Slátrun og vinnsla á kjöti, þó ekki alifuglakjöti",
+    "isat2008": "10.11.0",
+    "description_en": "Processing and preserving of meat"
+  },
+  {
+    "isat2008_normalized": "10120",
+    "description": "Slátrun og vinnsla á alifuglakjöti",
+    "isat2008": "10.12.0",
+    "description_en": "Processing and preserving of poultry meat"
+  },
+  {
+    "isat2008_normalized": "10130",
+    "description": "Framleiðsla á kjötafurðum",
+    "isat2008": "10.13.0",
+    "description_en": "Production of meat and poultry meat products"
+  },
+  {
+    "isat2008_normalized": "10201",
+    "description": "Frysting fiskafurða, krabbadýra og lindýra",
+    "isat2008": "10.20.1",
+    "description_en": "Freezing of fish, fish fillets, crustaceans and molluscs"
+  },
+  {
+    "isat2008_normalized": "10202",
+    "description": "Söltun, þurrkun og hersla fiskafurða, krabbadýra og lindýra",
+    "isat2008": "10.20.2",
+    "description_en": "Drying and salting of fish, crustaceans and molluscs"
+  },
+  {
+    "isat2008_normalized": "10203",
+    "description": "Mjöl- og lýsisvinnsla",
+    "isat2008": "10.20.3",
+    "description_en": "Manufacture of fish meal and crude fish oils"
+  },
+  {
+    "isat2008_normalized": "10204",
+    "description": "Framleiðsla lagmetis úr fiskafurðum, krabbadýrum og lindýrum",
+    "isat2008": "10.20.4",
+    "description_en": "Canning and preserving of fish, crustaceans and molluscs"
+  },
+  {
+    "isat2008_normalized": "10209",
+    "description": "Önnur ótalin vinnsla fiskafurða, krabbadýra og lindýra",
+    "isat2008": "10.20.9",
+    "description_en": "Processing and preserving of fish and fish products n.e.c."
+  },
+  {
+    "isat2008_normalized": "10310",
+    "description": "Vinnsla á kartöflum",
+    "isat2008": "10.31.0",
+    "description_en": "Processing and preserving of potatoes"
+  },
+  {
+    "isat2008_normalized": "10320",
+    "description": "Framleiðsla á ávaxta- og grænmetissafa",
+    "isat2008": "10.32.0",
+    "description_en": "Manufacture of fruit and vegetable juice"
+  },
+  {
+    "isat2008_normalized": "10390",
+    "description": "Önnur ótalin vinnsla ávaxta og grænmetis",
+    "isat2008": "10.39.0",
+    "description_en": "Other processing and preserving of fruit and vegetables"
+  },
+  {
+    "isat2008_normalized": "10410",
+    "description": "Framleiðsla á olíu og feiti",
+    "isat2008": "10.41.0",
+    "description_en": "Manufacture of oils and fats"
+  },
+  {
+    "isat2008_normalized": "10420",
+    "description": "Framleiðsla á smjörlíki og svipaðri feiti til manneldis",
+    "isat2008": "10.42.0",
+    "description_en": "Manufacture of margarine and similar edible fats"
+  },
+  {
+    "isat2008_normalized": "10510",
+    "description": "Mjólkurbú og ostagerð",
+    "isat2008": "10.51.0",
+    "description_en": "Operation of dairies and cheese making"
+  },
+  {
+    "isat2008_normalized": "10520",
+    "description": "Ísgerð",
+    "isat2008": "10.52.0",
+    "description_en": "Manufacture of ice cream"
+  },
+  {
+    "isat2008_normalized": "10610",
+    "description": "Framleiðsla á kornvöru",
+    "isat2008": "10.61.0",
+    "description_en": "Manufacture of grain mill products"
+  },
+  {
+    "isat2008_normalized": "10620",
+    "description": "Framleiðsla á mjölva og mjölvavöru",
+    "isat2008": "10.62.0",
+    "description_en": "Manufacture of starches and starch products"
+  },
+  {
+    "isat2008_normalized": "10710",
+    "description": "Framleiðsla á brauði, nýju sætabrauði og kökum",
+    "isat2008": "10.71.0",
+    "description_en": "Manufacture of bread; manufacture of fresh pastry goods and cakes"
+  },
+  {
+    "isat2008_normalized": "10720",
+    "description": "Framleiðsla á tvíbökum og kexi, framleiðsla á geymsluþolnu sætabrauði og kökum",
+    "isat2008": "10.72.0",
+    "description_en": "Manufacture of rusks and biscuits; manufacture of preserved pastry goods and cakes"
+  },
+  {
+    "isat2008_normalized": "10730",
+    "description": "Framleiðsla á pastavörum og svipuðum vörum",
+    "isat2008": "10.73.0",
+    "description_en": "Manufacture of macaroni, noodles, couscous and similar farinaceous products"
+  },
+  {
+    "isat2008_normalized": "10810",
+    "description": "Sykurframleiðsla",
+    "isat2008": "10.81.0",
+    "description_en": "Manufacture of sugar"
+  },
+  {
+    "isat2008_normalized": "10820",
+    "description": "Framleiðsla á súkkulaði og sælgæti; kakói",
+    "isat2008": "10.82.0",
+    "description_en": "Manufacture of cocoa, chocolate and sugar confectionery"
+  },
+  {
+    "isat2008_normalized": "10830",
+    "description": "Te- og kaffivinnsla",
+    "isat2008": "10.83.0",
+    "description_en": "Processing of tea and coffee"
+  },
+  {
+    "isat2008_normalized": "10840",
+    "description": "Framleiðsla á bragðefnum og kryddi",
+    "isat2008": "10.84.0",
+    "description_en": "Manufacture of condiments and seasonings"
+  },
+  {
+    "isat2008_normalized": "10850",
+    "description": "Framleiðsla á tilbúnum máltíðum og réttum",
+    "isat2008": "10.85.0",
+    "description_en": "Manufacture of prepared meals and dishes"
+  },
+  {
+    "isat2008_normalized": "10860",
+    "description": "Framleiðsla á jafnblönduðum matvælum og sérfæði",
+    "isat2008": "10.86.0",
+    "description_en": "Manufacture of homogenised food preparations and dietetic food"
+  },
+  {
+    "isat2008_normalized": "10890",
+    "description": "Önnur ótalin framleiðsla á matvælum",
+    "isat2008": "10.89.0",
+    "description_en": "Manufacture of other food products n.e.c."
+  },
+  {
+    "isat2008_normalized": "10910",
+    "description": "Framleiðsla húsdýrafóðurs",
+    "isat2008": "10.91.0",
+    "description_en": "Manufacture of prepared feeds for farm animals"
+  },
+  {
+    "isat2008_normalized": "10920",
+    "description": "Framleiðsla gæludýrafóðurs",
+    "isat2008": "10.92.0",
+    "description_en": "Manufacture of prepared pet foods"
+  },
+  {
+    "isat2008_normalized": "11010",
+    "description": "Eiming, hreinsun og blöndun áfengra drykkja",
+    "isat2008": "11.01.0",
+    "description_en": "Distilling, rectifying and blending of spirits"
+  },
+  {
+    "isat2008_normalized": "11020",
+    "description": "Framleiðsla á víni úr þrúgum",
+    "isat2008": "11.02.0",
+    "description_en": "Manufacture of wine from grape"
+  },
+  {
+    "isat2008_normalized": "11030",
+    "description": "Framleiðsla annarra ávaxtavína",
+    "isat2008": "11.03.0",
+    "description_en": "Manufacture of cider and other fruit wines"
+  },
+  {
+    "isat2008_normalized": "11040",
+    "description": "Framleiðsla á öðrum óeimuðum, gerjuðum drykkjarvörum",
+    "isat2008": "11.04.0",
+    "description_en": "Manufacture of other non-distilled fermented beverages"
+  },
+  {
+    "isat2008_normalized": "11050",
+    "description": "Bjórgerð",
+    "isat2008": "11.05.0",
+    "description_en": "Manufacture of beer"
+  },
+  {
+    "isat2008_normalized": "11060",
+    "description": "Maltgerð",
+    "isat2008": "11.06.0",
+    "description_en": "Manufacture of malt"
+  },
+  {
+    "isat2008_normalized": "11070",
+    "description": "Framleiðsla á gosdrykkjum, ölkelduvatni og öðru átöppuðu vatni",
+    "isat2008": "11.07.0",
+    "description_en": "Manufacture of soft drinks; production of mineral waters and other bottled waters"
+  },
+  {
+    "isat2008_normalized": "12000",
+    "description": "Framleiðsla á tóbaksvörum",
+    "isat2008": "12.00.0",
+    "description_en": "Manufacture of tobacco products"
+  },
+  {
+    "isat2008_normalized": "13100",
+    "description": "Forvinnsla og spuni á textíltrefjum",
+    "isat2008": "13.10.0",
+    "description_en": "Preparation and spinning of textile fibres"
+  },
+  {
+    "isat2008_normalized": "13200",
+    "description": "Textílvefnaður",
+    "isat2008": "13.20.0",
+    "description_en": "Weaving of textiles"
+  },
+  {
+    "isat2008_normalized": "13300",
+    "description": "Frágangur á textílum",
+    "isat2008": "13.30.0",
+    "description_en": "Finishing of textiles"
+  },
+  {
+    "isat2008_normalized": "13910",
+    "description": "Framleiðsla á hekluðum og prjónuðum dúk",
+    "isat2008": "13.91.0",
+    "description_en": "Manufacture of knitted and crocheted fabrics"
+  },
+  {
+    "isat2008_normalized": "13920",
+    "description": "Framleiðsla á tilbúinni spunavöru annarri en fatnaði",
+    "isat2008": "13.92.0",
+    "description_en": "Manufacture of made-up textile articles, except apparel"
+  },
+  {
+    "isat2008_normalized": "13930",
+    "description": "Framleiðsla á gólfteppum og mottum",
+    "isat2008": "13.93.0",
+    "description_en": "Manufacture of carpets and rugs"
+  },
+  {
+    "isat2008_normalized": "13940",
+    "description": "Framleiðsla á köðlum, seglgarni og netum",
+    "isat2008": "13.94.0",
+    "description_en": "Manufacture of cordage, rope, twine and netting"
+  },
+  {
+    "isat2008_normalized": "13950",
+    "description": "Framleiðsla á trefjadúk og vörum úr þeim, þó ekki fatnaði",
+    "isat2008": "13.95.0",
+    "description_en": "Manufacture of non-wovens and articles made from non-wovens, except apparel"
+  },
+  {
+    "isat2008_normalized": "13960",
+    "description": "Framleiðsla annarra tækni- og iðnaðartextíla",
+    "isat2008": "13.96.0",
+    "description_en": "Manufacture of other technical and industrial textiles"
+  },
+  {
+    "isat2008_normalized": "13990",
+    "description": "Framleiðsla á annarri ótalinni textílvöru",
+    "isat2008": "13.99.0",
+    "description_en": "Manufacture of other textiles n.e.c."
+  },
+  {
+    "isat2008_normalized": "14110",
+    "description": "Framleiðsla á leðurfatnaði",
+    "isat2008": "14.11.0",
+    "description_en": "Manufacture of leather clothes"
+  },
+  {
+    "isat2008_normalized": "14120",
+    "description": "Vinnufatagerð",
+    "isat2008": "14.12.0",
+    "description_en": "Manufacture of workwear"
+  },
+  {
+    "isat2008_normalized": "14130",
+    "description": "Framleiðsla á öðrum yfirfatnaði",
+    "isat2008": "14.13.0",
+    "description_en": "Manufacture of other outerwear"
+  },
+  {
+    "isat2008_normalized": "14140",
+    "description": "Framleiðsla á nærfatnaði",
+    "isat2008": "14.14.0",
+    "description_en": "Manufacture of underwear"
+  },
+  {
+    "isat2008_normalized": "14190",
+    "description": "Framleiðsla á öðrum fatnaði og fylgihlutum",
+    "isat2008": "14.19.0",
+    "description_en": "Manufacture of other wearing apparel and accessories"
+  },
+  {
+    "isat2008_normalized": "14200",
+    "description": "Framleiðsla á vörum úr loðskinnum",
+    "isat2008": "14.20.0",
+    "description_en": "Manufacture of articles of fur"
+  },
+  {
+    "isat2008_normalized": "14310",
+    "description": "Framleiðsla á sokkum og sokkavörum",
+    "isat2008": "14.31.0",
+    "description_en": "Manufacture of knitted and crocheted hosiery"
+  },
+  {
+    "isat2008_normalized": "14390",
+    "description": "Framleiðsla á öðrum prjónuðum og hekluðum fatnaði",
+    "isat2008": "14.39.0",
+    "description_en": "Manufacture of other knitted and crocheted apparel"
+  },
+  {
+    "isat2008_normalized": "15110",
+    "description": "Sútun leðurs; sútun og litun á loðskinni",
+    "isat2008": "15.11.0",
+    "description_en": "Tanning and dressing of leather; dressing and dyeing of fur"
+  },
+  {
+    "isat2008_normalized": "15120",
+    "description": "Framleiðsla á ferðatöskum, handtöskum og áþekkum vörum; reiðtygjum og skyldum vörum",
+    "isat2008": "15.12.0",
+    "description_en": "Manufacture of luggage, handbags and the like, saddlery and harness"
+  },
+  {
+    "isat2008_normalized": "15200",
+    "description": "Framleiðsla á skófatnaði",
+    "isat2008": "15.20.0",
+    "description_en": "Manufacture of footwear"
+  },
+  {
+    "isat2008_normalized": "16100",
+    "description": "Sögun, heflun og fúavörn á viði",
+    "isat2008": "16.10.0",
+    "description_en": "Sawmilling and planing of wood"
+  },
+  {
+    "isat2008_normalized": "16210",
+    "description": "Framleiðsla á viðarspæni og plötum að grunni til úr viði",
+    "isat2008": "16.21.0",
+    "description_en": "Manufacture of veneer sheets and wood-based panels"
+  },
+  {
+    "isat2008_normalized": "16220",
+    "description": "Framleiðsla á samsettum parketgólfum",
+    "isat2008": "16.22.0",
+    "description_en": "Manufacture of assembled parquet floors"
+  },
+  {
+    "isat2008_normalized": "16230",
+    "description": "Framleiðsla á öðrum trésmíðavörum til bygginga",
+    "isat2008": "16.23.0",
+    "description_en": "Manufacture of other builders' carpentry and joinery"
+  },
+  {
+    "isat2008_normalized": "16240",
+    "description": "Framleiðsla á umbúðum úr viði",
+    "isat2008": "16.24.0",
+    "description_en": "Manufacture of wooden containers"
+  },
+  {
+    "isat2008_normalized": "16290",
+    "description": "Framleiðsla á annarri viðarvöru; framleiðsla á vörum úr korki, hálmi og fléttiefnum",
+    "isat2008": "16.29.0",
+    "description_en": "Manufacture of other products of wood; manufacture of articles of cork, straw and plaiting materials"
+  },
+  {
+    "isat2008_normalized": "17110",
+    "description": "Framleiðsla á pappírskvoðu",
+    "isat2008": "17.11.0",
+    "description_en": "Manufacture of pulp"
+  },
+  {
+    "isat2008_normalized": "17120",
+    "description": "Framleiðsla á pappír og pappa",
+    "isat2008": "17.12.0",
+    "description_en": "Manufacture of paper and paperboard"
+  },
+  {
+    "isat2008_normalized": "17210",
+    "description": "Framleiðsla á bylgjupappír og -pappa og umbúðum úr pappír og pappa",
+    "isat2008": "17.21.0",
+    "description_en": "Manufacture of corrugated paper and paperboard and of containers of paper and paperboard"
+  },
+  {
+    "isat2008_normalized": "17220",
+    "description": "Framleiðsla á heimilis- og hreinlætisvörum úr pappír og pappa",
+    "isat2008": "17.22.0",
+    "description_en": "Manufacture of household and sanitary goods and of toilet requisites"
+  },
+  {
+    "isat2008_normalized": "17230",
+    "description": "Framleiðsla á skrifpappír og skrifstofuvörum úr pappír og pappa",
+    "isat2008": "17.23.0",
+    "description_en": "Manufacture of paper stationery"
+  },
+  {
+    "isat2008_normalized": "17240",
+    "description": "Framleiðsla á veggfóðri",
+    "isat2008": "17.24.0",
+    "description_en": "Manufacture of wallpaper"
+  },
+  {
+    "isat2008_normalized": "17290",
+    "description": "Framleiðsla á annarri pappírs- og pappavöru",
+    "isat2008": "17.29.0",
+    "description_en": "Manufacture of other articles of paper and paperboard"
+  },
+  {
+    "isat2008_normalized": "18110",
+    "description": "Prentun dagblaða",
+    "isat2008": "18.11.0",
+    "description_en": "Printing of newspapers"
+  },
+  {
+    "isat2008_normalized": "18120",
+    "description": "Önnur prentun",
+    "isat2008": "18.12.0",
+    "description_en": "Other printing"
+  },
+  {
+    "isat2008_normalized": "18130",
+    "description": "Undirbúningur fyrir prentun",
+    "isat2008": "18.13.0",
+    "description_en": "Pre-press and pre-media services"
+  },
+  {
+    "isat2008_normalized": "18140",
+    "description": "Bókband og tengd þjónusta",
+    "isat2008": "18.14.0",
+    "description_en": "Binding and related services"
+  },
+  {
+    "isat2008_normalized": "18200",
+    "description": "Fjölföldun upptekins efnis",
+    "isat2008": "18.20.0",
+    "description_en": "Reproduction of recorded media"
+  },
+  {
+    "isat2008_normalized": "19100",
+    "description": "Koksframleiðsla",
+    "isat2008": "19.10.0",
+    "description_en": "Manufacture of coke oven products"
+  },
+  {
+    "isat2008_normalized": "19200",
+    "description": "Framleiðsla á hreinsuðum olíuvörum",
+    "isat2008": "19.20.0",
+    "description_en": "Manufacture of refined petroleum products"
+  },
+  {
+    "isat2008_normalized": "20110",
+    "description": "Framleiðsla á iðnaðargasi",
+    "isat2008": "20.11.0",
+    "description_en": "Manufacture of industrial gases"
+  },
+  {
+    "isat2008_normalized": "20120",
+    "description": "Framleiðsla á lit og litarefnum",
+    "isat2008": "20.12.0",
+    "description_en": "Manufacture of dyes and pigments"
+  },
+  {
+    "isat2008_normalized": "20130",
+    "description": "Framleiðsla á öðrum ólífrænum grunnefnum til efnaiðnaðar",
+    "isat2008": "20.13.0",
+    "description_en": "Manufacture of other inorganic basic chemicals"
+  },
+  {
+    "isat2008_normalized": "20140",
+    "description": "Framleiðsla á öðrum lífrænum grunnefnum til efnaiðnaðar",
+    "isat2008": "20.14.0",
+    "description_en": "Manufacture of other organic basic chemicals"
+  },
+  {
+    "isat2008_normalized": "20150",
+    "description": "Framleiðsla á tilbúnum áburði og köfnunarefnissamböndum",
+    "isat2008": "20.15.0",
+    "description_en": "Manufacture of fertilisers and nitrogen compounds"
+  },
+  {
+    "isat2008_normalized": "20160",
+    "description": "Framleiðsla á plasthráefnum",
+    "isat2008": "20.16.0",
+    "description_en": "Manufacture of plastics in primary forms"
+  },
+  {
+    "isat2008_normalized": "20170",
+    "description": "Framleiðsla á syntetísku gúmmíi til úrvinnslu",
+    "isat2008": "20.17.0",
+    "description_en": "Manufacture of synthetic rubber in primary forms"
+  },
+  {
+    "isat2008_normalized": "20200",
+    "description": "Framleiðsla á skordýra- og illgresiseyði og öðrum efnum til nota í landbúnaði",
+    "isat2008": "20.20.0",
+    "description_en": "Manufacture of pesticides and other agrochemical products"
+  },
+  {
+    "isat2008_normalized": "20300",
+    "description": "Framleiðsla á málningu, lökkum og svipuðum þekjuefnum, prentbleki og fylli- og þéttiefnum",
+    "isat2008": "20.30.0",
+    "description_en": "Manufacture of paints, varnishes and similar coatings, printing ink and mastics"
+  },
+  {
+    "isat2008_normalized": "20410",
+    "description": "Framleiðsla á sápu, hreinsi- og þvottaefnum, hreingerningar- og fægiefnum",
+    "isat2008": "20.41.0",
+    "description_en": "Manufacture of soap and detergents, cleaning and polishing preparations"
+  },
+  {
+    "isat2008_normalized": "20420",
+    "description": "Framleiðsla á ilmvatni og snyrtivörum",
+    "isat2008": "20.42.0",
+    "description_en": "Manufacture of perfumes and toilet preparations"
+  },
+  {
+    "isat2008_normalized": "20510",
+    "description": "Framleiðsla á sprengiefnum",
+    "isat2008": "20.51.0",
+    "description_en": "Manufacture of explosives"
+  },
+  {
+    "isat2008_normalized": "20520",
+    "description": "Framleiðsla á lími",
+    "isat2008": "20.52.0",
+    "description_en": "Manufacture of glues"
+  },
+  {
+    "isat2008_normalized": "20530",
+    "description": "Framleiðsla á ilmolíum",
+    "isat2008": "20.53.0",
+    "description_en": "Manufacture of essential oils"
+  },
+  {
+    "isat2008_normalized": "20590",
+    "description": "Framleiðsla á annarri ótalinni efnavöru",
+    "isat2008": "20.59.0",
+    "description_en": "Manufacture of other chemical products n.e.c."
+  },
+  {
+    "isat2008_normalized": "20600",
+    "description": "Framleiðsla gerviþráðar",
+    "isat2008": "20.60.0",
+    "description_en": "Manufacture of man-made fibres"
+  },
+  {
+    "isat2008_normalized": "21100",
+    "description": "Framleiðsla á efnum til lyfjagerðar",
+    "isat2008": "21.10.0",
+    "description_en": "Manufacture of basic pharmaceutical products"
+  },
+  {
+    "isat2008_normalized": "21200",
+    "description": "Lyfjaframleiðsla",
+    "isat2008": "21.20.0",
+    "description_en": "Manufacture of pharmaceutical preparations"
+  },
+  {
+    "isat2008_normalized": "22110",
+    "description": "Framleiðsla á gúmmíhjólbörðum og hjólbarðaslöngum, sólun notaðra gúmmíhjólbarða",
+    "isat2008": "22.11.0",
+    "description_en": "Manufacture of rubber tyres and tubes; retreading and rebuilding of rubber tyres"
+  },
+  {
+    "isat2008_normalized": "22190",
+    "description": "Framleiðsla á öðrum gúmmívörum",
+    "isat2008": "22.19.0",
+    "description_en": "Manufacture of other rubber products"
+  },
+  {
+    "isat2008_normalized": "22210",
+    "description": "Framleiðsla á plötum, þynnum, slöngum og prófílum úr plasti",
+    "isat2008": "22.21.0",
+    "description_en": "Manufacture of plastic plates, sheets, tubes and profiles"
+  },
+  {
+    "isat2008_normalized": "22221",
+    "description": "Framleiðsla á plastvörum til nota í sjávarútvegi",
+    "isat2008": "22.22.1",
+    "description_en": "Manufacture of plastic products for the fisheries"
+  },
+  {
+    "isat2008_normalized": "22229",
+    "description": "Framleiðsla á öðru umbúðaplasti",
+    "isat2008": "22.22.9",
+    "description_en": "Manufacture of other plastic packing goods"
+  },
+  {
+    "isat2008_normalized": "22230",
+    "description": "Framleiðsla á byggingarvörum úr plasti",
+    "isat2008": "22.23.0",
+    "description_en": "Manufacture of builders’ ware of plastic"
+  },
+  {
+    "isat2008_normalized": "22290",
+    "description": "Framleiðsla á öðrum plastvörum",
+    "isat2008": "22.29.0",
+    "description_en": "Manufacture of other plastic products"
+  },
+  {
+    "isat2008_normalized": "23110",
+    "description": "Framleiðsla á flotgleri",
+    "isat2008": "23.11.0",
+    "description_en": "Manufacture of flat glass"
+  },
+  {
+    "isat2008_normalized": "23120",
+    "description": "Skurður og vinnsla á flotgleri",
+    "isat2008": "23.12.0",
+    "description_en": "Shaping and processing of flat glass"
+  },
+  {
+    "isat2008_normalized": "23130",
+    "description": "Framleiðsla á glerílátum",
+    "isat2008": "23.13.0",
+    "description_en": "Manufacture of hollow glass"
+  },
+  {
+    "isat2008_normalized": "23140",
+    "description": "Framleiðsla á glertrefjum",
+    "isat2008": "23.14.0",
+    "description_en": "Manufacture of glass fibres"
+  },
+  {
+    "isat2008_normalized": "23190",
+    "description": "Framleiðsla og vinnsla á öðru gleri, þ.m.t. glervara til tæknilegra nota",
+    "isat2008": "23.19.0",
+    "description_en": "Manufacture and processing of other glass, including technical glassware"
+  },
+  {
+    "isat2008_normalized": "23200",
+    "description": "Framleiðsla á eldföstum vörum",
+    "isat2008": "23.20.0",
+    "description_en": "Manufacture of refractory products"
+  },
+  {
+    "isat2008_normalized": "23310",
+    "description": "Framleiðsla á flísum og hellum úr leir",
+    "isat2008": "23.31.0",
+    "description_en": "Manufacture of ceramic tiles and flags"
+  },
+  {
+    "isat2008_normalized": "23320",
+    "description": "Framleiðsla á byggingarvörum úr brenndum leir",
+    "isat2008": "23.32.0",
+    "description_en": "Manufacture of bricks, tiles and construction products, in baked clay"
+  },
+  {
+    "isat2008_normalized": "23410",
+    "description": "Framleiðsla á heimilisvörum og skrautmunum úr leir og postulíni",
+    "isat2008": "23.41.0",
+    "description_en": "Manufacture of ceramic household and ornamental articles"
+  },
+  {
+    "isat2008_normalized": "23420",
+    "description": "Framleiðsla á hreinlætistækjum úr leir og postulíni",
+    "isat2008": "23.42.0",
+    "description_en": "Manufacture of ceramic sanitary fixtures"
+  },
+  {
+    "isat2008_normalized": "23430",
+    "description": "Framleiðsla á einangrurum og tengjum úr leir",
+    "isat2008": "23.43.0",
+    "description_en": "Manufacture of ceramic insulators and insulating fittings"
+  },
+  {
+    "isat2008_normalized": "23440",
+    "description": "Framleiðsla á annarri leirvöru til tæknilegra nota",
+    "isat2008": "23.44.0",
+    "description_en": "Manufacture of other technical ceramic products"
+  },
+  {
+    "isat2008_normalized": "23490",
+    "description": "Framleiðsla á öðrum leirvörum",
+    "isat2008": "23.49.0",
+    "description_en": "Manufacture of other ceramic products"
+  },
+  {
+    "isat2008_normalized": "23510",
+    "description": "Sementsframleiðsla",
+    "isat2008": "23.51.0",
+    "description_en": "Manufacture of cement"
+  },
+  {
+    "isat2008_normalized": "23520",
+    "description": "Kalk- og gifsframleiðsla",
+    "isat2008": "23.52.0",
+    "description_en": "Manufacture of lime and plaster"
+  },
+  {
+    "isat2008_normalized": "23610",
+    "description": "Framleiðsla á byggingarefni úr steinsteypu",
+    "isat2008": "23.61.0",
+    "description_en": "Manufacture of concrete products for construction purposes"
+  },
+  {
+    "isat2008_normalized": "23620",
+    "description": "Framleiðsla á byggingarefni úr gifsi",
+    "isat2008": "23.62.0",
+    "description_en": "Manufacture of plaster products for construction purposes"
+  },
+  {
+    "isat2008_normalized": "23630",
+    "description": "Framleiðsla á tilbúinni steinsteypu",
+    "isat2008": "23.63.0",
+    "description_en": "Manufacture of ready-mixed concrete"
+  },
+  {
+    "isat2008_normalized": "23640",
+    "description": "Framleiðsla á steinlími",
+    "isat2008": "23.64.0",
+    "description_en": "Manufacture of mortars"
+  },
+  {
+    "isat2008_normalized": "23650",
+    "description": "Framleiðsla á vörum úr trefjasementi",
+    "isat2008": "23.65.0",
+    "description_en": "Manufacture of fibre cement"
+  },
+  {
+    "isat2008_normalized": "23690",
+    "description": "Framleiðsla á öðrum vörum úr steinsteypu, sementi og gifsi",
+    "isat2008": "23.69.0",
+    "description_en": "Manufacture of other articles of concrete, plaster and cement"
+  },
+  {
+    "isat2008_normalized": "23700",
+    "description": "Steinsmíði",
+    "isat2008": "23.70.0",
+    "description_en": "Cutting, shaping and finishing of stone"
+  },
+  {
+    "isat2008_normalized": "23910",
+    "description": "Framleiðsla á vörum til slípunar",
+    "isat2008": "23.91.0",
+    "description_en": "Production of abrasive products"
+  },
+  {
+    "isat2008_normalized": "23990",
+    "description": "Framleiðsla á öðrum ótöldum vörum úr málmlausum steinefnum",
+    "isat2008": "23.99.0",
+    "description_en": "Manufacture of other non-metallic mineral products n.e.c."
+  },
+  {
+    "isat2008_normalized": "24100",
+    "description": "Framleiðsla á járni, stáli og járnblendi",
+    "isat2008": "24.10.0",
+    "description_en": "Manufacture of basic iron and steel and of ferro-alloys "
+  },
+  {
+    "isat2008_normalized": "24200",
+    "description": "Framleiðsla á rörum, pípum, holum prófílum og tengihlutum úr stáli",
+    "isat2008": "24.20.0",
+    "description_en": "Manufacture of tubes, pipes, hollow profiles and related fittings, of steel"
+  },
+  {
+    "isat2008_normalized": "24310",
+    "description": "Kalddráttur stanga",
+    "isat2008": "24.31.0",
+    "description_en": "Cold drawing of bars"
+  },
+  {
+    "isat2008_normalized": "24320",
+    "description": "Kaldvölsun flatstáls",
+    "isat2008": "24.32.0",
+    "description_en": "Cold rolling of narrow strip"
+  },
+  {
+    "isat2008_normalized": "24330",
+    "description": "Kaldmótun",
+    "isat2008": "24.33.0",
+    "description_en": "Cold forming or folding"
+  },
+  {
+    "isat2008_normalized": "24340",
+    "description": "Kalddráttur víra",
+    "isat2008": "24.34.0",
+    "description_en": "Cold drawing of wire"
+  },
+  {
+    "isat2008_normalized": "24410",
+    "description": "Framleiðsla góðmálma",
+    "isat2008": "24.41.0",
+    "description_en": "Precious metals production"
+  },
+  {
+    "isat2008_normalized": "24420",
+    "description": "Álframleiðsla",
+    "isat2008": "24.42.0",
+    "description_en": "Aluminium production"
+  },
+  {
+    "isat2008_normalized": "24430",
+    "description": "Blý-, sink- og tinframleiðsla",
+    "isat2008": "24.43.0",
+    "description_en": "Lead, zinc and tin production"
+  },
+  {
+    "isat2008_normalized": "24440",
+    "description": "Koparframleiðsla",
+    "isat2008": "24.44.0",
+    "description_en": "Copper production"
+  },
+  {
+    "isat2008_normalized": "24450",
+    "description": "Framleiðsla annarra málma sem ekki innihalda járn",
+    "isat2008": "24.45.0",
+    "description_en": "Other non-ferrous metal production"
+  },
+  {
+    "isat2008_normalized": "24460",
+    "description": "Vinnsla á kjarnorkueldsneyti",
+    "isat2008": "24.46.0",
+    "description_en": "Processing of nuclear fuel "
+  },
+  {
+    "isat2008_normalized": "24510",
+    "description": "Járnsteypa",
+    "isat2008": "24.51.0",
+    "description_en": "Casting of iron"
+  },
+  {
+    "isat2008_normalized": "24520",
+    "description": "Stálsteypa",
+    "isat2008": "24.52.0",
+    "description_en": "Casting of steel"
+  },
+  {
+    "isat2008_normalized": "24530",
+    "description": "Steypa léttmálma",
+    "isat2008": "24.53.0",
+    "description_en": "Casting of light metals"
+  },
+  {
+    "isat2008_normalized": "24540",
+    "description": "Steypa annarra málma sem ekki innihalda járn",
+    "isat2008": "24.54.0",
+    "description_en": "Casting of other non-ferrous metals"
+  },
+  {
+    "isat2008_normalized": "25110",
+    "description": "Framleiðsla á  burðarvirkjum og byggingareiningum úr málmi",
+    "isat2008": "25.11.0",
+    "description_en": "Manufacture of metal structures and parts of structures"
+  },
+  {
+    "isat2008_normalized": "25120",
+    "description": "Framleiðsla á hurðum og gluggum úr málmi",
+    "isat2008": "25.12.0",
+    "description_en": "Manufacture of doors and windows of metal"
+  },
+  {
+    "isat2008_normalized": "25210",
+    "description": "Framleiðsla á miðstöðvarofnum og -kötlum",
+    "isat2008": "25.21.0",
+    "description_en": "Manufacture of central heating radiators and boilers"
+  },
+  {
+    "isat2008_normalized": "25290",
+    "description": "Framleiðsla á öðrum geymum, kerum og ílátum úr málmi",
+    "isat2008": "25.29.0",
+    "description_en": "Manufacture of other tanks, reservoirs and containers of metal"
+  },
+  {
+    "isat2008_normalized": "25300",
+    "description": "Framleiðsla á gufukötlum, þó ekki miðstöðvarkötlum",
+    "isat2008": "25.30.0",
+    "description_en": "Manufacture of steam generators, except central heating hot water boilers"
+  },
+  {
+    "isat2008_normalized": "25400",
+    "description": "Vopna- og skotfæraframleiðsla",
+    "isat2008": "25.40.0",
+    "description_en": "Manufacture of weapons and ammunition"
+  },
+  {
+    "isat2008_normalized": "25500",
+    "description": "Eldsmíði og önnur málmsmíði; sindurmótun",
+    "isat2008": "25.50.0",
+    "description_en": "Forging, pressing, stamping and roll-forming of metal; powder metallurgy"
+  },
+  {
+    "isat2008_normalized": "25610",
+    "description": "Meðhöndlun og húðun málma",
+    "isat2008": "25.61.0",
+    "description_en": "Treatment and coating of metals"
+  },
+  {
+    "isat2008_normalized": "25620",
+    "description": "Vélvinnsla málma",
+    "isat2008": "25.62.0",
+    "description_en": "Machining"
+  },
+  {
+    "isat2008_normalized": "25710",
+    "description": "Framleiðsla á hnífapörum, hnífum, skærum, o.þ.h.",
+    "isat2008": "25.71.0",
+    "description_en": "Manufacture of cutlery"
+  },
+  {
+    "isat2008_normalized": "25720",
+    "description": "Framleiðsla á lásum og lömum",
+    "isat2008": "25.72.0",
+    "description_en": "Manufacture of locks and hinges"
+  },
+  {
+    "isat2008_normalized": "25730",
+    "description": "Framleiðsla á verkfærum, þó ekki vélknúnum",
+    "isat2008": "25.73.0",
+    "description_en": "Manufacture of tools"
+  },
+  {
+    "isat2008_normalized": "25910",
+    "description": "Framleiðsla á stáltunnum og svipuðum ílátum",
+    "isat2008": "25.91.0",
+    "description_en": "Manufacture of steel drums and similar containers"
+  },
+  {
+    "isat2008_normalized": "25920",
+    "description": "Framleiðsla á umbúðum úr léttmálmi",
+    "isat2008": "25.92.0",
+    "description_en": "Manufacture of light metal packaging "
+  },
+  {
+    "isat2008_normalized": "25930",
+    "description": "Framleiðsla á keðjum,  fjöðrum og vörum úr vír",
+    "isat2008": "25.93.0",
+    "description_en": "Manufacture of wire products, chain and springs"
+  },
+  {
+    "isat2008_normalized": "25940",
+    "description": "Framleiðsla á boltum og skrúfum",
+    "isat2008": "25.94.0",
+    "description_en": "Manufacture of fasteners and screw machine products"
+  },
+  {
+    "isat2008_normalized": "25990",
+    "description": "Framleiðsla á öðrum ótöldum málmvörum",
+    "isat2008": "25.99.0",
+    "description_en": "Manufacture of other fabricated metal products n.e.c."
+  },
+  {
+    "isat2008_normalized": "26110",
+    "description": "Framleiðsla á rafeindaíhlutum",
+    "isat2008": "26.11.0",
+    "description_en": "Manufacture of electronic components"
+  },
+  {
+    "isat2008_normalized": "26120",
+    "description": "Framleiðsla á fullbúnum rafeindaspjöldum",
+    "isat2008": "26.12.0",
+    "description_en": "Manufacture of loaded electronic boards"
+  },
+  {
+    "isat2008_normalized": "26200",
+    "description": "Framleiðsla á tölvum og jaðarbúnaði",
+    "isat2008": "26.20.0",
+    "description_en": "Manufacture of computers and peripheral equipment"
+  },
+  {
+    "isat2008_normalized": "26300",
+    "description": "Framleiðsla fjarskiptabúnaðar",
+    "isat2008": "26.30.0",
+    "description_en": "Manufacture of communication equipment"
+  },
+  {
+    "isat2008_normalized": "26400",
+    "description": "Framleiðsla á sjónvarps-, útvarps- og hljómtækjum og skyldum búnaði",
+    "isat2008": "26.40.0",
+    "description_en": "Manufacture of consumer electronics"
+  },
+  {
+    "isat2008_normalized": "26510",
+    "description": "Framleiðsla á tækjum og búnaði til mælinga, prófana og leiðsögu",
+    "isat2008": "26.51.0",
+    "description_en": "Manufacture of instruments and appliances for measuring, testing and navigation"
+  },
+  {
+    "isat2008_normalized": "26520",
+    "description": "Framleiðsla á úrum og klukkum",
+    "isat2008": "26.52.0",
+    "description_en": "Manufacture of watches and clocks"
+  },
+  {
+    "isat2008_normalized": "26600",
+    "description": "Framleiðsla á búnaði til geislunar, raftækjabúnaði til lækninga og meðferðar",
+    "isat2008": "26.60.0",
+    "description_en": "Manufacture of irradiation, electromedical and electrotherapeutic equipment"
+  },
+  {
+    "isat2008_normalized": "26700",
+    "description": "Framleiðsla á optískum tækjum og ljósmyndabúnaði",
+    "isat2008": "26.70.0",
+    "description_en": "Manufacture of optical instruments and photographic equipment"
+  },
+  {
+    "isat2008_normalized": "26800",
+    "description": "Framleiðsla á segul- og optískum miðlum",
+    "isat2008": "26.80.0",
+    "description_en": "Manufacture of magnetic and optical media"
+  },
+  {
+    "isat2008_normalized": "27110",
+    "description": "Framleiðsla á rafhreyflum, rafölum og spennubreytum",
+    "isat2008": "27.11.0",
+    "description_en": "Manufacture of electric motors, generators and transformers"
+  },
+  {
+    "isat2008_normalized": "27120",
+    "description": "Framleiðsla á dreifi- og stjórnbúnaði fyrir raforku",
+    "isat2008": "27.12.0",
+    "description_en": "Manufacture of electricity distribution and control apparatus"
+  },
+  {
+    "isat2008_normalized": "27200",
+    "description": "Framleiðsla rafhlaðna og rafgeyma",
+    "isat2008": "27.20.0",
+    "description_en": "Manufacture of batteries and accumulators"
+  },
+  {
+    "isat2008_normalized": "27310",
+    "description": "Framleiðsla á ljósleiðaraköplum",
+    "isat2008": "27.31.0",
+    "description_en": "Manufacture of fibre optic cables"
+  },
+  {
+    "isat2008_normalized": "27320",
+    "description": "Framleiðsla á öðrum rafeinda- og rafmagnsvírum og köplum",
+    "isat2008": "27.32.0",
+    "description_en": "Manufacture of other electronic and electric wires and cables"
+  },
+  {
+    "isat2008_normalized": "27330",
+    "description": "Framleiðsla á leiðslubúnaði",
+    "isat2008": "27.33.0",
+    "description_en": "Manufacture of wiring devices"
+  },
+  {
+    "isat2008_normalized": "27400",
+    "description": "Framleiðsla á rafljósabúnaði",
+    "isat2008": "27.40.0",
+    "description_en": "Manufacture of electric lighting equipment"
+  },
+  {
+    "isat2008_normalized": "27510",
+    "description": "Framleiðsla rafknúinna heimilistækja",
+    "isat2008": "27.51.0",
+    "description_en": "Manufacture of electric domestic appliances"
+  },
+  {
+    "isat2008_normalized": "27520",
+    "description": "Framleiðsla heimilistækja, annarra en rafknúinna",
+    "isat2008": "27.52.0",
+    "description_en": "Manufacture of non-electric domestic appliances"
+  },
+  {
+    "isat2008_normalized": "27900",
+    "description": "Framleiðsla á öðrum rafbúnaði",
+    "isat2008": "27.90.0",
+    "description_en": "Manufacture of other electrical equipment"
+  },
+  {
+    "isat2008_normalized": "28110",
+    "description": "Framleiðsla hreyfla og hverfla, þó ekki í loftför, ökutæki eða vélhjól",
+    "isat2008": "28.11.0",
+    "description_en": "Manufacture of engines and turbines, except aircraft, vehicle and cycle engines"
+  },
+  {
+    "isat2008_normalized": "28120",
+    "description": "Framleiðsla á vökvaaflsbúnaði",
+    "isat2008": "28.12.0",
+    "description_en": "Manufacture of fluid power equipment"
+  },
+  {
+    "isat2008_normalized": "28130",
+    "description": "Framleiðsla á öðrum dælum og þjöppum",
+    "isat2008": "28.13.0",
+    "description_en": "Manufacture of other pumps and compressors"
+  },
+  {
+    "isat2008_normalized": "28140",
+    "description": "Framleiðsla á krönum og lokum",
+    "isat2008": "28.14.0",
+    "description_en": "Manufacture of other taps and valves"
+  },
+  {
+    "isat2008_normalized": "28150",
+    "description": "Framleiðsla á legum, tannhjólum, drifum og drifbúnaði",
+    "isat2008": "28.15.0",
+    "description_en": "Manufacture of bearings, gears, gearing and driving elements"
+  },
+  {
+    "isat2008_normalized": "28210",
+    "description": "Framleiðsla á ofnum, bræðsluofnum og brennurum",
+    "isat2008": "28.21.0",
+    "description_en": "Manufacture of ovens, furnaces and furnace burners"
+  },
+  {
+    "isat2008_normalized": "28220",
+    "description": "Framleiðsla á lyftitækjum og færslubúnaði",
+    "isat2008": "28.22.0",
+    "description_en": "Manufacture of lifting and handling equipment"
+  },
+  {
+    "isat2008_normalized": "28230",
+    "description": "Framleiðsla á skrifstofuvélum og –búnaði, þó ekki tölvum og jaðarbúnaði",
+    "isat2008": "28.23.0",
+    "description_en": "Manufacture of office machinery and equipment (except computers and peripheral equipment)"
+  },
+  {
+    "isat2008_normalized": "28240",
+    "description": "Framleiðsla á aflknúnum handverkfærum",
+    "isat2008": "28.24.0",
+    "description_en": "Manufacture of power-driven hand tools"
+  },
+  {
+    "isat2008_normalized": "28250",
+    "description": "Framleiðsla á kæli- og loftræstibúnaði, þó ekki til  heimilisnota",
+    "isat2008": "28.25.0",
+    "description_en": "Manufacture of non-domestic cooling and ventilation equipment"
+  },
+  {
+    "isat2008_normalized": "28290",
+    "description": "Framleiðsla á öðrum ótöldum vélum til almennra nota",
+    "isat2008": "28.29.0",
+    "description_en": "Manufacture of other general-purpose machinery n.e.c."
+  },
+  {
+    "isat2008_normalized": "28300",
+    "description": "Framleiðsla á vélum til nota í landbúnaði og skógrækt",
+    "isat2008": "28.30.0",
+    "description_en": "Manufacture of agricultural and forestry machinery"
+  },
+  {
+    "isat2008_normalized": "28410",
+    "description": "Framleiðsla á vélum til mótunar á málmi",
+    "isat2008": "28.41.0",
+    "description_en": "Manufacture of metal forming machinery"
+  },
+  {
+    "isat2008_normalized": "28490",
+    "description": "Framleiðsla á öðrum ótöldum smíðavélum",
+    "isat2008": "28.49.0",
+    "description_en": "Manufacture of other machine tools"
+  },
+  {
+    "isat2008_normalized": "28910",
+    "description": "Framleiðsla á vélum til málmvinnslu",
+    "isat2008": "28.91.0",
+    "description_en": "Manufacture of machinery for metallurgy"
+  },
+  {
+    "isat2008_normalized": "28920",
+    "description": "Framleiðsla á vélum til mannvirkjagerðar, námugraftrar og vinnslu hráefna úr jörðu",
+    "isat2008": "28.92.0",
+    "description_en": "Manufacture of machinery for mining, quarrying and construction"
+  },
+  {
+    "isat2008_normalized": "28930",
+    "description": "Framleiðsla á vélum fyrir matvæla-, drykkjarvöru- og tóbaksvinnslu",
+    "isat2008": "28.93.0",
+    "description_en": "Manufacture of machinery for food, beverage and tobacco processing"
+  },
+  {
+    "isat2008_normalized": "28940",
+    "description": "Framleiðsla á vélum fyrir textíl-, fata- og leðurframleiðslu",
+    "isat2008": "28.94.0",
+    "description_en": "Manufacture of machinery for textile, apparel and leather production"
+  },
+  {
+    "isat2008_normalized": "28950",
+    "description": "Framleiðsla á vélum til pappírs- og pappaframleiðslu",
+    "isat2008": "28.95.0",
+    "description_en": "Manufacture of machinery for paper and paperboard production"
+  },
+  {
+    "isat2008_normalized": "28960",
+    "description": "Framleiðsla á vélum til plast- og gúmmívinnslu",
+    "isat2008": "28.96.0",
+    "description_en": "Manufacture of plastics and rubber machinery"
+  },
+  {
+    "isat2008_normalized": "28990",
+    "description": "Framleiðsla á öðrum ótöldum sérhæfðum vélum",
+    "isat2008": "28.99.0",
+    "description_en": "Manufacture of other special-purpose machinery n.e.c."
+  },
+  {
+    "isat2008_normalized": "29100",
+    "description": "Framleiðsla vélknúinna ökutækja",
+    "isat2008": "29.10.0",
+    "description_en": "Manufacture of motor vehicles"
+  },
+  {
+    "isat2008_normalized": "29200",
+    "description": "Smíði yfirbygginga fyrir vélknúin ökutæki og framleiðsla tengivagna",
+    "isat2008": "29.20.0",
+    "description_en": "Manufacture of bodies (coachwork) for motor vehicles; manufacture of trailers and semi-trailers"
+  },
+  {
+    "isat2008_normalized": "29310",
+    "description": "Framleiðsla á raf- og rafeindabúnaði í vélknúin ökutæki og hreyfla þeirra",
+    "isat2008": "29.31.0",
+    "description_en": "Manufacture of electrical and electronic equipment for motor vehicles"
+  },
+  {
+    "isat2008_normalized": "29320",
+    "description": "Framleiðsla á öðrum íhlutum og aukabúnaði í vélknúin ökutæki og hreyfla þeirra",
+    "isat2008": "29.32.0",
+    "description_en": "Manufacture of other parts and accessories for motor vehicles"
+  },
+  {
+    "isat2008_normalized": "30110",
+    "description": "Smíði skipa og annarra fljótandi mannvirkja",
+    "isat2008": "30.11.0",
+    "description_en": "Building of ships and floating structures"
+  },
+  {
+    "isat2008_normalized": "30120",
+    "description": "Smíði skemmti- og sportbáta",
+    "isat2008": "30.12.0",
+    "description_en": "Building of pleasure and sporting boats"
+  },
+  {
+    "isat2008_normalized": "30200",
+    "description": "Framleiðsla eimreiða og járnbrautarvagna",
+    "isat2008": "30.20.0",
+    "description_en": "Manufacture of railway locomotives and rolling stock"
+  },
+  {
+    "isat2008_normalized": "30300",
+    "description": "Framleiðsla á loft- og geimförum og tengdum vélbúnaði",
+    "isat2008": "30.30.0",
+    "description_en": "Manufacture of air and spacecraft and related machinery"
+  },
+  {
+    "isat2008_normalized": "30400",
+    "description": "Framleiðsla á hernaðarökutækjum",
+    "isat2008": "30.40.0",
+    "description_en": "Manufacture of military fighting vehicles"
+  },
+  {
+    "isat2008_normalized": "30910",
+    "description": "Framleiðsla vélhjóla",
+    "isat2008": "30.91.0",
+    "description_en": "Manufacture of motorcycles"
+  },
+  {
+    "isat2008_normalized": "30920",
+    "description": "Framleiðsla á reiðhjólum, barnavögnum og farartækjum fyrir hreyfihamlaða",
+    "isat2008": "30.92.0",
+    "description_en": "Manufacture of bicycles and invalid carriages"
+  },
+  {
+    "isat2008_normalized": "30990",
+    "description": "Framleiðsla annarra ótaldra farartækja",
+    "isat2008": "30.99.0",
+    "description_en": "Manufacture of other transport equipment n.e.c."
+  },
+  {
+    "isat2008_normalized": "31010",
+    "description": "Framleiðsla á húsgögnum og innréttingum fyrir atvinnuhúsnæði",
+    "isat2008": "31.01.0",
+    "description_en": "Manufacture of office and shop furniture"
+  },
+  {
+    "isat2008_normalized": "31020",
+    "description": "Framleiðsla á húsgögnum og innréttingum í eldhús",
+    "isat2008": "31.02.0",
+    "description_en": "Manufacture of kitchen furniture"
+  },
+  {
+    "isat2008_normalized": "31030",
+    "description": "Framleiðsla á dýnum",
+    "isat2008": "31.03.0",
+    "description_en": "Manufacture of mattresses"
+  },
+  {
+    "isat2008_normalized": "31090",
+    "description": "Framleiðsla á öðrum húsgögnum og innréttingum",
+    "isat2008": "31.09.0",
+    "description_en": "Manufacture of other furniture"
+  },
+  {
+    "isat2008_normalized": "32110",
+    "description": "Myntslátta",
+    "isat2008": "32.11.0",
+    "description_en": "Striking of coins"
+  },
+  {
+    "isat2008_normalized": "32120",
+    "description": "Skartgripasmíði og skyld framleiðsla",
+    "isat2008": "32.12.0",
+    "description_en": "Manufacture of jewellery and related articles"
+  },
+  {
+    "isat2008_normalized": "32130",
+    "description": "Framleiðsla á óekta skartgripum og skyldum vörum",
+    "isat2008": "32.13.0",
+    "description_en": "Manufacture of imitation jewellery and related articles"
+  },
+  {
+    "isat2008_normalized": "32200",
+    "description": "Hljóðfærasmíði",
+    "isat2008": "32.20.0",
+    "description_en": "Manufacture of musical instruments"
+  },
+  {
+    "isat2008_normalized": "32300",
+    "description": "Framleiðsla á íþróttavörum",
+    "isat2008": "32.30.0",
+    "description_en": "Manufacture of sports goods"
+  },
+  {
+    "isat2008_normalized": "32400",
+    "description": "Framleiðsla á spilum og leikföngum",
+    "isat2008": "32.40.0",
+    "description_en": "Manufacture of games and toys"
+  },
+  {
+    "isat2008_normalized": "32500",
+    "description": "Framleiðsla á tækjum og vörum til lækninga og tannlækninga",
+    "isat2008": "32.50.0",
+    "description_en": "Manufacture of medical and dental instruments and supplies"
+  },
+  {
+    "isat2008_normalized": "32910",
+    "description": "Framleiðsla á sópum og burstum",
+    "isat2008": "32.91.0",
+    "description_en": "Manufacture of brooms and brushes"
+  },
+  {
+    "isat2008_normalized": "32990",
+    "description": "Önnur ótalin framleiðsla",
+    "isat2008": "32.99.0",
+    "description_en": "Other manufacturing n.e.c. "
+  },
+  {
+    "isat2008_normalized": "33110",
+    "description": "Viðgerðir á málmvörum",
+    "isat2008": "33.11.0",
+    "description_en": "Repair of fabricated metal products"
+  },
+  {
+    "isat2008_normalized": "33120",
+    "description": "Viðgerðir á vélbúnaði",
+    "isat2008": "33.12.0",
+    "description_en": "Repair of machinery"
+  },
+  {
+    "isat2008_normalized": "33130",
+    "description": "Viðgerðir á rafeindabúnaði og optískum tækjum",
+    "isat2008": "33.13.0",
+    "description_en": "Repair of electronic and optical equipment"
+  },
+  {
+    "isat2008_normalized": "33140",
+    "description": "Viðgerðir á rafbúnaði",
+    "isat2008": "33.14.0",
+    "description_en": "Repair of electrical equipment"
+  },
+  {
+    "isat2008_normalized": "33150",
+    "description": "Viðgerðir og viðhald á skipum og bátum",
+    "isat2008": "33.15.0",
+    "description_en": "Repair and maintenance of ships and boats"
+  },
+  {
+    "isat2008_normalized": "33160",
+    "description": "Viðgerðir og viðhald á loftförum og geimförum",
+    "isat2008": "33.16.0",
+    "description_en": "Repair and maintenance of aircraft and spacecraft"
+  },
+  {
+    "isat2008_normalized": "33170",
+    "description": "Viðgerðir og viðhald á öðrum ótöldum flutningatækjum",
+    "isat2008": "33.17.0",
+    "description_en": "Repair and maintenance of other transport equipment"
+  },
+  {
+    "isat2008_normalized": "33190",
+    "description": "Viðgerðir á öðrum búnaði",
+    "isat2008": "33.19.0",
+    "description_en": "Repair of other equipment"
+  },
+  {
+    "isat2008_normalized": "33200",
+    "description": "Uppsetning á vélum og búnaði til nota í atvinnuskyni",
+    "isat2008": "33.20.0",
+    "description_en": "Installation of industrial machinery and equipment"
+  },
+  {
+    "isat2008_normalized": "35110",
+    "description": "Framleiðsla rafmagns",
+    "isat2008": "35.11.0",
+    "description_en": "Production of electricity"
+  },
+  {
+    "isat2008_normalized": "35120",
+    "description": "Flutningur rafmagns",
+    "isat2008": "35.12.0",
+    "description_en": "Transmission of electricity"
+  },
+  {
+    "isat2008_normalized": "35130",
+    "description": "Dreifing rafmagns",
+    "isat2008": "35.13.0",
+    "description_en": "Distribution of electricity"
+  },
+  {
+    "isat2008_normalized": "35140",
+    "description": "Viðskipti með rafmagn",
+    "isat2008": "35.14.0",
+    "description_en": "Trade of electricity"
+  },
+  {
+    "isat2008_normalized": "35210",
+    "description": "Gasframleiðsla",
+    "isat2008": "35.21.0",
+    "description_en": "Manufacture of gas"
+  },
+  {
+    "isat2008_normalized": "35220",
+    "description": "Dreifing á loftkenndu eldsneyti um leiðslur",
+    "isat2008": "35.22.0",
+    "description_en": "Distribution of gaseous fuels through mains"
+  },
+  {
+    "isat2008_normalized": "35230",
+    "description": "Viðskipti með gas um leiðslur",
+    "isat2008": "35.23.0",
+    "description_en": "Trade of gas through mains"
+  },
+  {
+    "isat2008_normalized": "35300",
+    "description": "Hitaveita; kæli- og loftræstiveita",
+    "isat2008": "35.30.0",
+    "description_en": "Steam and air conditioning supply"
+  },
+  {
+    "isat2008_normalized": "36000",
+    "description": "Vatnsveita, öflun og meðferð vatns",
+    "isat2008": "36.00.0",
+    "description_en": "Water collection, treatment and supply"
+  },
+  {
+    "isat2008_normalized": "37000",
+    "description": "Fráveita",
+    "isat2008": "37.00.0",
+    "description_en": "Sewerage"
+  },
+  {
+    "isat2008_normalized": "38110",
+    "description": "Söfnun hættulítils sorps",
+    "isat2008": "38.11.0",
+    "description_en": "Collection of non-hazardous waste"
+  },
+  {
+    "isat2008_normalized": "38120",
+    "description": "Söfnun hættulegs úrgangs",
+    "isat2008": "38.12.0",
+    "description_en": "Collection of hazardous waste"
+  },
+  {
+    "isat2008_normalized": "38210",
+    "description": "Meðhöndlun og förgun hættulítils sorps",
+    "isat2008": "38.21.0",
+    "description_en": "Treatment and disposal of non-hazardous waste"
+  },
+  {
+    "isat2008_normalized": "38220",
+    "description": "Meðhöndlun og förgun hættulegs úrgangs",
+    "isat2008": "38.22.0",
+    "description_en": "Treatment and disposal of hazardous waste"
+  },
+  {
+    "isat2008_normalized": "38310",
+    "description": "Niðurrif á ónýtum hlutum",
+    "isat2008": "38.31.0",
+    "description_en": "Dismantling of wrecks"
+  },
+  {
+    "isat2008_normalized": "38320",
+    "description": "Endurnýting flokkaðra efna",
+    "isat2008": "38.32.0",
+    "description_en": "Recovery of sorted materials"
+  },
+  {
+    "isat2008_normalized": "39000",
+    "description": "Afmengun og önnur þjónusta við meðhöndlun úrgangs",
+    "isat2008": "39.00.0",
+    "description_en": "Remediation activities and other waste management services"
+  },
+  {
+    "isat2008_normalized": "41100",
+    "description": "Þróun byggingarverkefna",
+    "isat2008": "41.10.0",
+    "description_en": "Development of building projects"
+  },
+  {
+    "isat2008_normalized": "41200",
+    "description": "Bygging íbúðar- og atvinnuhúsnæðis",
+    "isat2008": "41.20.0",
+    "description_en": "Construction of residential and non-residential buildings"
+  },
+  {
+    "isat2008_normalized": "42110",
+    "description": "Vegagerð",
+    "isat2008": "42.11.0",
+    "description_en": "Construction of roads and motorways"
+  },
+  {
+    "isat2008_normalized": "42120",
+    "description": "Lagning járnbrauta og neðanjarðarjárnbrauta",
+    "isat2008": "42.12.0",
+    "description_en": "Construction of railways and underground railways"
+  },
+  {
+    "isat2008_normalized": "42130",
+    "description": "Brúarsmíði og jarðgangagerð",
+    "isat2008": "42.13.0",
+    "description_en": "Construction of bridges and tunnels"
+  },
+  {
+    "isat2008_normalized": "42210",
+    "description": "Gerð þjónustumannvirkja fyrir vatn",
+    "isat2008": "42.21.0",
+    "description_en": "Construction of utility projects for fluids"
+  },
+  {
+    "isat2008_normalized": "42220",
+    "description": "Bygging þjónustumannvirkja fyrir rafmagn og fjarskipti",
+    "isat2008": "42.22.0",
+    "description_en": "Construction of utility projects for electricity and telecommunications"
+  },
+  {
+    "isat2008_normalized": "42910",
+    "description": "Gerð vatnsmannvirkja",
+    "isat2008": "42.91.0",
+    "description_en": "Construction of water projects"
+  },
+  {
+    "isat2008_normalized": "42990",
+    "description": "Bygging annarra ótalinna mannvirkja",
+    "isat2008": "42.99.0",
+    "description_en": "Construction of other civil engineering projects n.e.c."
+  },
+  {
+    "isat2008_normalized": "43110",
+    "description": "Niðurrif",
+    "isat2008": "43.11.0",
+    "description_en": "Demolition"
+  },
+  {
+    "isat2008_normalized": "43120",
+    "description": "Undirbúningsvinna á byggingarsvæði",
+    "isat2008": "43.12.0",
+    "description_en": "Site preparation"
+  },
+  {
+    "isat2008_normalized": "43130",
+    "description": "Tilraunaboranir og borvinna",
+    "isat2008": "43.13.0",
+    "description_en": "Test drilling and boring"
+  },
+  {
+    "isat2008_normalized": "43210",
+    "description": "Raflagnir",
+    "isat2008": "43.21.0",
+    "description_en": "Electrical installation"
+  },
+  {
+    "isat2008_normalized": "43220",
+    "description": "Pípulagnir, uppsetning hitunar- og loftræstikerfa",
+    "isat2008": "43.22.0",
+    "description_en": "Plumbing, heat and air-conditioning installation"
+  },
+  {
+    "isat2008_normalized": "43290",
+    "description": "Önnur uppsetning í mannvirki",
+    "isat2008": "43.29.0",
+    "description_en": "Other construction installation"
+  },
+  {
+    "isat2008_normalized": "43310",
+    "description": "Múrhúðun",
+    "isat2008": "43.31.0",
+    "description_en": "Plastering"
+  },
+  {
+    "isat2008_normalized": "43320",
+    "description": "Uppsetning innréttinga",
+    "isat2008": "43.32.0",
+    "description_en": "Joinery installation"
+  },
+  {
+    "isat2008_normalized": "43330",
+    "description": "Lagning gólfefna og veggefna",
+    "isat2008": "43.33.0",
+    "description_en": "Floor and wall covering"
+  },
+  {
+    "isat2008_normalized": "43341",
+    "description": "Málningarvinna",
+    "isat2008": "43.34.1",
+    "description_en": "Painting"
+  },
+  {
+    "isat2008_normalized": "43342",
+    "description": "Glerjun",
+    "isat2008": "43.34.2",
+    "description_en": "Glazing"
+  },
+  {
+    "isat2008_normalized": "43390",
+    "description": "Annar frágangur bygginga",
+    "isat2008": "43.39.0",
+    "description_en": "Other building completion and finishing"
+  },
+  {
+    "isat2008_normalized": "43910",
+    "description": "Vinna við þök",
+    "isat2008": "43.91.0",
+    "description_en": "Roofing activities"
+  },
+  {
+    "isat2008_normalized": "43990",
+    "description": "Önnur ótalin sérhæfð byggingarstarfsemi",
+    "isat2008": "43.99.0",
+    "description_en": "Other specialised construction activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "45110",
+    "description": "Bílasala",
+    "isat2008": "45.11.0",
+    "description_en": "Sale of cars and light motor vehicles"
+  },
+  {
+    "isat2008_normalized": "45191",
+    "description": "Sala á húsbílum og húsvögnum",
+    "isat2008": "45.19.1",
+    "description_en": "Sale of camping vehicles"
+  },
+  {
+    "isat2008_normalized": "45199",
+    "description": "Sala á öðrum ótöldum vélknúnum ökutækjum og tengivögnum",
+    "isat2008": "45.19.9",
+    "description_en": "Sale of other motor vehicles"
+  },
+  {
+    "isat2008_normalized": "45201",
+    "description": "Almenn bílaverkstæði",
+    "isat2008": "45.20.1",
+    "description_en": "General maintenance and repair of motor vehicles"
+  },
+  {
+    "isat2008_normalized": "45202",
+    "description": "Bílaréttingar og -sprautun",
+    "isat2008": "45.20.2",
+    "description_en": "Bodywork repair and painting of motor vehicles"
+  },
+  {
+    "isat2008_normalized": "45203",
+    "description": "Dekkjaverkstæði og smurstöðvar",
+    "isat2008": "45.20.3",
+    "description_en": "Tyre and lubrication services"
+  },
+  {
+    "isat2008_normalized": "45204",
+    "description": "Bón- og þvottastöðvar",
+    "isat2008": "45.20.4",
+    "description_en": "Washing and  polishing of motor vehicles"
+  },
+  {
+    "isat2008_normalized": "45310",
+    "description": "Heildverslun með varahluti og aukabúnað í bíla",
+    "isat2008": "45.31.0",
+    "description_en": "Wholesale trade of motor vehicle parts and accessories"
+  },
+  {
+    "isat2008_normalized": "45320",
+    "description": "Smásala á varahlutum og aukabúnaði í bíla",
+    "isat2008": "45.32.0",
+    "description_en": "Retail trade of motor vehicle parts and accessories"
+  },
+  {
+    "isat2008_normalized": "45400",
+    "description": "Sala, viðhald og viðgerðir vélhjóla og hluta og aukabúnaðar til þeirra",
+    "isat2008": "45.40.0",
+    "description_en": "Sale, maintenance and repair of motorcycles and related parts and accessories"
+  },
+  {
+    "isat2008_normalized": "46110",
+    "description": "Umboðsverslun með hráefni úr landbúnaði, lifandi dýr, textílhráefni og hálfunna vöru",
+    "isat2008": "46.11.0",
+    "description_en": "Agents involved in the sale of agricultural raw materials, live animals, textile raw materials and semi-finished goods"
+  },
+  {
+    "isat2008_normalized": "46120",
+    "description": "Umboðsverslun með eldsneyti, málmgrýti, málma og íðefni til iðnaðarnota",
+    "isat2008": "46.12.0",
+    "description_en": "Agents involved in the sale of fuels, ores, metals and industrial chemicals"
+  },
+  {
+    "isat2008_normalized": "46130",
+    "description": "Umboðsverslun með timbur og byggingarefni",
+    "isat2008": "46.13.0",
+    "description_en": "Agents involved in the sale of timber and building materials"
+  },
+  {
+    "isat2008_normalized": "46140",
+    "description": "Umboðsverslun með vélar, iðnaðarvélar, skip og loftför",
+    "isat2008": "46.14.0",
+    "description_en": "Agents involved in the sale of machinery, industrial equipment, ships and aircraft"
+  },
+  {
+    "isat2008_normalized": "46150",
+    "description": "Umboðsverslun með húsgögn, heimilisbúnað og járnvörur",
+    "isat2008": "46.15.0",
+    "description_en": "Agents involved in the sale of furniture, household goods, hardware and ironmongery"
+  },
+  {
+    "isat2008_normalized": "46160",
+    "description": "Umboðsverslun með textílefni, fatnað, loðfelda, skófatnað og leðurvörur",
+    "isat2008": "46.16.0",
+    "description_en": "Agents involved in the sale of textiles, clothing, fur, footwear and leather goods"
+  },
+  {
+    "isat2008_normalized": "46171",
+    "description": "Umboðsverslun með fisk og fiskafurðir",
+    "isat2008": "46.17.1",
+    "description_en": "Agents involved in the sale of marine products"
+  },
+  {
+    "isat2008_normalized": "46172",
+    "description": "Fiskmarkaðir",
+    "isat2008": "46.17.2",
+    "description_en": "Fish markets"
+  },
+  {
+    "isat2008_normalized": "46179",
+    "description": "Umboðsverslun með aðra matvöru, drykkjarvöru og tóbak",
+    "isat2008": "46.17.9",
+    "description_en": "Agents involved in the sale of food, beverages and tobacco, excl. marine products"
+  },
+  {
+    "isat2008_normalized": "46180",
+    "description": "Umboðsverslun sem sérhæfir sig í sölu á öðrum tilteknum vörum eða vöruflokkum",
+    "isat2008": "46.18.0",
+    "description_en": "Agents specialised in the sale of other particular products"
+  },
+  {
+    "isat2008_normalized": "46190",
+    "description": "Blönduð umboðsverslun",
+    "isat2008": "46.19.0",
+    "description_en": "Agents involved in the sale of a variety of goods"
+  },
+  {
+    "isat2008_normalized": "46210",
+    "description": "Heildverslun með korn, óunnið tóbak, fræ og dýrafóður",
+    "isat2008": "46.21.0",
+    "description_en": "Wholesale of grain, unmanufactured tobacco, seeds and animal feeds"
+  },
+  {
+    "isat2008_normalized": "46220",
+    "description": "Heildverslun með blóm og plöntur",
+    "isat2008": "46.22.0",
+    "description_en": "Wholesale of flowers and plants"
+  },
+  {
+    "isat2008_normalized": "46230",
+    "description": "Heildverslun með lifandi dýr",
+    "isat2008": "46.23.0",
+    "description_en": "Wholesale of live animals"
+  },
+  {
+    "isat2008_normalized": "46240",
+    "description": "Heildverslun með húðir, skinn og leður",
+    "isat2008": "46.24.0",
+    "description_en": "Wholesale of hides, skins and leather"
+  },
+  {
+    "isat2008_normalized": "46310",
+    "description": "Heildverslun með ávexti og grænmeti",
+    "isat2008": "46.31.0",
+    "description_en": "Wholesale of fruit and vegetables"
+  },
+  {
+    "isat2008_normalized": "46320",
+    "description": "Heildverslun með kjöt og kjötvöru",
+    "isat2008": "46.32.0",
+    "description_en": "Wholesale of meat and meat products"
+  },
+  {
+    "isat2008_normalized": "46330",
+    "description": "Heildverslun með mjólkurafurðir, egg, matarolíu og -feiti",
+    "isat2008": "46.33.0",
+    "description_en": "Wholesale of dairy products, eggs and edible oils and fats"
+  },
+  {
+    "isat2008_normalized": "46340",
+    "description": "Heildverslun með drykkjarvörur",
+    "isat2008": "46.34.0",
+    "description_en": "Wholesale of beverages"
+  },
+  {
+    "isat2008_normalized": "46350",
+    "description": "Heildverslun með tóbaksvöru",
+    "isat2008": "46.35.0",
+    "description_en": "Wholesale of tobacco products"
+  },
+  {
+    "isat2008_normalized": "46360",
+    "description": "Heildverslun með sykur, súkkulaði og sælgæti",
+    "isat2008": "46.36.0",
+    "description_en": "Wholesale of sugar and chocolate and sugar confectionery"
+  },
+  {
+    "isat2008_normalized": "46370",
+    "description": "Heildverslun með kaffi, te, kakó og krydd",
+    "isat2008": "46.37.0",
+    "description_en": "Wholesale of coffee, tea, cocoa and spices"
+  },
+  {
+    "isat2008_normalized": "46381",
+    "description": "Heildverslun með fisk og fiskafurðir",
+    "isat2008": "46.38.1",
+    "description_en": "Wholesale of fish and fish products"
+  },
+  {
+    "isat2008_normalized": "46389",
+    "description": "Heildverslun með önnur ótalin matvæli",
+    "isat2008": "46.38.9",
+    "description_en": "Wholesale of other food n.e.c."
+  },
+  {
+    "isat2008_normalized": "46390",
+    "description": "Blönduð heildverslun með matvæli, drykkjarvöru og tóbak",
+    "isat2008": "46.39.0",
+    "description_en": "Non-specialised wholesale of food, beverages and tobacco"
+  },
+  {
+    "isat2008_normalized": "46410",
+    "description": "Heildverslun með textílvöru",
+    "isat2008": "46.41.0",
+    "description_en": "Wholesale of textiles"
+  },
+  {
+    "isat2008_normalized": "46420",
+    "description": "Heildverslun með fatnað og skófatnað",
+    "isat2008": "46.42.0",
+    "description_en": "Wholesale of clothing and footwear"
+  },
+  {
+    "isat2008_normalized": "46430",
+    "description": "Heildverslun með heimilistæki, útvörp, sjónvörp og tengdar vörur",
+    "isat2008": "46.43.0",
+    "description_en": "Wholesale of electrical household appliances"
+  },
+  {
+    "isat2008_normalized": "46441",
+    "description": "Heildverslun með postulín og glervöru",
+    "isat2008": "46.44.1",
+    "description_en": "Wholesale of china and glassware"
+  },
+  {
+    "isat2008_normalized": "46442",
+    "description": "Heildverslun með hreingerningarefni",
+    "isat2008": "46.44.2",
+    "description_en": "Wholesale of cleaning materials"
+  },
+  {
+    "isat2008_normalized": "46450",
+    "description": "Heildverslun með ilmvötn og snyrtivörur",
+    "isat2008": "46.45.0",
+    "description_en": "Wholesale of perfume and cosmetics"
+  },
+  {
+    "isat2008_normalized": "46460",
+    "description": "Heildverslun með lyf og lækningavörur",
+    "isat2008": "46.46.0",
+    "description_en": "Wholesale of pharmaceutical goods"
+  },
+  {
+    "isat2008_normalized": "46470",
+    "description": "Heildverslun með húsgögn, teppi og ljósabúnað",
+    "isat2008": "46.47.0",
+    "description_en": "Wholesale of furniture, carpets and lighting equipment"
+  },
+  {
+    "isat2008_normalized": "46480",
+    "description": "Heildverslun með úr og skartgripi",
+    "isat2008": "46.48.0",
+    "description_en": "Wholesale of watches and jewellery"
+  },
+  {
+    "isat2008_normalized": "46490",
+    "description": "Heildverslun með aðrar vörur til heimilisnota",
+    "isat2008": "46.49.0",
+    "description_en": "Wholesale of other household goods"
+  },
+  {
+    "isat2008_normalized": "46510",
+    "description": "Heildverslun með tölvur, jaðartæki fyrir tölvur og hugbúnað",
+    "isat2008": "46.51.0",
+    "description_en": "Wholesale of computers, computer peripheral equipment and software"
+  },
+  {
+    "isat2008_normalized": "46520",
+    "description": "Heildverslun með rafeinda- og fjarskiptabúnað og tengda hluti",
+    "isat2008": "46.52.0",
+    "description_en": "Wholesale of electronic and telecommunications equipment and parts"
+  },
+  {
+    "isat2008_normalized": "46610",
+    "description": "Heildverslun með landbúnaðarvélar, -tæki og hluti til þeirra",
+    "isat2008": "46.61.0",
+    "description_en": "Wholesale of agricultural machinery, equipment and supplies"
+  },
+  {
+    "isat2008_normalized": "46620",
+    "description": "Heildverslun með smíðavélar",
+    "isat2008": "46.62.0",
+    "description_en": "Wholesale of machine tools"
+  },
+  {
+    "isat2008_normalized": "46630",
+    "description": "Heildverslun með vélbúnað til námavinnslu, byggingarstarfsemi og mannvirkjagerðar",
+    "isat2008": "46.63.0",
+    "description_en": "Wholesale of mining, construction and civil engineering machinery"
+  },
+  {
+    "isat2008_normalized": "46640",
+    "description": "Heildverslun með vélar til textíliðnaðar, sauma- og prjónavélar",
+    "isat2008": "46.64.0",
+    "description_en": "Wholesale of machinery for the textile industry and of sewing and knitting machines"
+  },
+  {
+    "isat2008_normalized": "46650",
+    "description": "Heildverslun með skrifstofuhúsgögn",
+    "isat2008": "46.65.0",
+    "description_en": "Wholesale of office furniture"
+  },
+  {
+    "isat2008_normalized": "46660",
+    "description": "Heildverslun með aðrar skrifstofuvélar og tæki",
+    "isat2008": "46.66.0",
+    "description_en": "Wholesale of other office machinery and equipment"
+  },
+  {
+    "isat2008_normalized": "46691",
+    "description": "Heildverslun með skipsbúnað, veiðarfæri og fiskvinnsluvélar",
+    "isat2008": "46.69.1",
+    "description_en": "Wholesale of fishing gear and fish-processing machinery"
+  },
+  {
+    "isat2008_normalized": "46699",
+    "description": "Heildverslun með aðrar ótaldar vélar og tæki",
+    "isat2008": "46.69.9",
+    "description_en": "Wholesale of other machinery and equipment n.e.c."
+  },
+  {
+    "isat2008_normalized": "46710",
+    "description": "Heildverslun með fast, fljótandi og loftkennt eldsneyti og skyldar vörur",
+    "isat2008": "46.71.0",
+    "description_en": "Wholesale of solid, liquid and gaseous fuels and related products"
+  },
+  {
+    "isat2008_normalized": "46720",
+    "description": "Heildverslun með málma og málmgrýti",
+    "isat2008": "46.72.0",
+    "description_en": "Wholesale of metals and metal ores"
+  },
+  {
+    "isat2008_normalized": "46730",
+    "description": "Heildverslun með timbur, byggingarefni og hreinlætistæki",
+    "isat2008": "46.73.0",
+    "description_en": "Wholesale of wood, construction materials and sanitary equipment"
+  },
+  {
+    "isat2008_normalized": "46740",
+    "description": "Heildverslun með járnvöru, búnað til pípu- og hitalagna og hluti til þeirra",
+    "isat2008": "46.74.0",
+    "description_en": "Wholesale of hardware, plumbing and heating equipment and supplies"
+  },
+  {
+    "isat2008_normalized": "46750",
+    "description": "Heildverslun með efnavörur",
+    "isat2008": "46.75.0",
+    "description_en": "Wholesale of chemical products"
+  },
+  {
+    "isat2008_normalized": "46760",
+    "description": "Heildverslun með aðrar hálfunnar vörur",
+    "isat2008": "46.76.0",
+    "description_en": "Wholesale of other intermediate products"
+  },
+  {
+    "isat2008_normalized": "46770",
+    "description": "Heildverslun með úrgangsefni og brotajárn",
+    "isat2008": "46.77.0",
+    "description_en": "Wholesale of waste and scrap"
+  },
+  {
+    "isat2008_normalized": "46900",
+    "description": "Blönduð heildverslun",
+    "isat2008": "46.90.0",
+    "description_en": "Non-specialised wholesale trade"
+  },
+  {
+    "isat2008_normalized": "47111",
+    "description": "Stórmarkaðir og matvöruverslanir",
+    "isat2008": "47.11.1",
+    "description_en": "Supermarkets and convenience stores"
+  },
+  {
+    "isat2008_normalized": "47112",
+    "description": "Söluturnar",
+    "isat2008": "47.11.2",
+    "description_en": "Kiosks"
+  },
+  {
+    "isat2008_normalized": "47190",
+    "description": "Önnur blönduð smásala",
+    "isat2008": "47.19.0",
+    "description_en": "Other retail sale in non-specialised stores"
+  },
+  {
+    "isat2008_normalized": "47210",
+    "description": "Smásala á ávöxtum og grænmeti í sérverslunum",
+    "isat2008": "47.21.0",
+    "description_en": "Retail sale of fruit and vegetables in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47220",
+    "description": "Smásala á kjöti og kjötvöru í sérverslunum",
+    "isat2008": "47.22.0",
+    "description_en": "Retail sale of meat and meat products in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47230",
+    "description": "Fiskbúðir",
+    "isat2008": "47.23.0",
+    "description_en": "Retail sale of fish, crustaceans and molluscs in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47240",
+    "description": "Smásala á brauði, kökum, sætabrauði og sælgæti í sérverslunum",
+    "isat2008": "47.24.0",
+    "description_en": "Retail sale of bread, cakes, flour confectionery and sugar confectionery in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47250",
+    "description": "Smásala á drykkjarvöru í sérverslunum",
+    "isat2008": "47.25.0",
+    "description_en": "Retail sale of beverages in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47260",
+    "description": "Smásala á tóbaksvörum í sérverslunum",
+    "isat2008": "47.26.0",
+    "description_en": "Retail sale of tobacco products in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47290",
+    "description": "Önnur smásala á matvælum í sérverslunum",
+    "isat2008": "47.29.0",
+    "description_en": "Other retail sale of food in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47300",
+    "description": "Bensínstöðvar",
+    "isat2008": "47.30.0",
+    "description_en": "Retail sale of automotive fuel in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47410",
+    "description": "Smásala á tölvum, jaðarbúnaði og hugbúnaði í sérverslunum",
+    "isat2008": "47.41.0",
+    "description_en": "Retail sale of computers, peripheral units and software in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47420",
+    "description": "Smásala á fjarskiptabúnaði í sérverslunum",
+    "isat2008": "47.42.0",
+    "description_en": "Retail sale of telecommunications equipment in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47430",
+    "description": "Smásala á hljóð- og myndbandsbúnaði í sérverslunum",
+    "isat2008": "47.43.0",
+    "description_en": "Retail sale of audio and video equipment in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47510",
+    "description": "Smásala á textílvörum í sérverslunum",
+    "isat2008": "47.51.0",
+    "description_en": "Retail sale of textiles in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47521",
+    "description": "Smásala á járn- og byggingarvöru í sérverslunum",
+    "isat2008": "47.52.1",
+    "description_en": "Retail sale of hardware in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47522",
+    "description": "Smásala á málningu í sérverslunum",
+    "isat2008": "47.52.2",
+    "description_en": "Retail sale of paints and glass in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47530",
+    "description": "Smásala á teppum, mottum, gluggatjöldum, vegg- og gólfefnum í sérverslunum",
+    "isat2008": "47.53.0",
+    "description_en": "Retail sale of carpets, rugs, wall and floor coverings in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47540",
+    "description": "Smásala á heimilistækjum í sérverslunum",
+    "isat2008": "47.54.0",
+    "description_en": "Retail sale of electrical household appliances in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47591",
+    "description": "Smásala á húsgögnum í sérverslunum",
+    "isat2008": "47.59.1",
+    "description_en": "Retail sale of furniture in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47592",
+    "description": "Smásala á ljósabúnaði í sérverslunum",
+    "isat2008": "47.59.2",
+    "description_en": "Retail sale of lighting equipment in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47593",
+    "description": "Smásala á hljóðfærum í sérverslunum",
+    "isat2008": "47.59.3",
+    "description_en": "Retail sale of musical instruments in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47599",
+    "description": "Smásala á öðrum ótöldum heimilisbúnaði í sérverslunum",
+    "isat2008": "47.59.9",
+    "description_en": "Retail sale of other household articles in specialised stores, n.e.c."
+  },
+  {
+    "isat2008_normalized": "47610",
+    "description": "Smásala á bókum í sérverslunum",
+    "isat2008": "47.61.0",
+    "description_en": "Retail sale of books in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47620",
+    "description": "Smásala á dagblöðum og ritföngum í sérverslunum",
+    "isat2008": "47.62.0",
+    "description_en": "Retail sale of newspapers and stationery in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47630",
+    "description": "Smásala á tónlistar- og myndupptökum í sérverslunum",
+    "isat2008": "47.63.0",
+    "description_en": "Retail sale of music and video recordings in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47640",
+    "description": "Smásala á íþrótta- og tómstundabúnaði í sérverslunum",
+    "isat2008": "47.64.0",
+    "description_en": "Retail sale of sporting equipment in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47650",
+    "description": "Smásala á spilum og leikföngum í sérverslunum",
+    "isat2008": "47.65.0",
+    "description_en": "Retail sale of games and toys in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47711",
+    "description": "Fataverslanir",
+    "isat2008": "47.71.1",
+    "description_en": "Retail sale of clothing (execpt children's clothing) in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47712",
+    "description": "Barnafataverslanir",
+    "isat2008": "47.71.2",
+    "description_en": "Retail sale of children's clothing in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47721",
+    "description": "Smásala á skófatnaði í sérverslunum",
+    "isat2008": "47.72.1",
+    "description_en": "Retail sale of footwear in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47722",
+    "description": "Smásala á leðurvörum í sérverslunum",
+    "isat2008": "47.72.2",
+    "description_en": "Retail sale of leather goods in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47730",
+    "description": "Lyfjaverslanir",
+    "isat2008": "47.73.0",
+    "description_en": "Dispensing chemist in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47740",
+    "description": "Smásala á lækninga- og hjúkrunarvörum í sérverslunum",
+    "isat2008": "47.74.0",
+    "description_en": "Retail sale of medical and orthopaedic goods in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47750",
+    "description": "Smásala á snyrtivörum og sápum í sérverslunum",
+    "isat2008": "47.75.0",
+    "description_en": "Retail sale of cosmetic and toilet articles in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47761",
+    "description": "Smásala á blómum, plöntum, fræjum og áburði í sérverslunum",
+    "isat2008": "47.76.1",
+    "description_en": "Retail sale of flowers, plants, seeds and fertilisers in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47762",
+    "description": "Smásala á gæludýrum og gæludýrafóðri í sérverslunum",
+    "isat2008": "47.76.2",
+    "description_en": "Retail sale of pet animals and pet food in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47770",
+    "description": "Smásala á úrum og skartgripum í sérverslunum",
+    "isat2008": "47.77.0",
+    "description_en": "Retail sale of watches and jewellery in specialised stores"
+  },
+  {
+    "isat2008_normalized": "47781",
+    "description": "Smásala á gleraugum og sjóntækjum í sérverslunum",
+    "isat2008": "47.78.1",
+    "description_en": "Retail sale of glasses and optical equipment"
+  },
+  {
+    "isat2008_normalized": "47782",
+    "description": "Smásala á ljósmyndavörum í sérverslunum",
+    "isat2008": "47.78.2",
+    "description_en": "Retail sale of photographic equipment"
+  },
+  {
+    "isat2008_normalized": "47783",
+    "description": "Starfsemi listmunahúsa og listaverkasala",
+    "isat2008": "47.78.3",
+    "description_en": "Activities of commercial art galleries"
+  },
+  {
+    "isat2008_normalized": "47789",
+    "description": "Önnur ótalin smásala á nýjum vörum í sérverslunum",
+    "isat2008": "47.78.9",
+    "description_en": "Other retail sale of new goods in specialised stores, n.e.c."
+  },
+  {
+    "isat2008_normalized": "47790",
+    "description": "Smásala á notuðum vörum í verslunum",
+    "isat2008": "47.79.0",
+    "description_en": "Retail sale of second-hand goods in stores"
+  },
+  {
+    "isat2008_normalized": "47810",
+    "description": "Smásala á mat-, drykkjar- og tóbaksvörum úr söluvögnum og á mörkuðum",
+    "isat2008": "47.81.0",
+    "description_en": "Retail sale via stalls and markets of food, beverages and tobacco products"
+  },
+  {
+    "isat2008_normalized": "47820",
+    "description": "Smásala á textílvörum, fatnaði og skófatnaði úr söluvögnum og á mörkuðum",
+    "isat2008": "47.82.0",
+    "description_en": "Retail sale via stalls and markets of textiles, clothing and footwear"
+  },
+  {
+    "isat2008_normalized": "47890",
+    "description": "Smásala á öðrum vörum úr söluvögnum og á mörkuðum",
+    "isat2008": "47.89.0",
+    "description_en": "Retail sale via stalls and markets of other goods"
+  },
+  {
+    "isat2008_normalized": "47910",
+    "description": "Smásala póstverslana eða um Netið",
+    "isat2008": "47.91.0",
+    "description_en": "Retail sale via mail order houses or via Internet"
+  },
+  {
+    "isat2008_normalized": "47990",
+    "description": "Önnur smásala, ekki í verslunum, úr söluvögnum eða á mörkuðum",
+    "isat2008": "47.99.0",
+    "description_en": "Other retail sale not in stores, stalls or markets"
+  },
+  {
+    "isat2008_normalized": "49100",
+    "description": "Farþegaflutningar með járnbrautarlestum milli borga",
+    "isat2008": "49.10.0",
+    "description_en": "Passenger rail transport, interurban"
+  },
+  {
+    "isat2008_normalized": "49200",
+    "description": "Vöruflutningar með járnbrautarlestum",
+    "isat2008": "49.20.0",
+    "description_en": "Freight rail transport"
+  },
+  {
+    "isat2008_normalized": "49310",
+    "description": "Farþegaflutningar á landi, innanbæjar og í úthverfum",
+    "isat2008": "49.31.0",
+    "description_en": "Urban and suburban passenger land transport"
+  },
+  {
+    "isat2008_normalized": "49320",
+    "description": "Rekstur leigubíla",
+    "isat2008": "49.32.0",
+    "description_en": "Taxi operation"
+  },
+  {
+    "isat2008_normalized": "49390",
+    "description": "Aðrir farþegaflutningar á landi",
+    "isat2008": "49.39.0",
+    "description_en": "Other passenger land transport n.e.c."
+  },
+  {
+    "isat2008_normalized": "49411",
+    "description": "Akstur sendibíla",
+    "isat2008": "49.41.1",
+    "description_en": "Delivery van services"
+  },
+  {
+    "isat2008_normalized": "49412",
+    "description": "Akstur vörubíla",
+    "isat2008": "49.41.2",
+    "description_en": "Open-lorry services"
+  },
+  {
+    "isat2008_normalized": "49419",
+    "description": "Aðrir vöruflutningar á vegum",
+    "isat2008": "49.41.9",
+    "description_en": "Other lorry services (incl. container trucks)"
+  },
+  {
+    "isat2008_normalized": "49420",
+    "description": "Flutningsþjónusta",
+    "isat2008": "49.42.0",
+    "description_en": "Removal services"
+  },
+  {
+    "isat2008_normalized": "49500",
+    "description": "Flutningar eftir leiðslum",
+    "isat2008": "49.50.0",
+    "description_en": "Transport via pipeline"
+  },
+  {
+    "isat2008_normalized": "50100",
+    "description": "Millilanda- og strandsiglingar með farþega",
+    "isat2008": "50.10.0",
+    "description_en": "Sea and coastal passenger water transport"
+  },
+  {
+    "isat2008_normalized": "50200",
+    "description": "Millilanda- og strandsiglingar með vörur",
+    "isat2008": "50.20.0",
+    "description_en": "Sea and coastal freight water transport"
+  },
+  {
+    "isat2008_normalized": "50300",
+    "description": "Farþegaflutningar á skipgengum vatnaleiðum",
+    "isat2008": "50.30.0",
+    "description_en": "Inland passenger water transport"
+  },
+  {
+    "isat2008_normalized": "50400",
+    "description": "Vöruflutningar á skipgengum vatnaleiðum",
+    "isat2008": "50.40.0",
+    "description_en": "Inland freight water transport"
+  },
+  {
+    "isat2008_normalized": "51101",
+    "description": "Farþegaflutningar með áætlunarflugi",
+    "isat2008": "51.10.1",
+    "description_en": "Scheduled air transport"
+  },
+  {
+    "isat2008_normalized": "51102",
+    "description": "Farþegaflutningar með leiguflugi",
+    "isat2008": "51.10.2",
+    "description_en": "Non-scheduled air transport"
+  },
+  {
+    "isat2008_normalized": "51210",
+    "description": "Vöruflutningar með flugi",
+    "isat2008": "51.21.0",
+    "description_en": "Freight air transport"
+  },
+  {
+    "isat2008_normalized": "51220",
+    "description": "Geimferðir",
+    "isat2008": "51.22.0",
+    "description_en": "Space transport"
+  },
+  {
+    "isat2008_normalized": "52100",
+    "description": "Vörugeymsla",
+    "isat2008": "52.10.0",
+    "description_en": "Warehousing and storage"
+  },
+  {
+    "isat2008_normalized": "52210",
+    "description": "Þjónustustarfsemi tengd flutningum á landi",
+    "isat2008": "52.21.0",
+    "description_en": "Service activities incidental to land transportation"
+  },
+  {
+    "isat2008_normalized": "52220",
+    "description": "Þjónustustarfsemi tengd flutningum á sjó og vatni",
+    "isat2008": "52.22.0",
+    "description_en": "Service activities incidental to water transportation"
+  },
+  {
+    "isat2008_normalized": "52230",
+    "description": "Þjónustustarfsemi tengd flutningum með flugi",
+    "isat2008": "52.23.0",
+    "description_en": "Service activities incidental to air transportation"
+  },
+  {
+    "isat2008_normalized": "52240",
+    "description": "Vöruafgreiðsla",
+    "isat2008": "52.24.0",
+    "description_en": "Cargo handling"
+  },
+  {
+    "isat2008_normalized": "52290",
+    "description": "Önnur þjónusta tengd flutningum",
+    "isat2008": "52.29.0",
+    "description_en": "Other transportation support activities "
+  },
+  {
+    "isat2008_normalized": "53100",
+    "description": "Almenn póstþjónusta",
+    "isat2008": "53.10.0",
+    "description_en": "Postal activities under universal service obligation"
+  },
+  {
+    "isat2008_normalized": "53200",
+    "description": "Önnur póst- og boðberaþjónusta",
+    "isat2008": "53.20.0",
+    "description_en": "Other postal and courier activities"
+  },
+  {
+    "isat2008_normalized": "55101",
+    "description": "Hótel og gistiheimili með veitingaþjónustu",
+    "isat2008": "55.10.1",
+    "description_en": "Hotels and similar accommodation, without restaurants"
+  },
+  {
+    "isat2008_normalized": "55102",
+    "description": "Hótel og gistiheimili án veitingaþjónustu",
+    "isat2008": "55.10.2",
+    "description_en": "Hotels and similar accommodation, with restaurants"
+  },
+  {
+    "isat2008_normalized": "55200",
+    "description": "Orlofsdvalarstaðir og annars konar gistiaðstaða",
+    "isat2008": "55.20.0",
+    "description_en": "Holiday and other short-stay accommodation"
+  },
+  {
+    "isat2008_normalized": "55300",
+    "description": "Tjaldsvæði, svæði fyrir húsbíla og hjólhýsi",
+    "isat2008": "55.30.0",
+    "description_en": "Camping grounds, recreational vehicle parks and trailer parks"
+  },
+  {
+    "isat2008_normalized": "55900",
+    "description": "Önnur gistiaðstaða",
+    "isat2008": "55.90.0",
+    "description_en": "Other accommodation"
+  },
+  {
+    "isat2008_normalized": "56100",
+    "description": "Veitingastaðir",
+    "isat2008": "56.10.0",
+    "description_en": "Restaurants and mobile food service activities"
+  },
+  {
+    "isat2008_normalized": "56210",
+    "description": "Veisluþjónusta",
+    "isat2008": "56.21.0",
+    "description_en": "Event catering activities"
+  },
+  {
+    "isat2008_normalized": "56290",
+    "description": "Önnur ótalin veitingaþjónusta",
+    "isat2008": "56.29.0",
+    "description_en": "Other food service activities"
+  },
+  {
+    "isat2008_normalized": "56300",
+    "description": "Krár, kaffihús og dansstaðir o.þ.h.",
+    "isat2008": "56.30.0",
+    "description_en": "Beverage serving activities"
+  },
+  {
+    "isat2008_normalized": "58110",
+    "description": "Bókaútgáfa",
+    "isat2008": "58.11.0",
+    "description_en": "Book publishing"
+  },
+  {
+    "isat2008_normalized": "58120",
+    "description": "Útgáfa skráa og póstlista",
+    "isat2008": "58.12.0",
+    "description_en": "Publishing of directories and mailing lists"
+  },
+  {
+    "isat2008_normalized": "58130",
+    "description": "Dagblaðaútgáfa",
+    "isat2008": "58.13.0",
+    "description_en": "Publishing of newspapers"
+  },
+  {
+    "isat2008_normalized": "58140",
+    "description": "Tímaritaútgáfa",
+    "isat2008": "58.14.0",
+    "description_en": "Publishing of journals and periodicals"
+  },
+  {
+    "isat2008_normalized": "58190",
+    "description": "Önnur útgáfustarfsemi",
+    "isat2008": "58.19.0",
+    "description_en": "Other publishing activities"
+  },
+  {
+    "isat2008_normalized": "58210",
+    "description": "Útgáfa tölvuleikja",
+    "isat2008": "58.21.0",
+    "description_en": "Publishing of computer games"
+  },
+  {
+    "isat2008_normalized": "58290",
+    "description": "Önnur hugbúnaðarútgáfa",
+    "isat2008": "58.29.0",
+    "description_en": "Other software publishing"
+  },
+  {
+    "isat2008_normalized": "59110",
+    "description": "Framleiðsla á kvikmyndum, myndböndum og sjónvarpsefni",
+    "isat2008": "59.11.0",
+    "description_en": "Motion picture, video and television programme production activities"
+  },
+  {
+    "isat2008_normalized": "59120",
+    "description": "Eftirvinnsla kvikmynda, myndbanda og sjónvarpsefnis",
+    "isat2008": "59.12.0",
+    "description_en": "Motion picture, video and television programme post-production activities"
+  },
+  {
+    "isat2008_normalized": "59130",
+    "description": "Dreifing á kvikmyndum, myndböndum og sjónvarpsefni",
+    "isat2008": "59.13.0",
+    "description_en": "Motion picture, video and television programme distribution activities"
+  },
+  {
+    "isat2008_normalized": "59140",
+    "description": "Kvikmyndasýningar",
+    "isat2008": "59.14.0",
+    "description_en": "Motion picture projection activities"
+  },
+  {
+    "isat2008_normalized": "59200",
+    "description": "Hljóðupptaka og tónlistarútgáfa",
+    "isat2008": "59.20.0",
+    "description_en": "Sound recording and music publishing activities"
+  },
+  {
+    "isat2008_normalized": "60100",
+    "description": "Útvarpsútsending og dagskrárgerð",
+    "isat2008": "60.10.0",
+    "description_en": "Radio broadcasting"
+  },
+  {
+    "isat2008_normalized": "60200",
+    "description": "Sjónvarpsútsendingar og dagskrárgerð",
+    "isat2008": "60.20.0",
+    "description_en": "Television programming and broadcasting activities"
+  },
+  {
+    "isat2008_normalized": "61100",
+    "description": "Fjarskipti um streng",
+    "isat2008": "61.10.0",
+    "description_en": "Wired telecommunications activities"
+  },
+  {
+    "isat2008_normalized": "61200",
+    "description": "Þráðlaus fjarskipti",
+    "isat2008": "61.20.0",
+    "description_en": "Wireless telecommunications activities"
+  },
+  {
+    "isat2008_normalized": "61300",
+    "description": "Gervihnattafjarskipti",
+    "isat2008": "61.30.0",
+    "description_en": "Satellite telecommunications activities"
+  },
+  {
+    "isat2008_normalized": "61900",
+    "description": "Önnur fjarskiptastarfsemi",
+    "isat2008": "61.90.0",
+    "description_en": "Other telecommunications activities"
+  },
+  {
+    "isat2008_normalized": "62010",
+    "description": "Hugbúnaðargerð",
+    "isat2008": "62.01.0",
+    "description_en": "Computer programming activities"
+  },
+  {
+    "isat2008_normalized": "62020",
+    "description": "Ráðgjafarstarfsemi á sviði upplýsingatækni",
+    "isat2008": "62.02.0",
+    "description_en": "Computer consultancy activities"
+  },
+  {
+    "isat2008_normalized": "62030",
+    "description": "Rekstur tölvukerfa",
+    "isat2008": "62.03.0",
+    "description_en": "Computer facilities management activities"
+  },
+  {
+    "isat2008_normalized": "62090",
+    "description": "Önnur þjónustustarfsemi á sviði upplýsingatækni",
+    "isat2008": "62.09.0",
+    "description_en": "Other information technology and computer service activities"
+  },
+  {
+    "isat2008_normalized": "63110",
+    "description": "Gagnavinnsla, hýsing og tengd starfsemi",
+    "isat2008": "63.11.0",
+    "description_en": "Data processing, hosting and related activities"
+  },
+  {
+    "isat2008_normalized": "63120",
+    "description": "Vefgáttir",
+    "isat2008": "63.12.0",
+    "description_en": "Web portals"
+  },
+  {
+    "isat2008_normalized": "63910",
+    "description": "Starfsemi fréttastofa",
+    "isat2008": "63.91.0",
+    "description_en": "News agency activities"
+  },
+  {
+    "isat2008_normalized": "63990",
+    "description": "Önnur ótalin starfsemi á sviði upplýsingaþjónustu",
+    "isat2008": "63.99.0",
+    "description_en": "Other information service activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "64110",
+    "description": "Starfsemi seðlabanka",
+    "isat2008": "64.11.0",
+    "description_en": "Central banking"
+  },
+  {
+    "isat2008_normalized": "64190",
+    "description": "Önnur fjármálafyrirtæki",
+    "isat2008": "64.19.0",
+    "description_en": "Other monetary intermediation"
+  },
+  {
+    "isat2008_normalized": "64200",
+    "description": "Starfsemi eignarhaldsfélaga",
+    "isat2008": "64.20.0",
+    "description_en": "Activities of holding companies"
+  },
+  {
+    "isat2008_normalized": "64300",
+    "description": "Fjárvörslusjóðir, sjóðir og önnur sérhæfð fjársýslufélög",
+    "isat2008": "64.30.0",
+    "description_en": "Trusts, funds and similar financial entities"
+  },
+  {
+    "isat2008_normalized": "64910",
+    "description": "Fjármögnunarleiga",
+    "isat2008": "64.91.0",
+    "description_en": "Financial leasing"
+  },
+  {
+    "isat2008_normalized": "64920",
+    "description": "Önnur lánaþjónusta",
+    "isat2008": "64.92.0",
+    "description_en": "Other credit granting"
+  },
+  {
+    "isat2008_normalized": "64990",
+    "description": "Önnur ótalin fjármálaþjónusta, þó ekki vátryggingafélög og lífeyrissjóðir",
+    "isat2008": "64.99.0",
+    "description_en": "Other financial service activities, except insurance and pension funding n.e.c."
+  },
+  {
+    "isat2008_normalized": "65110",
+    "description": "Líftryggingar",
+    "isat2008": "65.11.0",
+    "description_en": "Life insurance"
+  },
+  {
+    "isat2008_normalized": "65120",
+    "description": "Skaðatryggingar",
+    "isat2008": "65.12.0",
+    "description_en": "Non-life insurance"
+  },
+  {
+    "isat2008_normalized": "65200",
+    "description": "Endurtryggingar",
+    "isat2008": "65.20.0",
+    "description_en": "Reinsurance"
+  },
+  {
+    "isat2008_normalized": "65300",
+    "description": "Lífeyrissjóðir",
+    "isat2008": "65.30.0",
+    "description_en": "Pension funding"
+  },
+  {
+    "isat2008_normalized": "66110",
+    "description": "Stjórnun fjármálamarkaða",
+    "isat2008": "66.11.0",
+    "description_en": "Administration of financial markets"
+  },
+  {
+    "isat2008_normalized": "66120",
+    "description": "Starfsemi við miðlun verðbréfa og hrávörusamninga",
+    "isat2008": "66.12.0",
+    "description_en": "Security and commodity contracts brokerage"
+  },
+  {
+    "isat2008_normalized": "66190",
+    "description": "Önnur ótalin starfsemi tengd fjármálaþjónustu, þó ekki vátryggingafélögum og lífeyrissjóðum",
+    "isat2008": "66.19.0",
+    "description_en": "Other activities auxiliary to financial services, except insurance and pension funding"
+  },
+  {
+    "isat2008_normalized": "66210",
+    "description": "Áhættu- og tjónamat",
+    "isat2008": "66.21.0",
+    "description_en": "Risk and damage evaluation"
+  },
+  {
+    "isat2008_normalized": "66220",
+    "description": "Starfsemi umboðsmanna og miðlara í vátryggingum",
+    "isat2008": "66.22.0",
+    "description_en": "Activities of insurance agents and brokers"
+  },
+  {
+    "isat2008_normalized": "66290",
+    "description": "Önnur starfsemi tengd vátryggingum og lífeyrissjóðum",
+    "isat2008": "66.29.0",
+    "description_en": "Other activities auxiliary to insurance and pension funding"
+  },
+  {
+    "isat2008_normalized": "66300",
+    "description": "Stýring verðbréfasjóða",
+    "isat2008": "66.30.0",
+    "description_en": "Fund management activities"
+  },
+  {
+    "isat2008_normalized": "68100",
+    "description": "Kaup og sala á eigin fasteignum",
+    "isat2008": "68.10.0",
+    "description_en": "Buying and selling of own real estate"
+  },
+  {
+    "isat2008_normalized": "68201",
+    "description": "Leiga íbúðarhúsnæðis",
+    "isat2008": "68.20.1",
+    "description_en": "Letting of residential housing"
+  },
+  {
+    "isat2008_normalized": "68202",
+    "description": "Leiga atvinnuhúsnæðis",
+    "isat2008": "68.20.2",
+    "description_en": "Letting of non-residential housing"
+  },
+  {
+    "isat2008_normalized": "68203",
+    "description": "Leiga á landi og landréttindum",
+    "isat2008": "68.20.3",
+    "description_en": "Letting of land and land rights"
+  },
+  {
+    "isat2008_normalized": "68310",
+    "description": "Fasteignamiðlun",
+    "isat2008": "68.31.0",
+    "description_en": "Real estate agencies"
+  },
+  {
+    "isat2008_normalized": "68320",
+    "description": "Fasteignarekstur gegn þóknun eða samkvæmt samningi",
+    "isat2008": "68.32.0",
+    "description_en": "Management of real estate on a fee or contract basis"
+  },
+  {
+    "isat2008_normalized": "69100",
+    "description": "Lögfræðiþjónusta",
+    "isat2008": "69.10.0",
+    "description_en": "Legal activities"
+  },
+  {
+    "isat2008_normalized": "69200",
+    "description": "Reikningshald, bókhald og endurskoðun; skattaráðgjöf",
+    "isat2008": "69.20.0",
+    "description_en": "Accounting, bookkeeping and auditing activities; tax consultancy"
+  },
+  {
+    "isat2008_normalized": "70100",
+    "description": "Starfsemi höfuðstöðva",
+    "isat2008": "70.10.0",
+    "description_en": "Activities of head offices"
+  },
+  {
+    "isat2008_normalized": "70210",
+    "description": "Almannatengsl",
+    "isat2008": "70.21.0",
+    "description_en": "Public relations and communication activities"
+  },
+  {
+    "isat2008_normalized": "70220",
+    "description": "Viðskiptaráðgjöf og önnur rekstrarráðgjöf",
+    "isat2008": "70.22.0",
+    "description_en": "Business and other management consultancy activities"
+  },
+  {
+    "isat2008_normalized": "71110",
+    "description": "Starfsemi arkitekta og skyld tæknileg ráðgjöf",
+    "isat2008": "71.11.0",
+    "description_en": "Architectural activities "
+  },
+  {
+    "isat2008_normalized": "71121",
+    "description": "Starfsemi verkfræðinga og skyld tæknileg ráðgjöf",
+    "isat2008": "71.12.1",
+    "description_en": "Engineering activities"
+  },
+  {
+    "isat2008_normalized": "71122",
+    "description": "Starfsemi á sviði landmælinga; jarðfræðilegar rannsóknir",
+    "isat2008": "71.12.2",
+    "description_en": "Geological research and prospecting activities"
+  },
+  {
+    "isat2008_normalized": "71200",
+    "description": "Tæknilegar prófanir og greining",
+    "isat2008": "71.20.0",
+    "description_en": "Technical testing and analysis"
+  },
+  {
+    "isat2008_normalized": "72110",
+    "description": "Rannsóknir og þróunarstarf í líftækni",
+    "isat2008": "72.11.0",
+    "description_en": "Research and experimental development on biotechnology"
+  },
+  {
+    "isat2008_normalized": "72190",
+    "description": "Aðrar rannsóknir og þróunarstarf í raunvísindum og verkfræði",
+    "isat2008": "72.19.0",
+    "description_en": "Other research and experimental development on natural sciences and engineering"
+  },
+  {
+    "isat2008_normalized": "72200",
+    "description": "Rannsóknir og þróunarstarf í félags- og hugvísindum",
+    "isat2008": "72.20.0",
+    "description_en": "Research and experimental development on social sciences and humanities"
+  },
+  {
+    "isat2008_normalized": "73110",
+    "description": "Auglýsingastofur",
+    "isat2008": "73.11.0",
+    "description_en": "Advertising agencies"
+  },
+  {
+    "isat2008_normalized": "73120",
+    "description": "Auglýsingamiðlun",
+    "isat2008": "73.12.0",
+    "description_en": "Media representation"
+  },
+  {
+    "isat2008_normalized": "73200",
+    "description": "Markaðsrannsóknir og skoðanakannanir",
+    "isat2008": "73.20.0",
+    "description_en": "Market research and public opinion polling"
+  },
+  {
+    "isat2008_normalized": "74100",
+    "description": "Sérhæfð hönnun",
+    "isat2008": "74.10.0",
+    "description_en": "Specialised design activities"
+  },
+  {
+    "isat2008_normalized": "74200",
+    "description": "Ljósmyndaþjónusta",
+    "isat2008": "74.20.0",
+    "description_en": "Photographic activities"
+  },
+  {
+    "isat2008_normalized": "74300",
+    "description": "Þýðingar- og túlkunarþjónusta",
+    "isat2008": "74.30.0",
+    "description_en": "Translation and interpretation activities"
+  },
+  {
+    "isat2008_normalized": "74900",
+    "description": "Önnur ótalin sérfræðileg, vísindaleg og tæknileg starfsemi",
+    "isat2008": "74.90.0",
+    "description_en": "Other professional, scientific and technical activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "75000",
+    "description": "Dýralækningar",
+    "isat2008": "75.00.0",
+    "description_en": "Veterinary activities"
+  },
+  {
+    "isat2008_normalized": "77110",
+    "description": "Leiga á bifreiðum og léttum vélknúnum ökutækjum",
+    "isat2008": "77.11.0",
+    "description_en": "Renting and leasing of cars and light motor vehicles"
+  },
+  {
+    "isat2008_normalized": "77120",
+    "description": "Leiga á vörubifreiðum",
+    "isat2008": "77.12.0",
+    "description_en": "Renting and leasing of trucks"
+  },
+  {
+    "isat2008_normalized": "77210",
+    "description": "Leiga á tómstunda- og íþróttavörum",
+    "isat2008": "77.21.0",
+    "description_en": "Renting and leasing of recreational and sports goods"
+  },
+  {
+    "isat2008_normalized": "77220",
+    "description": "Leiga á myndböndum og -diskum",
+    "isat2008": "77.22.0",
+    "description_en": "Renting of video tapes and disks"
+  },
+  {
+    "isat2008_normalized": "77290",
+    "description": "Leiga á öðrum ótöldum munum til einka- og heimilisnota",
+    "isat2008": "77.29.0",
+    "description_en": "Renting and leasing of other personal and household goods"
+  },
+  {
+    "isat2008_normalized": "77310",
+    "description": "Leiga á landbúnaðarvélum og -tækjum",
+    "isat2008": "77.31.0",
+    "description_en": "Renting and leasing of agricultural machinery and equipment"
+  },
+  {
+    "isat2008_normalized": "77320",
+    "description": "Leiga á vinnuvélum og tækjum til byggingaframkvæmda og mannvirkjagerðar",
+    "isat2008": "77.32.0",
+    "description_en": "Renting and leasing of construction and civil engineering machinery and equipment"
+  },
+  {
+    "isat2008_normalized": "77330",
+    "description": "Leiga á tölvum, skrifstofuvélum og -búnaði",
+    "isat2008": "77.33.0",
+    "description_en": "Renting and leasing of office machinery and equipment (including computers)"
+  },
+  {
+    "isat2008_normalized": "77340",
+    "description": "Leiga á búnaði til flutninga á sjó- og vatnaleiðum",
+    "isat2008": "77.34.0",
+    "description_en": "Renting and leasing of water transport equipment"
+  },
+  {
+    "isat2008_normalized": "77350",
+    "description": "Leiga á loftförum",
+    "isat2008": "77.35.0",
+    "description_en": "Renting and leasing of air transport equipment"
+  },
+  {
+    "isat2008_normalized": "77390",
+    "description": "Leiga á öðrum ótöldum vélum og búnaði",
+    "isat2008": "77.39.0",
+    "description_en": "Renting and leasing of other machinery, equipment and tangible goods n.e.c."
+  },
+  {
+    "isat2008_normalized": "77400",
+    "description": "Leiga á hugverkum og skyldum eignum sem ekki njóta höfundarréttar",
+    "isat2008": "77.40.0",
+    "description_en": "Leasing of intellectual property and similar products, except copyrighted works"
+  },
+  {
+    "isat2008_normalized": "78100",
+    "description": "Ráðningarstofur",
+    "isat2008": "78.10.0",
+    "description_en": "Activities of employment placement agencies"
+  },
+  {
+    "isat2008_normalized": "78200",
+    "description": "Starfsmannaleigur",
+    "isat2008": "78.20.0",
+    "description_en": "Temporary employment agency activities"
+  },
+  {
+    "isat2008_normalized": "78300",
+    "description": "Önnur þjónusta tengd starfsmannahaldi",
+    "isat2008": "78.30.0",
+    "description_en": "Other human resources provision"
+  },
+  {
+    "isat2008_normalized": "79110",
+    "description": "Ferðaskrifstofur",
+    "isat2008": "79.11.0",
+    "description_en": "Travel agency activities"
+  },
+  {
+    "isat2008_normalized": "79120",
+    "description": "Ferðaskipuleggjendur",
+    "isat2008": "79.12.0",
+    "description_en": "Tour operator activities"
+  },
+  {
+    "isat2008_normalized": "79900",
+    "description": "Önnur bókunarþjónusta og önnur starfsemi tengd ferðaþjónustu",
+    "isat2008": "79.90.0",
+    "description_en": "Other reservation service and related activities"
+  },
+  {
+    "isat2008_normalized": "80100",
+    "description": "Einkarekin öryggisþjónusta",
+    "isat2008": "80.10.0",
+    "description_en": "Private security activities"
+  },
+  {
+    "isat2008_normalized": "80200",
+    "description": "Starfsemi við öryggiskerfaþjónustu",
+    "isat2008": "80.20.0",
+    "description_en": "Security systems service activities"
+  },
+  {
+    "isat2008_normalized": "80300",
+    "description": "Rannsóknarstarfsemi",
+    "isat2008": "80.30.0",
+    "description_en": "Investigation activities"
+  },
+  {
+    "isat2008_normalized": "81100",
+    "description": "Blönduð fasteignarumsýsla",
+    "isat2008": "81.10.0",
+    "description_en": "Combined facilities support activities"
+  },
+  {
+    "isat2008_normalized": "81210",
+    "description": "Almenn þrif bygginga",
+    "isat2008": "81.21.0",
+    "description_en": "General cleaning of buildings"
+  },
+  {
+    "isat2008_normalized": "81220",
+    "description": "Önnur þrif á byggingum og í iðnaði",
+    "isat2008": "81.22.0",
+    "description_en": "Other building and industrial cleaning activities"
+  },
+  {
+    "isat2008_normalized": "81290",
+    "description": "Önnur ótalin hreingerningarþjónusta",
+    "isat2008": "81.29.0",
+    "description_en": "Other cleaning activities"
+  },
+  {
+    "isat2008_normalized": "81300",
+    "description": "Skrúðgarðyrkja",
+    "isat2008": "81.30.0",
+    "description_en": "Landscape service activities"
+  },
+  {
+    "isat2008_normalized": "82110",
+    "description": "Blönduð skrifstofuþjónusta",
+    "isat2008": "82.11.0",
+    "description_en": "Combined office administrative service activities"
+  },
+  {
+    "isat2008_normalized": "82190",
+    "description": "Ljósritun, meðferð skjala og önnur sérhæfð skrifstofuþjónusta",
+    "isat2008": "82.19.0",
+    "description_en": "Photocopying, document preparation and other specialised office support activities"
+  },
+  {
+    "isat2008_normalized": "82200",
+    "description": "Símsvörun og úthringiþjónusta",
+    "isat2008": "82.20.0",
+    "description_en": "Activities of call centres"
+  },
+  {
+    "isat2008_normalized": "82300",
+    "description": "Skipulagning á ráðstefnum og vörusýningum",
+    "isat2008": "82.30.0",
+    "description_en": "Organisation of conventions and trade shows"
+  },
+  {
+    "isat2008_normalized": "82910",
+    "description": "Innheimtuþjónusta og upplýsingar um lánstraust",
+    "isat2008": "82.91.0",
+    "description_en": "Activities of collection agencies and credit bureaus"
+  },
+  {
+    "isat2008_normalized": "82920",
+    "description": "Pökkunarstarfsemi",
+    "isat2008": "82.92.0",
+    "description_en": "Packaging activities"
+  },
+  {
+    "isat2008_normalized": "82990",
+    "description": "Önnur ótalin þjónusta við atvinnurekstur",
+    "isat2008": "82.99.0",
+    "description_en": "Other business support service activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "84110",
+    "description": "Almenn stjórnsýsla og löggjöf",
+    "isat2008": "84.11.0",
+    "description_en": "General public administration activities"
+  },
+  {
+    "isat2008_normalized": "84120",
+    "description": "Stjórnsýsla á sviði heilbrigðisþjónustu, mennta- og menningarmála og félagsmála, þó ekki almannatryggingar",
+    "isat2008": "84.12.0",
+    "description_en": "Regulation of the activities of providing health care, education, cultural services and other social services, excluding social security"
+  },
+  {
+    "isat2008_normalized": "84130",
+    "description": "Stjórnsýsla í þágu atvinnuveganna",
+    "isat2008": "84.13.0",
+    "description_en": "Regulation of and contribution to more efficient operation of businesses"
+  },
+  {
+    "isat2008_normalized": "84210",
+    "description": "Utanríkisþjónusta",
+    "isat2008": "84.21.0",
+    "description_en": "Foreign affairs"
+  },
+  {
+    "isat2008_normalized": "84220",
+    "description": "Varnarmál",
+    "isat2008": "84.22.0",
+    "description_en": "Defence activities"
+  },
+  {
+    "isat2008_normalized": "84230",
+    "description": "Dómstólar og fangelsi",
+    "isat2008": "84.23.0",
+    "description_en": "Justice and judicial activities"
+  },
+  {
+    "isat2008_normalized": "84240",
+    "description": "Löggæsla og almannaöryggi",
+    "isat2008": "84.24.0",
+    "description_en": "Public order and safety activities"
+  },
+  {
+    "isat2008_normalized": "84250",
+    "description": "Slökkviliðs- og björgunarstarfsemi",
+    "isat2008": "84.25.0",
+    "description_en": "Fire service activities"
+  },
+  {
+    "isat2008_normalized": "84300",
+    "description": "Almannatryggingar",
+    "isat2008": "84.30.0",
+    "description_en": "Compulsory social security activities"
+  },
+  {
+    "isat2008_normalized": "85100",
+    "description": "Fræðslustarfsemi á leikskólastigi",
+    "isat2008": "85.10.0",
+    "description_en": "Pre-primary education "
+  },
+  {
+    "isat2008_normalized": "85200",
+    "description": "Fræðslustarfsemi á grunnskólastigi",
+    "isat2008": "85.20.0",
+    "description_en": "Primary education "
+  },
+  {
+    "isat2008_normalized": "85310",
+    "description": "Fræðslustarfsemi á framhaldsskólastigi - bóknám",
+    "isat2008": "85.31.0",
+    "description_en": "General secondary education "
+  },
+  {
+    "isat2008_normalized": "85320",
+    "description": "Fræðslustarfsemi á framhaldsskólastigi – iðn- og verknám",
+    "isat2008": "85.32.0",
+    "description_en": "Technical and vocational secondary education "
+  },
+  {
+    "isat2008_normalized": "85410",
+    "description": "Fræðslustarfsemi á viðbótarstigi",
+    "isat2008": "85.41.0",
+    "description_en": "Post-secondary non-tertiary education"
+  },
+  {
+    "isat2008_normalized": "85420",
+    "description": "Fræðslustarfsemi á háskólastigi",
+    "isat2008": "85.42.0",
+    "description_en": "Tertiary education"
+  },
+  {
+    "isat2008_normalized": "85510",
+    "description": "Íþrótta- og tómstundakennsla",
+    "isat2008": "85.51.0",
+    "description_en": "Sports and recreation education"
+  },
+  {
+    "isat2008_normalized": "85520",
+    "description": "Listnám",
+    "isat2008": "85.52.0",
+    "description_en": "Cultural education"
+  },
+  {
+    "isat2008_normalized": "85530",
+    "description": "Ökuskólar, flugskólar o.þ.h.",
+    "isat2008": "85.53.0",
+    "description_en": "Driving school activities"
+  },
+  {
+    "isat2008_normalized": "85590",
+    "description": "Önnur ótalin fræðslustarfsemi",
+    "isat2008": "85.59.0",
+    "description_en": "Other education n.e.c."
+  },
+  {
+    "isat2008_normalized": "85600",
+    "description": "Þjónusta við fræðslustarfsemi",
+    "isat2008": "85.60.0",
+    "description_en": "Educational support activities"
+  },
+  {
+    "isat2008_normalized": "86100",
+    "description": "Sjúkrahús",
+    "isat2008": "86.10.0",
+    "description_en": "Hospital activities"
+  },
+  {
+    "isat2008_normalized": "86210",
+    "description": "Heilsugæsla og heimilislækningar",
+    "isat2008": "86.21.0",
+    "description_en": "General medical practice activities"
+  },
+  {
+    "isat2008_normalized": "86220",
+    "description": "Sérfræðilækningar",
+    "isat2008": "86.22.0",
+    "description_en": "Specialist medical practice activities"
+  },
+  {
+    "isat2008_normalized": "86230",
+    "description": "Tannlækningar",
+    "isat2008": "86.23.0",
+    "description_en": "Dental practice activities"
+  },
+  {
+    "isat2008_normalized": "86901",
+    "description": "Starfsemi sjúkraþjálfara",
+    "isat2008": "86.90.1",
+    "description_en": "Practicing physiotherapists"
+  },
+  {
+    "isat2008_normalized": "86902",
+    "description": "Starfsemi sálfræðinga",
+    "isat2008": "86.90.2",
+    "description_en": "Practicing psychologists"
+  },
+  {
+    "isat2008_normalized": "86903",
+    "description": "Rannsóknarstofur í læknisfræði",
+    "isat2008": "86.90.3",
+    "description_en": "Medical laboratories"
+  },
+  {
+    "isat2008_normalized": "86909",
+    "description": "Önnur ótalin heilbrigðisþjónusta",
+    "isat2008": "86.90.9",
+    "description_en": "Other human health activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "87100",
+    "description": "Dvalarheimili með hjúkrun",
+    "isat2008": "87.10.0",
+    "description_en": "Residential nursing care activities"
+  },
+  {
+    "isat2008_normalized": "87200",
+    "description": "Dvalarheimili á sviði þroskahömlunar, geðheilbrigðis og vímuefnamisnotkunar",
+    "isat2008": "87.20.0",
+    "description_en": "Residential care activities for mental retardation, mental health and substance abuse"
+  },
+  {
+    "isat2008_normalized": "87301",
+    "description": "Dvalarheimili fyrir aldraða",
+    "isat2008": "87.30.1",
+    "description_en": "Residential care activities for the elderly"
+  },
+  {
+    "isat2008_normalized": "87302",
+    "description": "Heimili fyrir fatlaða",
+    "isat2008": "87.30.2",
+    "description_en": "Residential care activities for the disabled"
+  },
+  {
+    "isat2008_normalized": "87900",
+    "description": "Önnur ótalin dvalarheimili",
+    "isat2008": "87.90.0",
+    "description_en": "Other residential care activities"
+  },
+  {
+    "isat2008_normalized": "88100",
+    "description": "Félagsþjónusta án gistiaðstöðu fyrir aldraða og fatlaða",
+    "isat2008": "88.10.0",
+    "description_en": "Social work activities without accommodation for the elderly and disabled"
+  },
+  {
+    "isat2008_normalized": "88911",
+    "description": "Starfsemi dagmæðra og önnur dagvistun ungbarna",
+    "isat2008": "88.91.1",
+    "description_en": "Child daycare centres"
+  },
+  {
+    "isat2008_normalized": "88912",
+    "description": "Starfsemi skóladagheimila og frístundaheimila",
+    "isat2008": "88.91.2",
+    "description_en": "School daycare centres "
+  },
+  {
+    "isat2008_normalized": "88990",
+    "description": "Önnur ótalin félagsþjónusta án dvalar á stofnun",
+    "isat2008": "88.99.0",
+    "description_en": "Other social work activities without accommodation n.e.c."
+  },
+  {
+    "isat2008_normalized": "90010",
+    "description": "Sviðslistir",
+    "isat2008": "90.01.0",
+    "description_en": "Performing arts"
+  },
+  {
+    "isat2008_normalized": "90020",
+    "description": "Þjónusta við sviðslistir",
+    "isat2008": "90.02.0",
+    "description_en": "Support activities to performing arts"
+  },
+  {
+    "isat2008_normalized": "90030",
+    "description": "Listsköpun",
+    "isat2008": "90.03.0",
+    "description_en": "Artistic creation"
+  },
+  {
+    "isat2008_normalized": "90040",
+    "description": "Rekstur húsnæðis og annarrar aðstöðu fyrir menningarstarfsemi",
+    "isat2008": "90.04.0",
+    "description_en": "Operation of arts facilities"
+  },
+  {
+    "isat2008_normalized": "91010",
+    "description": "Starfsemi bóka- og skjalasafna",
+    "isat2008": "91.01.0",
+    "description_en": "Library and archives activities"
+  },
+  {
+    "isat2008_normalized": "91020",
+    "description": "Starfsemi safna",
+    "isat2008": "91.02.0",
+    "description_en": "Museums activities"
+  },
+  {
+    "isat2008_normalized": "91030",
+    "description": "Rekstur sögulegra staða og bygginga og áþekkra ferðamannastaða",
+    "isat2008": "91.03.0",
+    "description_en": "Operation of historical sites and buildings and similar visitor attractions"
+  },
+  {
+    "isat2008_normalized": "91040",
+    "description": "Starfsemi grasagarða, dýragarða og þjóðgarða",
+    "isat2008": "91.04.0",
+    "description_en": "Botanical and zoological gardens and nature reserves activities"
+  },
+  {
+    "isat2008_normalized": "92000",
+    "description": "Fjárhættu- og veðmálastarfsemi",
+    "isat2008": "92.00.0",
+    "description_en": "Gambling and betting activities"
+  },
+  {
+    "isat2008_normalized": "93110",
+    "description": "Rekstur íþróttamannvirkja",
+    "isat2008": "93.11.0",
+    "description_en": "Operation of sports facilities"
+  },
+  {
+    "isat2008_normalized": "93120",
+    "description": "Starfsemi íþróttafélaga",
+    "isat2008": "93.12.0",
+    "description_en": "Activities of sport clubs"
+  },
+  {
+    "isat2008_normalized": "93130",
+    "description": "Heilsu- og líkamsræktarstöðvar",
+    "isat2008": "93.13.0",
+    "description_en": "Fitness facilities"
+  },
+  {
+    "isat2008_normalized": "93190",
+    "description": "Önnur íþróttastarfsemi",
+    "isat2008": "93.19.0",
+    "description_en": "Other sports activities"
+  },
+  {
+    "isat2008_normalized": "93210",
+    "description": "Starfsemi skemmti- og þemagarða",
+    "isat2008": "93.21.0",
+    "description_en": "Activities of amusement parks and theme parks"
+  },
+  {
+    "isat2008_normalized": "93290",
+    "description": "Önnur ótalin skemmtun og tómstundastarf",
+    "isat2008": "93.29.0",
+    "description_en": "Other amusement and recreation activities"
+  },
+  {
+    "isat2008_normalized": "94110",
+    "description": "Starfsemi samtaka í atvinnulífinu og félaga atvinnurekenda",
+    "isat2008": "94.11.0",
+    "description_en": "Activities of business and employers membership organisations"
+  },
+  {
+    "isat2008_normalized": "94120",
+    "description": "Starfsemi fagfélaga",
+    "isat2008": "94.12.0",
+    "description_en": "Activities of professional membership organisations"
+  },
+  {
+    "isat2008_normalized": "94200",
+    "description": "Starfsemi stéttarfélaga",
+    "isat2008": "94.20.0",
+    "description_en": "Activities of trade unions"
+  },
+  {
+    "isat2008_normalized": "94910",
+    "description": "Starfsemi trúfélaga",
+    "isat2008": "94.91.0",
+    "description_en": "Activities of religious organisations"
+  },
+  {
+    "isat2008_normalized": "94920",
+    "description": "Starfsemi stjórnmálasamtaka",
+    "isat2008": "94.92.0",
+    "description_en": "Activities of political organisations"
+  },
+  {
+    "isat2008_normalized": "94991",
+    "description": "Starfsemi húsfélaga íbúðareigenda",
+    "isat2008": "94.99.1",
+    "description_en": "Apartment-building associations (of individual owners)"
+  },
+  {
+    "isat2008_normalized": "94999",
+    "description": "Starfsemi annarra ótalinna félagasamtaka",
+    "isat2008": "94.99.9",
+    "description_en": "Activities of other membership organisations n.e.c."
+  },
+  {
+    "isat2008_normalized": "95110",
+    "description": "Viðgerðir á tölvum og jaðarbúnaði",
+    "isat2008": "95.11.0",
+    "description_en": "Repair of computers and peripheral equipment"
+  },
+  {
+    "isat2008_normalized": "95120",
+    "description": "Viðgerðir á fjarskiptabúnaði",
+    "isat2008": "95.12.0",
+    "description_en": "Repair of communication equipment"
+  },
+  {
+    "isat2008_normalized": "95210",
+    "description": "Viðgerðir á sjónvarps-, útvarps- og hljómtækjum og skyldum búnaði",
+    "isat2008": "95.21.0",
+    "description_en": "Repair of consumer electronics"
+  },
+  {
+    "isat2008_normalized": "95220",
+    "description": "Viðgerðir á heimilistækjum og heimilis- og garðyrkjuáhöldum",
+    "isat2008": "95.22.0",
+    "description_en": "Repair of household appliances and home and garden equipment"
+  },
+  {
+    "isat2008_normalized": "95230",
+    "description": "Viðgerðir á skófatnaði og leðurvörum",
+    "isat2008": "95.23.0",
+    "description_en": "Repair of footwear and leather goods"
+  },
+  {
+    "isat2008_normalized": "95240",
+    "description": "Viðgerðir á húsgögnum og áklæðum",
+    "isat2008": "95.24.0",
+    "description_en": "Repair of furniture and home furnishings"
+  },
+  {
+    "isat2008_normalized": "95250",
+    "description": "Viðgerðir á úrum, klukkum og skartgripum",
+    "isat2008": "95.25.0",
+    "description_en": "Repair of watches, clocks and jewellery"
+  },
+  {
+    "isat2008_normalized": "95290",
+    "description": "Viðgerðir á öðrum hlutum til einka- og heimilisnota",
+    "isat2008": "95.29.0",
+    "description_en": "Repair of other personal and household goods"
+  },
+  {
+    "isat2008_normalized": "96010",
+    "description": "Þvottahús og efnalaugar",
+    "isat2008": "96.01.0",
+    "description_en": "Washing and (dry-)cleaning of textile and fur products"
+  },
+  {
+    "isat2008_normalized": "96021",
+    "description": "Hársnyrtistofur",
+    "isat2008": "96.02.1",
+    "description_en": "Hairdressing"
+  },
+  {
+    "isat2008_normalized": "96022",
+    "description": "Snyrtistofur",
+    "isat2008": "96.02.2",
+    "description_en": "Other beauty treatment"
+  },
+  {
+    "isat2008_normalized": "96030",
+    "description": "Útfararþjónusta og tengd starfsemi",
+    "isat2008": "96.03.0",
+    "description_en": "Funeral and related activities"
+  },
+  {
+    "isat2008_normalized": "96040",
+    "description": "Nuddstofur, sólbaðsstofur, gufuböð o.þ.h.",
+    "isat2008": "96.04.0",
+    "description_en": "Physical well-being activities"
+  },
+  {
+    "isat2008_normalized": "96090",
+    "description": "Önnur ótalin þjónustustarfsemi",
+    "isat2008": "96.09.0",
+    "description_en": "Other personal service activities n.e.c."
+  },
+  {
+    "isat2008_normalized": "97000",
+    "description": "Heimilishald með launuðu starfsfólki",
+    "isat2008": "97.00.0",
+    "description_en": "Activities of households as employers of domestic personnel"
+  },
+  {
+    "isat2008_normalized": "98100",
+    "description": "Framleiðsla á heimilum á ýmis konar vöru til eigin nota",
+    "isat2008": "98.10.0",
+    "description_en": "Undifferentiated goods-producing activities of private households for own use"
+  },
+  {
+    "isat2008_normalized": "98200",
+    "description": "Þjónustustarfsemi á heimilum í eigin þágu",
+    "isat2008": "98.20.0",
+    "description_en": "Undifferentiated service-producing activities of private households for own use"
+  },
+  {
+    "isat2008_normalized": "99000",
+    "description": "Starfsemi alþjóðlegra stofnana og samtaka með úrlendisrétt",
+    "isat2008": "99.00.0",
+    "description_en": "Activities of extraterritorial organisations and bodies"
+  },
+  {
+    "isat2008_normalized": "99999",
+    "description": "Óþekkt starfsemi",
+    "isat2008": "99.99.9",
+    "description_en": "Unknown activity"
+  }
+]

--- a/apps/directorate-of-equality-api/db/seeders/seed-isat-category.js
+++ b/apps/directorate-of-equality-api/db/seeders/seed-isat-category.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+
+// ÍSAT2008 reference data — 665 leaf (5-digit / two-dot) codes. See db/README.md.
+// Source: db/seeders/data/isat-2008.json (cleaned from the Hagstofan export).
+
+const escStr = (s) => `'${String(s).replace(/'/g, "''")}'`
+
+function isatCategorySql() {
+  const rows = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'data', 'isat-2008.json'), 'utf8'),
+  )
+
+  const values = rows
+    .map(
+      (r) =>
+        `(${escStr(r.isat2008_normalized)}, ${escStr(r.isat2008)}, ` +
+        `${escStr(r.description)}, ${escStr(r.description_en)})`,
+    )
+    .join(',\n      ')
+
+  return `
+    BEGIN;
+
+    INSERT INTO isat_category (code, code_dotted, description, description_en)
+    VALUES
+      ${values}
+    ON CONFLICT (code) DO NOTHING;
+
+    COMMIT;
+  `
+}
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    return await queryInterface.sequelize.query(isatCategorySql())
+  },
+
+  async down(queryInterface) {
+    return await queryInterface.sequelize.query(`DELETE FROM isat_category;`)
+  },
+}

--- a/apps/directorate-of-equality-api/src/app/app.module.ts
+++ b/apps/directorate-of-equality-api/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { CompanyModel } from '../modules/company/models/company.model'
 import { CompanyCommentModel } from '../modules/company/models/company-comment.model'
 import { CompanyEventModel } from '../modules/company/models/company-event.model'
 import { CompanyReportModel } from '../modules/company/models/company-report.model'
+import { IsatCategoryModel } from '../modules/company/models/isat-category.model'
 import { ConfigModel } from '../modules/config/models/config.model'
 import { PostcodeModel } from '../modules/location/models/postcode.model'
 import { RegionModel } from '../modules/location/models/region.model'
@@ -58,6 +59,7 @@ import { HealthController } from './health.controller'
             UserModel,
             RegionModel,
             PostcodeModel,
+            IsatCategoryModel,
             CompanyModel,
             ReportEmployeeRoleModel,
             ReportModel,

--- a/apps/directorate-of-equality-api/src/core/constants.ts
+++ b/apps/directorate-of-equality-api/src/core/constants.ts
@@ -4,6 +4,7 @@ export enum DoeModels {
   USER = 'doe_user',
   REGION = 'region',
   POSTCODE = 'postcode',
+  ISAT_CATEGORY = 'isat_category',
   COMPANY = 'company',
   COMPANY_REPORT = 'company_report',
   REPORT = 'report',

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.api.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.api.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common'
+
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
+import { CompanyImportController } from './company-import.controller'
+import { CompanyImportCoreModule } from './company-import.core.module'
+
+@Module({
+  imports: [CompanyImportCoreModule, AuthorizationCoreModule],
+  controllers: [CompanyImportController],
+  providers: [AdminGuard],
+})
+export class CompanyImportApiModule {}

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Controller,
+  Inject,
+  MaxFileSizeValidator,
+  ParseFilePipe,
+  Post,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common'
+import { FileInterceptor } from '@nestjs/platform-express'
+import { ApiBearerAuth, ApiBody, ApiConsumes, ApiTags } from '@nestjs/swagger'
+
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+
+import { CurrentAdminUser } from '../../core/decorators/current-admin-user.decorator'
+import { DoeResponse } from '../../core/decorators/doe-response.decorator'
+import { AdminGuard } from '../../core/guards/admin/admin.guard'
+import { UserModel } from '../user/models/user.model'
+import { CompanyImportResultDto } from './dto/company-import-result.dto'
+import { ICompanyImportService } from './company-import.service.interface'
+
+const ONE_MB = 1024 * 1024
+const MAX_UPLOAD_BYTES = ONE_MB * 20
+
+const FILE_BODY = {
+  schema: {
+    type: 'object',
+    properties: { file: { type: 'string', format: 'binary' } },
+    required: ['file'],
+  },
+}
+
+const uploadPipe = new ParseFilePipe({
+  validators: [new MaxFileSizeValidator({ maxSize: MAX_UPLOAD_BYTES })],
+})
+
+@Controller({
+  path: 'companies/import',
+  version: '1',
+})
+@ApiTags('Company Import')
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, AdminGuard)
+export class CompanyImportController {
+  constructor(
+    @Inject(ICompanyImportService)
+    private readonly companyImportService: ICompanyImportService,
+  ) {}
+
+  @Post('preview')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody(FILE_BODY)
+  @DoeResponse({
+    operationId: 'previewCompanyImport',
+    type: CompanyImportResultDto,
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async preview(
+    @UploadedFile(uploadPipe) file: Express.Multer.File,
+  ): Promise<CompanyImportResultDto> {
+    return this.companyImportService.preview(file.buffer)
+  }
+
+  @Post('apply')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody(FILE_BODY)
+  @DoeResponse({
+    operationId: 'applyCompanyImport',
+    type: CompanyImportResultDto,
+  })
+  @UseInterceptors(FileInterceptor('file'))
+  async apply(
+    @UploadedFile(uploadPipe) file: Express.Multer.File,
+    @CurrentAdminUser() admin: UserModel,
+  ): Promise<CompanyImportResultDto> {
+    return this.companyImportService.apply(file.buffer, admin.id)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.core.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { CompanyModel } from '../company/models/company.model'
+import { IsatCategoryModel } from '../company/models/isat-category.model'
+import { CompanyEventCoreModule } from '../company-event/company-event.core.module'
+import { PostcodeModel } from '../location/models/postcode.model'
+import { CompanyImportService } from './company-import.service'
+import { ICompanyImportService } from './company-import.service.interface'
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([
+      CompanyModel,
+      IsatCategoryModel,
+      PostcodeModel,
+    ]),
+    CompanyEventCoreModule,
+  ],
+  providers: [
+    {
+      provide: ICompanyImportService,
+      useClass: CompanyImportService,
+    },
+  ],
+  exports: [ICompanyImportService],
+})
+export class CompanyImportCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.interface.ts
@@ -1,0 +1,10 @@
+import { CompanyImportResultDto } from './dto/company-import-result.dto'
+
+export interface ICompanyImportService {
+  /** Parse + reconcile against the DB and return the diff. Writes nothing. */
+  preview(fileBuffer: Buffer): Promise<CompanyImportResultDto>
+  /** Parse + reconcile, then apply in one transaction. Returns the committed result. */
+  apply(fileBuffer: Buffer, actorUserId: string): Promise<CompanyImportResultDto>
+}
+
+export const ICompanyImportService = Symbol('ICompanyImportService')

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.spec.ts
@@ -1,0 +1,300 @@
+import { getConnectionToken, getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import {
+  CompanySizeEnum,
+  CompanyStatusEnum,
+} from '../company/models/company.enums'
+import { CompanyModel } from '../company/models/company.model'
+import { IsatCategoryModel } from '../company/models/isat-category.model'
+import { ICompanyEventService } from '../company-event/company-event.service.interface'
+import { PostcodeModel } from '../location/models/postcode.model'
+import { CompanyImportOutcomeEnum } from './dto/company-import-result.dto'
+import { ParsedCompanyRow } from './dto/parsed-company-row.dto'
+import { CompanyImportService } from './company-import.service'
+
+jest.mock('./parser/company-import.parser', () => ({
+  parseCompanyImport: jest.fn(),
+}))
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { parseCompanyImport } = require('./parser/company-import.parser')
+const mockParse = parseCompanyImport as jest.Mock
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+const BUF = Buffer.from('x')
+
+const makeRow = (o: Partial<ParsedCompanyRow> = {}): ParsedCompanyRow => ({
+  row: 2,
+  nationalId: '4101660389',
+  name: 'Acme ehf.',
+  address: 'Vesturvör 34',
+  postcodeCode: '200',
+  isatCategoryCode: '49390',
+  size: CompanySizeEnum.LARGE,
+  ...o,
+})
+
+const makeCompany = (o: Partial<CompanyModel> = {}) =>
+  ({
+    id: 'c1',
+    nationalId: '4101660389',
+    name: 'Acme ehf.',
+    address: 'Vesturvör 34',
+    postcodeId: 'pc-200',
+    postcode: { code: '200' },
+    isatCategoryCode: '49390',
+    employeeCountCategory: CompanySizeEnum.LARGE,
+    status: CompanyStatusEnum.ACTIVE,
+    update: jest.fn(),
+    ...o,
+  }) as unknown as CompanyModel
+
+describe('CompanyImportService', () => {
+  let service: CompanyImportService
+  let companyFindAll: jest.Mock
+  let companyCreate: jest.Mock
+  let isatFindAll: jest.Mock
+  let postcodeFindAll: jest.Mock
+  let emitCreated: jest.Mock
+  let emitStatusChanged: jest.Mock
+  let transaction: jest.Mock
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    companyFindAll = jest.fn().mockResolvedValue([])
+    companyCreate = jest.fn().mockResolvedValue(makeCompany({ id: 'new-1' }))
+    isatFindAll = jest.fn().mockResolvedValue([{ code: '49390' }])
+    postcodeFindAll = jest
+      .fn()
+      .mockResolvedValue([{ code: '200', id: 'pc-200' }])
+    emitCreated = jest.fn()
+    emitStatusChanged = jest.fn()
+    transaction = jest.fn(async (cb: () => Promise<unknown>) => cb())
+
+    mockParse.mockResolvedValue({ rows: [], errors: [], year: 2025 })
+
+    const module = await Test.createTestingModule({
+      providers: [
+        CompanyImportService,
+        { provide: LOGGER_PROVIDER, useValue: mockLogger },
+        { provide: getConnectionToken(), useValue: { transaction } },
+        {
+          provide: getModelToken(CompanyModel),
+          useValue: { findAll: companyFindAll, create: companyCreate },
+        },
+        {
+          provide: getModelToken(IsatCategoryModel),
+          useValue: { findAll: isatFindAll },
+        },
+        {
+          provide: getModelToken(PostcodeModel),
+          useValue: { findAll: postcodeFindAll },
+        },
+        {
+          provide: ICompanyEventService,
+          useValue: { emitCreated, emitStatusChanged },
+        },
+      ],
+    }).compile()
+
+    service = module.get(CompanyImportService)
+  })
+
+  it('categorizes a company that is in the file but not in the DB as CREATED', async () => {
+    mockParse.mockResolvedValue({ rows: [makeRow()], errors: [], year: 2025 })
+    companyFindAll.mockResolvedValue([])
+
+    const result = await service.preview(BUF)
+
+    expect(result.committed).toBe(false)
+    expect(result.created).toHaveLength(1)
+    expect(result.created[0].outcome).toBe(CompanyImportOutcomeEnum.CREATED)
+  })
+
+  it('categorizes an identical company as UNCHANGED', async () => {
+    mockParse.mockResolvedValue({ rows: [makeRow()], errors: [], year: 2025 })
+    companyFindAll.mockResolvedValue([makeCompany()])
+
+    const result = await service.preview(BUF)
+
+    expect(result.unchanged).toHaveLength(1)
+    expect(result.updated).toHaveLength(0)
+  })
+
+  it('records field-level changes as UPDATED', async () => {
+    mockParse.mockResolvedValue({
+      rows: [makeRow({ name: 'Acme New ehf.', size: CompanySizeEnum.MEDIUM })],
+      errors: [],
+      year: 2025,
+    })
+    companyFindAll.mockResolvedValue([makeCompany()])
+
+    const result = await service.preview(BUF)
+
+    expect(result.updated).toHaveLength(1)
+    const fields = result.updated[0].changedFields.map((c) => c.field)
+    expect(fields).toEqual(expect.arrayContaining(['name', 'size']))
+  })
+
+  it('flips an UNKNOWN company back to ACTIVE as REACTIVATED', async () => {
+    mockParse.mockResolvedValue({ rows: [makeRow()], errors: [], year: 2025 })
+    companyFindAll.mockResolvedValue([
+      makeCompany({ status: CompanyStatusEnum.UNKNOWN }),
+    ])
+
+    const result = await service.preview(BUF)
+
+    expect(result.reactivated).toHaveLength(1)
+    expect(result.reactivated[0].changedFields[0]).toMatchObject({
+      field: 'status',
+      from: CompanyStatusEnum.UNKNOWN,
+      to: CompanyStatusEnum.ACTIVE,
+    })
+  })
+
+  it('marks a DB company absent from the file as MARKED_UNKNOWN', async () => {
+    mockParse.mockResolvedValue({ rows: [], errors: [], year: 2025 })
+    companyFindAll.mockResolvedValue([
+      makeCompany({ nationalId: '4101680229' }),
+    ])
+
+    const result = await service.preview(BUF)
+
+    expect(result.markedUnknown).toHaveLength(1)
+    expect(result.markedUnknown[0].outcome).toBe(
+      CompanyImportOutcomeEnum.MARKED_UNKNOWN,
+    )
+  })
+
+  it('leaves an INACTIVE company absent from the file untouched', async () => {
+    mockParse.mockResolvedValue({ rows: [], errors: [], year: 2025 })
+    companyFindAll.mockResolvedValue([
+      makeCompany({
+        nationalId: '4101680229',
+        status: CompanyStatusEnum.INACTIVE,
+      }),
+    ])
+
+    const result = await service.preview(BUF)
+
+    expect(result.markedUnknown).toHaveLength(0)
+  })
+
+  it('rejects a row with an unknown ÍSAT code', async () => {
+    mockParse.mockResolvedValue({
+      rows: [makeRow({ isatCategoryCode: '99999' })],
+      errors: [],
+      year: 2025,
+    })
+    isatFindAll.mockResolvedValue([]) // 99999 not known
+    companyFindAll.mockResolvedValue([])
+
+    const result = await service.preview(BUF)
+
+    expect(result.created).toHaveLength(0)
+    expect(result.invalid).toHaveLength(1)
+    expect(result.invalid[0].reason).toContain('Unknown ÍSAT code')
+  })
+
+  it('adds a note when the postcode cannot be resolved (not a rejection)', async () => {
+    mockParse.mockResolvedValue({
+      rows: [makeRow({ postcodeCode: '999' })],
+      errors: [],
+      year: 2025,
+    })
+    postcodeFindAll.mockResolvedValue([]) // 999 not found
+    companyFindAll.mockResolvedValue([])
+
+    const result = await service.preview(BUF)
+
+    expect(result.created).toHaveLength(1)
+    expect(result.created[0].note).toContain('999')
+    expect(result.noticeCount).toBe(1)
+  })
+
+  it('does not treat a company present-but-invalid as absent', async () => {
+    mockParse.mockResolvedValue({
+      rows: [],
+      errors: [
+        { row: 2, nationalId: '4101660389', reason: 'Unknown ÍSAT code "x"' },
+      ],
+      year: 2025,
+    })
+    companyFindAll.mockResolvedValue([makeCompany()])
+
+    const result = await service.preview(BUF)
+
+    expect(result.markedUnknown).toHaveLength(0)
+  })
+
+  describe('apply', () => {
+    it('creates new companies and emits CREATED, inside a transaction', async () => {
+      mockParse.mockResolvedValue({ rows: [makeRow()], errors: [], year: 2025 })
+      companyFindAll.mockResolvedValue([])
+
+      const result = await service.apply(BUF, 'admin-1')
+
+      expect(transaction).toHaveBeenCalledTimes(1)
+      expect(companyCreate).toHaveBeenCalledTimes(1)
+      expect(emitCreated).toHaveBeenCalledWith(
+        'new-1',
+        expect.anything(),
+        'admin-1',
+      )
+      expect(result.committed).toBe(true)
+    })
+
+    it('updates fields and emits STATUS_CHANGED only for status flips', async () => {
+      const company = makeCompany({ status: CompanyStatusEnum.UNKNOWN })
+      mockParse.mockResolvedValue({
+        rows: [makeRow({ name: 'Renamed ehf.' })],
+        errors: [],
+        year: 2025,
+      })
+      companyFindAll.mockResolvedValue([company])
+
+      await service.apply(BUF, 'admin-1')
+
+      expect(company.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Renamed ehf.',
+          status: CompanyStatusEnum.ACTIVE,
+        }),
+      )
+      expect(emitStatusChanged).toHaveBeenCalledWith(
+        'c1',
+        CompanyStatusEnum.UNKNOWN,
+        CompanyStatusEnum.ACTIVE,
+        'admin-1',
+        expect.any(String),
+      )
+    })
+
+    it('marks absent companies UNKNOWN and emits the transition', async () => {
+      const company = makeCompany({ nationalId: '4101680229' })
+      mockParse.mockResolvedValue({ rows: [], errors: [], year: 2025 })
+      companyFindAll.mockResolvedValue([company])
+
+      await service.apply(BUF, 'admin-1')
+
+      expect(company.update).toHaveBeenCalledWith({
+        status: CompanyStatusEnum.UNKNOWN,
+      })
+      expect(emitStatusChanged).toHaveBeenCalledWith(
+        'c1',
+        CompanyStatusEnum.ACTIVE,
+        CompanyStatusEnum.UNKNOWN,
+        'admin-1',
+        expect.any(String),
+      )
+    })
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/company-import.service.ts
@@ -1,0 +1,412 @@
+import { Op } from 'sequelize'
+import { Sequelize } from 'sequelize-typescript'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectConnection, InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import {
+  CompanySizeEnum,
+  CompanyStatusEnum,
+} from '../company/models/company.enums'
+import { CompanyModel } from '../company/models/company.model'
+import { IsatCategoryModel } from '../company/models/isat-category.model'
+import { ICompanyEventService } from '../company-event/company-event.service.interface'
+import { PostcodeModel } from '../location/models/postcode.model'
+import {
+  CompanyImportErrorDto,
+  CompanyImportFieldChangeDto,
+  CompanyImportOutcomeEnum,
+  CompanyImportResultDto,
+  CompanyImportRowResultDto,
+} from './dto/company-import-result.dto'
+import { ParsedCompanyRow } from './dto/parsed-company-row.dto'
+import { parseCompanyImport } from './parser/company-import.parser'
+import { ICompanyImportService } from './company-import.service.interface'
+
+const LOGGING_CONTEXT = 'CompanyImportService'
+
+/** A planned write plus its result row, produced by reconcile and consumed by apply. */
+type CreatePlan = {
+  row: ParsedCompanyRow
+  postcodeId: string | null
+  result: CompanyImportRowResultDto
+}
+type UpdatePlan = {
+  company: CompanyModel
+  updateFields: Partial<{
+    name: string
+    address: string | null
+    postcodeId: string | null
+    isatCategoryCode: string | null
+    employeeCountCategory: CompanySizeEnum
+    status: CompanyStatusEnum
+  }>
+  statusChange: { from: CompanyStatusEnum; to: CompanyStatusEnum } | null
+  result: CompanyImportRowResultDto
+}
+type MarkPlan = { company: CompanyModel; result: CompanyImportRowResultDto }
+
+type ReconcilePlan = {
+  year: number | null
+  creates: CreatePlan[]
+  updates: UpdatePlan[]
+  marked: MarkPlan[]
+  unchanged: CompanyImportRowResultDto[]
+  invalid: CompanyImportErrorDto[]
+}
+
+/** Compare two optional strings treating '' and null as equal. */
+const norm = (v: string | null | undefined): string | null =>
+  (v ?? '').trim() || null
+const differs = (a: string | null | undefined, b: string | null | undefined) =>
+  norm(a) !== norm(b)
+
+@Injectable()
+export class CompanyImportService implements ICompanyImportService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectConnection() private readonly sequelize: Sequelize,
+    @InjectModel(CompanyModel)
+    private readonly companyModel: typeof CompanyModel,
+    @InjectModel(IsatCategoryModel)
+    private readonly isatCategoryModel: typeof IsatCategoryModel,
+    @InjectModel(PostcodeModel)
+    private readonly postcodeModel: typeof PostcodeModel,
+    @Inject(ICompanyEventService)
+    private readonly companyEventService: ICompanyEventService,
+  ) {}
+
+  async preview(fileBuffer: Buffer): Promise<CompanyImportResultDto> {
+    const plan = await this.reconcile(fileBuffer)
+    return this.toResult(plan, false)
+  }
+
+  async apply(
+    fileBuffer: Buffer,
+    actorUserId: string,
+  ): Promise<CompanyImportResultDto> {
+    const plan = await this.reconcile(fileBuffer)
+
+    await this.sequelize.transaction(async () => {
+      // CLS auto-propagates this transaction to the event service's writes too.
+      for (const c of plan.creates) {
+        const company = await this.companyModel.create({
+          name: c.row.name,
+          nationalId: c.row.nationalId,
+          employeeCountCategory: c.row.size,
+          address: c.row.address,
+          postcodeId: c.postcodeId,
+          isatCategoryCode: c.row.isatCategoryCode,
+          status: CompanyStatusEnum.ACTIVE,
+        })
+        await this.companyEventService.emitCreated(
+          company.id,
+          company.status,
+          actorUserId,
+        )
+      }
+
+      for (const u of plan.updates) {
+        await u.company.update(u.updateFields)
+        if (u.statusChange) {
+          await this.companyEventService.emitStatusChanged(
+            u.company.id,
+            u.statusChange.from,
+            u.statusChange.to,
+            actorUserId,
+            'Company import',
+          )
+        }
+      }
+
+      for (const m of plan.marked) {
+        const from = m.company.status
+        await m.company.update({ status: CompanyStatusEnum.UNKNOWN })
+        await this.companyEventService.emitStatusChanged(
+          m.company.id,
+          from,
+          CompanyStatusEnum.UNKNOWN,
+          actorUserId,
+          'Absent from company import',
+        )
+      }
+    })
+
+    const result = this.toResult(plan, true)
+    this.logger.info(
+      `Company import applied by ${actorUserId} (year ${result.year ?? 'n/a'}): ` +
+        `created=${result.created.length} updated=${result.updated.length} ` +
+        `unchanged=${result.unchanged.length} reactivated=${result.reactivated.length} ` +
+        `markedUnknown=${result.markedUnknown.length} invalid=${result.invalid.length}`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    return result
+  }
+
+  /** Pure planning: parse, validate ISAT, resolve postcodes, categorize. No writes. */
+  private async reconcile(fileBuffer: Buffer): Promise<ReconcilePlan> {
+    const parsed = await parseCompanyImport(fileBuffer)
+    const errors: CompanyImportErrorDto[] = [...parsed.errors]
+
+    // Validate ISAT codes against the reference table; reject unknowns.
+    const isatCodes = [
+      ...new Set(parsed.rows.map((r) => r.isatCategoryCode).filter(Boolean)),
+    ] as string[]
+    const knownIsat = new Set(
+      isatCodes.length
+        ? (
+            await this.isatCategoryModel.findAll({
+              where: { code: { [Op.in]: isatCodes } },
+              attributes: ['code'],
+            })
+          ).map((m) => m.code)
+        : [],
+    )
+
+    const validRows: ParsedCompanyRow[] = []
+    for (const row of parsed.rows) {
+      if (row.isatCategoryCode && !knownIsat.has(row.isatCategoryCode)) {
+        errors.push({
+          row: row.row,
+          nationalId: row.nationalId,
+          reason: `Unknown ÍSAT code "${row.isatCategoryCode}"`,
+        })
+        continue
+      }
+      validRows.push(row)
+    }
+
+    // Resolve postcodes (soft — an unresolved code is a note, not a rejection).
+    const postcodeCodes = [
+      ...new Set(validRows.map((r) => r.postcodeCode).filter(Boolean)),
+    ] as string[]
+    const postcodeIdByCode = new Map<string, string>()
+    if (postcodeCodes.length) {
+      const found = await this.postcodeModel.findAll({
+        where: { code: { [Op.in]: postcodeCodes } },
+      })
+      for (const p of found) postcodeIdByCode.set(p.code, p.id)
+    }
+
+    // Load every company once, with its postcode (for diff display).
+    const companies = await this.companyModel.findAll({
+      include: [{ model: PostcodeModel, as: 'postcode' }],
+    })
+    const byNationalId = new Map(companies.map((c) => [c.nationalId, c]))
+
+    // Every kennitala that appeared in the file (valid or invalid) — so a
+    // company present-but-rejected is NOT also marked absent.
+    const fileNationalIds = new Set<string>([
+      ...validRows.map((r) => r.nationalId),
+      ...errors.map((e) => e.nationalId).filter((n): n is string => !!n),
+    ])
+
+    const plan: ReconcilePlan = {
+      year: parsed.year,
+      creates: [],
+      updates: [],
+      marked: [],
+      unchanged: [],
+      invalid: errors,
+    }
+
+    for (const row of validRows) {
+      const company = byNationalId.get(row.nationalId)
+      const resolvedPostcodeId = row.postcodeCode
+        ? (postcodeIdByCode.get(row.postcodeCode) ?? null)
+        : null
+      const postcodeUnresolved =
+        !!row.postcodeCode && !postcodeIdByCode.has(row.postcodeCode)
+      const note = postcodeUnresolved
+        ? `Postnúmer "${row.postcodeCode}" not found — postcode left unchanged`
+        : null
+
+      if (!company) {
+        plan.creates.push({
+          row,
+          postcodeId: resolvedPostcodeId,
+          result: {
+            nationalId: row.nationalId,
+            name: row.name,
+            outcome: CompanyImportOutcomeEnum.CREATED,
+            changedFields: [],
+            note,
+          },
+        })
+        continue
+      }
+
+      const { changes, updateFields } = this.buildChanges(
+        company,
+        row,
+        postcodeUnresolved ? undefined : resolvedPostcodeId,
+      )
+
+      const reactivating =
+        company.status === CompanyStatusEnum.UNKNOWN ||
+        company.status === CompanyStatusEnum.INACTIVE
+      const statusChange = reactivating
+        ? { from: company.status, to: CompanyStatusEnum.ACTIVE }
+        : null
+
+      if (statusChange) {
+        updateFields.status = CompanyStatusEnum.ACTIVE
+        changes.unshift({
+          field: 'status',
+          from: statusChange.from,
+          to: statusChange.to,
+        })
+      }
+
+      if (!changes.length) {
+        plan.unchanged.push({
+          nationalId: row.nationalId,
+          name: row.name,
+          outcome: CompanyImportOutcomeEnum.UNCHANGED,
+          changedFields: [],
+          note,
+        })
+        continue
+      }
+
+      plan.updates.push({
+        company,
+        updateFields,
+        statusChange,
+        result: {
+          nationalId: row.nationalId,
+          name: row.name,
+          outcome: statusChange
+            ? CompanyImportOutcomeEnum.REACTIVATED
+            : CompanyImportOutcomeEnum.UPDATED,
+          changedFields: changes,
+          note,
+        },
+      })
+    }
+
+    // Companies we hold that are absent from the file.
+    for (const company of companies) {
+      if (fileNationalIds.has(company.nationalId)) continue
+      // Leave deliberate deactivations and already-unknown rows untouched.
+      if (company.status !== CompanyStatusEnum.ACTIVE) continue
+      plan.marked.push({
+        company,
+        result: {
+          nationalId: company.nationalId,
+          name: company.name,
+          outcome: CompanyImportOutcomeEnum.MARKED_UNKNOWN,
+          changedFields: [
+            {
+              field: 'status',
+              from: CompanyStatusEnum.ACTIVE,
+              to: CompanyStatusEnum.UNKNOWN,
+            },
+          ],
+          note: null,
+        },
+      })
+    }
+
+    return plan
+  }
+
+  /**
+   * Diff the authoritative fields. A null/absent file value means "not
+   * provided" and never clears an existing value (except size, which the file
+   * always asserts). `resolvedPostcodeId` is undefined when the postcode could
+   * not be resolved (skip the postcode diff entirely).
+   */
+  private buildChanges(
+    company: CompanyModel,
+    row: ParsedCompanyRow,
+    resolvedPostcodeId: string | null | undefined,
+  ): {
+    changes: CompanyImportFieldChangeDto[]
+    updateFields: UpdatePlan['updateFields']
+  } {
+    const changes: CompanyImportFieldChangeDto[] = []
+    const updateFields: UpdatePlan['updateFields'] = {}
+
+    if (differs(row.name, company.name)) {
+      changes.push({ field: 'name', from: company.name, to: row.name })
+      updateFields.name = row.name
+    }
+
+    if (row.address != null && differs(row.address, company.address)) {
+      changes.push({ field: 'address', from: company.address, to: row.address })
+      updateFields.address = row.address
+    }
+
+    if (
+      resolvedPostcodeId !== undefined &&
+      resolvedPostcodeId !== company.postcodeId
+    ) {
+      changes.push({
+        field: 'postcode',
+        from: company.postcode?.code ?? null,
+        to: row.postcodeCode,
+      })
+      updateFields.postcodeId = resolvedPostcodeId
+    }
+
+    if (
+      row.isatCategoryCode != null &&
+      differs(row.isatCategoryCode, company.isatCategoryCode)
+    ) {
+      changes.push({
+        field: 'isat',
+        from: company.isatCategoryCode,
+        to: row.isatCategoryCode,
+      })
+      updateFields.isatCategoryCode = row.isatCategoryCode
+    }
+
+    if (row.size !== company.employeeCountCategory) {
+      changes.push({
+        field: 'size',
+        from: company.employeeCountCategory,
+        to: row.size,
+      })
+      updateFields.employeeCountCategory = row.size
+    }
+
+    return { changes, updateFields }
+  }
+
+  private toResult(
+    plan: ReconcilePlan,
+    committed: boolean,
+  ): CompanyImportResultDto {
+    const updated = plan.updates
+      .filter((u) => u.result.outcome === CompanyImportOutcomeEnum.UPDATED)
+      .map((u) => u.result)
+    const reactivated = plan.updates
+      .filter((u) => u.result.outcome === CompanyImportOutcomeEnum.REACTIVATED)
+      .map((u) => u.result)
+    const created = plan.creates.map((c) => c.result)
+    const markedUnknown = plan.marked.map((m) => m.result)
+
+    const noticeCount = [
+      ...created,
+      ...updated,
+      ...reactivated,
+      ...plan.unchanged,
+    ].filter((r) => r.note).length
+
+    return {
+      committed,
+      year: plan.year,
+      noticeCount,
+      created,
+      updated,
+      unchanged: plan.unchanged,
+      markedUnknown,
+      reactivated,
+      invalid: plan.invalid,
+    }
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company-import/dto/company-import-result.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/dto/company-import-result.dto.ts
@@ -1,0 +1,113 @@
+import {
+  ApiBoolean,
+  ApiDtoArray,
+  ApiEnum,
+  ApiNumber,
+  ApiOptionalNumber,
+  ApiOptionalString,
+  ApiString,
+} from '@dmr.is/decorators'
+
+/**
+ * Outcome categories for a single company in an import run. Drives both the
+ * per-row result lists and the totals.
+ */
+export enum CompanyImportOutcomeEnum {
+  /** In the file, not in our DB → will be created. */
+  CREATED = 'CREATED',
+  /** In file + DB, ≥1 authoritative field differs → fields updated. */
+  UPDATED = 'UPDATED',
+  /** In file + DB, identical and already ACTIVE → no change. */
+  UNCHANGED = 'UNCHANGED',
+  /** In DB (was ACTIVE), absent from file → status set to UNKNOWN. */
+  MARKED_UNKNOWN = 'MARKED_UNKNOWN',
+  /** In file, was UNKNOWN/INACTIVE → status flipped back to ACTIVE. */
+  REACTIVATED = 'REACTIVATED',
+}
+
+export class CompanyImportFieldChangeDto {
+  @ApiString({ description: 'Company field that changed, e.g. "name".' })
+  field!: string
+
+  @ApiOptionalString({ nullable: true, description: 'Previous value.' })
+  from!: string | null
+
+  @ApiOptionalString({ nullable: true, description: 'New value from the file.' })
+  to!: string | null
+}
+
+export class CompanyImportRowResultDto {
+  @ApiString()
+  nationalId!: string
+
+  @ApiString()
+  name!: string
+
+  @ApiEnum(CompanyImportOutcomeEnum, { enumName: 'CompanyImportOutcomeEnum' })
+  outcome!: CompanyImportOutcomeEnum
+
+  @ApiDtoArray(CompanyImportFieldChangeDto, {
+    description: 'Field-level diff (UPDATED / REACTIVATED only).',
+  })
+  changedFields!: CompanyImportFieldChangeDto[]
+
+  @ApiOptionalString({
+    nullable: true,
+    description: 'Soft notice, e.g. an unresolved postcode that was left unset.',
+  })
+  note!: string | null
+}
+
+export class CompanyImportErrorDto {
+  @ApiNumber({ description: 'Spreadsheet row number (1-based, incl. header).' })
+  row!: number
+
+  @ApiOptionalString({ nullable: true })
+  nationalId!: string | null
+
+  @ApiString({ description: 'Why the row was rejected.' })
+  reason!: string
+}
+
+export class CompanyImportTotalsDto {
+  @ApiNumber() created!: number
+  @ApiNumber() updated!: number
+  @ApiNumber() unchanged!: number
+  @ApiNumber() markedUnknown!: number
+  @ApiNumber() reactivated!: number
+  @ApiNumber() invalid!: number
+}
+
+export class CompanyImportResultDto {
+  @ApiBoolean({
+    description: 'false = preview (no writes); true = applied (committed).',
+  })
+  committed!: boolean
+
+  @ApiOptionalNumber({
+    nullable: true,
+    description: 'Reporting year (TEKJUAR) from the file, if consistent.',
+  })
+  year!: number | null
+
+  @ApiNumber({ description: 'Notice from a soft issue, e.g. an unresolved postcode.' })
+  noticeCount!: number
+
+  @ApiDtoArray(CompanyImportRowResultDto)
+  created!: CompanyImportRowResultDto[]
+
+  @ApiDtoArray(CompanyImportRowResultDto)
+  updated!: CompanyImportRowResultDto[]
+
+  @ApiDtoArray(CompanyImportRowResultDto)
+  unchanged!: CompanyImportRowResultDto[]
+
+  @ApiDtoArray(CompanyImportRowResultDto)
+  markedUnknown!: CompanyImportRowResultDto[]
+
+  @ApiDtoArray(CompanyImportRowResultDto)
+  reactivated!: CompanyImportRowResultDto[]
+
+  @ApiDtoArray(CompanyImportErrorDto)
+  invalid!: CompanyImportErrorDto[]
+}

--- a/apps/directorate-of-equality-api/src/modules/company-import/dto/parsed-company-row.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/dto/parsed-company-row.dto.ts
@@ -1,0 +1,27 @@
+import { CompanySizeEnum } from '../../company/models/company.enums'
+import { CompanyImportErrorDto } from './company-import-result.dto'
+
+/**
+ * One valid data row extracted from the import workbook. Pure parse output —
+ * the ISAT code is not yet checked against `isat_category` and the postcode is
+ * not yet resolved to a `postcodeId`; the service does both (DB-dependent).
+ */
+export interface ParsedCompanyRow {
+  /** 1-based spreadsheet row number (for error reporting). */
+  row: number
+  nationalId: string
+  name: string
+  address: string | null
+  /** POSTNUMER as a string code, e.g. "200". Resolved to a postcode by the service. */
+  postcodeCode: string | null
+  /** Normalized 5-digit ÍSAT code, e.g. "01110". Validated by the service. */
+  isatCategoryCode: string | null
+  size: CompanySizeEnum
+}
+
+export interface ParsedCompanyImport {
+  rows: ParsedCompanyRow[]
+  errors: CompanyImportErrorDto[]
+  /** TEKJUAR — present only if all rows agree on a single year. */
+  year: number | null
+}

--- a/apps/directorate-of-equality-api/src/modules/company-import/parser/company-import.parser.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/parser/company-import.parser.spec.ts
@@ -1,0 +1,148 @@
+import ExcelJS from 'exceljs'
+
+import { BadRequestException } from '@nestjs/common'
+
+import { CompanySizeEnum } from '../../company/models/company.enums'
+import {
+  mapSizeLabel,
+  normalizeIsatCode,
+  parseCompanyImport,
+} from './company-import.parser'
+
+// Header row mirrors the real file, including a blank spacer column (J) before
+// LAUNAFLOKKUR — so we exercise header-based (not letter-based) mapping.
+const HEADER = [
+  'TEKJUAR',
+  'KENNITALA',
+  'NAFN',
+  'LOGHEIMILI',
+  'POSTNUMER',
+  'SVEITARFELAG_NR',
+  'SVEITARFELAG',
+  'ISAT',
+  'ISAT2008LYSING',
+  null,
+  'LAUNAFLOKKUR',
+]
+
+type Cell = string | number | null
+
+const buildBook = async (rows: Cell[][], header = HEADER): Promise<Buffer> => {
+  const wb = new ExcelJS.Workbook()
+  const ws = wb.addWorksheet('Companies')
+  ws.addRow(header)
+  rows.forEach((r) => ws.addRow(r))
+  return Buffer.from((await wb.xlsx.writeBuffer()) as unknown as ArrayBuffer)
+}
+
+// Valid company kennitalas (verified with the kennitala package).
+const kt1 = '4101660389'
+const kt2 = '4101680229'
+
+const row = (overrides: Partial<Record<string, Cell>> = {}): Cell[] => [
+  overrides.year ?? 2025,
+  overrides.kt ?? kt1,
+  overrides.name ?? 'Acme ehf.',
+  overrides.address ?? 'Vesturvör 34',
+  overrides.postcode ?? '200',
+  1000,
+  'Kópavogur',
+  overrides.isat ?? '49390',
+  'Aðrir farþegaflutningar á landi',
+  null,
+  overrides.size ?? '50+',
+]
+
+describe('company-import parser', () => {
+  describe('mapSizeLabel', () => {
+    it('maps 50+ → LARGE, 25-49 → MEDIUM, everything else → SMALL', () => {
+      expect(mapSizeLabel('50+')).toBe(CompanySizeEnum.LARGE)
+      expect(mapSizeLabel('25-49')).toBe(CompanySizeEnum.MEDIUM)
+      expect(mapSizeLabel('0-24')).toBe(CompanySizeEnum.SMALL)
+      expect(mapSizeLabel('')).toBe(CompanySizeEnum.SMALL)
+      expect(mapSizeLabel(null)).toBe(CompanySizeEnum.SMALL)
+      expect(mapSizeLabel(' 50+ ')).toBe(CompanySizeEnum.LARGE)
+    })
+  })
+
+  describe('normalizeIsatCode', () => {
+    it('pads to 5 digits to recover leading zeros lost to numeric cells', () => {
+      expect(normalizeIsatCode('1110')).toBe('01110')
+      expect(normalizeIsatCode('49390')).toBe('49390')
+      expect(normalizeIsatCode('01.11.0')).toBe('01110')
+      expect(normalizeIsatCode(null)).toBeNull()
+      expect(normalizeIsatCode('')).toBeNull()
+    })
+  })
+
+  it('parses valid rows and maps the columns', async () => {
+    const buf = await buildBook([row(), row({ kt: kt2, name: 'Beta ehf.' })])
+    const result = await parseCompanyImport(buf)
+
+    expect(result.errors).toHaveLength(0)
+    expect(result.year).toBe(2025)
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0]).toMatchObject({
+      nationalId: kt1,
+      name: 'Acme ehf.',
+      address: 'Vesturvör 34',
+      postcodeCode: '200',
+      isatCategoryCode: '49390',
+      size: CompanySizeEnum.LARGE,
+    })
+  })
+
+  it('recovers a leading-zero ISAT code stored as a number', async () => {
+    const buf = await buildBook([row({ isat: 1110 })])
+    const result = await parseCompanyImport(buf)
+    expect(result.rows[0].isatCategoryCode).toBe('01110')
+  })
+
+  it('rejects an invalid kennitala', async () => {
+    const buf = await buildBook([row({ kt: '0000000000' })])
+    const result = await parseCompanyImport(buf)
+    expect(result.rows).toHaveLength(0)
+    expect(result.errors[0]).toMatchObject({ reason: 'Invalid or missing kennitala' })
+  })
+
+  it('rejects a row missing the company name', async () => {
+    const buf = await buildBook([row({ name: '' })])
+    const result = await parseCompanyImport(buf)
+    expect(result.rows).toHaveLength(0)
+    expect(result.errors[0].reason).toContain('Missing company name')
+  })
+
+  it('rejects every row of a duplicated kennitala', async () => {
+    const buf = await buildBook([
+      row({ kt: kt1, name: 'First' }),
+      row({ kt: kt1, name: 'Second' }),
+    ])
+    const result = await parseCompanyImport(buf)
+    expect(result.rows).toHaveLength(0)
+    expect(result.errors).toHaveLength(2)
+    expect(result.errors.every((e) => e.reason.includes('Duplicate'))).toBe(true)
+  })
+
+  it('skips fully blank rows', async () => {
+    const buf = await buildBook([
+      row(),
+      [null, null, null, null, null, null, null, null, null, null, null],
+    ])
+    const result = await parseCompanyImport(buf)
+    expect(result.rows).toHaveLength(1)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  it('returns null year when rows disagree', async () => {
+    const buf = await buildBook([row({ year: 2025 }), row({ kt: kt2, year: 2024 })])
+    const result = await parseCompanyImport(buf)
+    expect(result.year).toBeNull()
+  })
+
+  it('throws on a missing required header', async () => {
+    const badHeader = ['TEKJUAR', 'NAFN', 'LAUNAFLOKKUR'] // no KENNITALA
+    await expect(
+      parseCompanyImport(await buildBook([], badHeader)),
+    ).rejects.toThrow(BadRequestException)
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/company-import/parser/company-import.parser.ts
+++ b/apps/directorate-of-equality-api/src/modules/company-import/parser/company-import.parser.ts
@@ -1,0 +1,177 @@
+/**
+ * Parser for the annual company register workbook.
+ *
+ * Pure (buffer → result): extracts and locally validates every row, never
+ * throws on a single-row problem (those accumulate into `errors`). Only a
+ * structural problem — unreadable workbook or a missing required header —
+ * throws `BadRequestException`.
+ *
+ * Columns are located by header name (row 1), not by fixed letter, so a blank
+ * spacer column or reordering doesn't break the mapping. DB-dependent checks
+ * (ISAT code exists, postcode resolves) are deferred to the service.
+ */
+
+import ExcelJS from 'exceljs'
+import { isValid as isValidKennitala, sanitize } from 'kennitala'
+
+import { BadRequestException } from '@nestjs/common'
+
+import { CompanySizeEnum } from '../../company/models/company.enums'
+import { readInteger, readString } from '../../report-excel/parser/cell'
+import { CompanyImportErrorDto } from '../dto/company-import-result.dto'
+import {
+  ParsedCompanyImport,
+  ParsedCompanyRow,
+} from '../dto/parsed-company-row.dto'
+
+// Header labels as they appear in the sheet (row 1), upper-cased for matching.
+const HEADERS = {
+  year: 'TEKJUAR',
+  nationalId: 'KENNITALA',
+  name: 'NAFN',
+  address: 'LOGHEIMILI',
+  postcode: 'POSTNUMER',
+  isat: 'ISAT',
+  size: 'LAUNAFLOKKUR',
+} as const
+
+// Without these the file isn't the register we expect.
+const REQUIRED_HEADERS = [HEADERS.nationalId, HEADERS.name, HEADERS.size]
+
+/** LAUNAFLOKKUR → size bucket. Anything that isn't 50+/25-49 is treated as SMALL. */
+export const mapSizeLabel = (label: string | null): CompanySizeEnum => {
+  const v = (label ?? '').replace(/\s/g, '')
+  if (v === '50+') return CompanySizeEnum.LARGE
+  if (v === '25-49') return CompanySizeEnum.MEDIUM
+  return CompanySizeEnum.SMALL
+}
+
+/**
+ * Normalize an ÍSAT code to the 5-digit form. Excel often stores a code like
+ * "01110" as the number 1110, dropping the leading zero — pad it back. Codes
+ * outside 5 digits are returned as-is so the service rejects them with the
+ * offending value shown.
+ */
+export const normalizeIsatCode = (raw: string | null): string | null => {
+  if (raw == null) return null
+  const digits = raw.replace(/\D/g, '')
+  if (!digits) return null
+  return digits.length <= 5 ? digits.padStart(5, '0') : digits
+}
+
+export const parseCompanyImport = async (
+  fileBuffer: Buffer,
+): Promise<ParsedCompanyImport> => {
+  const workbook = new ExcelJS.Workbook()
+  try {
+    await workbook.xlsx.load(fileBuffer)
+  } catch {
+    throw new BadRequestException(
+      'Could not read the uploaded file as an .xlsx workbook',
+    )
+  }
+
+  const sheet = workbook.worksheets[0]
+  if (!sheet) {
+    throw new BadRequestException('The workbook has no worksheets')
+  }
+
+  // Map header label → column number from row 1.
+  const headerRow = sheet.getRow(1)
+  const colByHeader = new Map<string, number>()
+  headerRow.eachCell((cell, col) => {
+    const label = readString(cell)?.toUpperCase()
+    if (label && !colByHeader.has(label)) colByHeader.set(label, col)
+  })
+
+  const missing = REQUIRED_HEADERS.filter((h) => !colByHeader.has(h))
+  if (missing.length) {
+    throw new BadRequestException(
+      `Missing required column(s): ${missing.join(', ')}`,
+    )
+  }
+
+  const col = (header: string): number | null => colByHeader.get(header) ?? null
+  const cellStr = (rowNo: number, header: string): string | null => {
+    const c = col(header)
+    return c ? readString(sheet.getRow(rowNo).getCell(c)) : null
+  }
+
+  const rows: ParsedCompanyRow[] = []
+  const errors: CompanyImportErrorDto[] = []
+  const years = new Set<number>()
+  // Track kennitalas seen, to flag duplicates within the file.
+  const seenAt = new Map<string, number>()
+  const dupKennitalas = new Set<string>()
+
+  for (let rowNo = 2; rowNo <= sheet.rowCount; rowNo++) {
+    const rawKt = cellStr(rowNo, HEADERS.nationalId)
+    const name = cellStr(rowNo, HEADERS.name)
+
+    // Skip fully-blank rows (no kennitala and no name).
+    if (!rawKt && !name) continue
+
+    const nationalId = rawKt ? sanitize(rawKt) : null
+
+    if (!nationalId || !isValidKennitala(nationalId)) {
+      errors.push({
+        row: rowNo,
+        nationalId: rawKt,
+        reason: 'Invalid or missing kennitala',
+      })
+      continue
+    }
+
+    if (!name) {
+      errors.push({
+        row: rowNo,
+        nationalId,
+        reason: 'Missing company name (NAFN)',
+      })
+      continue
+    }
+
+    if (seenAt.has(nationalId)) dupKennitalas.add(nationalId)
+    else seenAt.set(nationalId, rowNo)
+
+    const yearCol = col(HEADERS.year)
+    if (yearCol) {
+      const y = readInteger(sheet.getRow(rowNo).getCell(yearCol))
+      if (y != null) years.add(y)
+    }
+
+    rows.push({
+      row: rowNo,
+      nationalId,
+      name,
+      address: cellStr(rowNo, HEADERS.address),
+      postcodeCode: cellStr(rowNo, HEADERS.postcode),
+      isatCategoryCode: normalizeIsatCode(cellStr(rowNo, HEADERS.isat)),
+      size: mapSizeLabel(cellStr(rowNo, HEADERS.size)),
+    })
+  }
+
+  // Reject every row of a duplicated kennitala — we can't tell which is truth.
+  if (dupKennitalas.size) {
+    const kept: ParsedCompanyRow[] = []
+    for (const r of rows) {
+      if (dupKennitalas.has(r.nationalId)) {
+        errors.push({
+          row: r.row,
+          nationalId: r.nationalId,
+          reason: 'Duplicate kennitala in file — no row applied',
+        })
+      } else {
+        kept.push(r)
+      }
+    }
+    rows.length = 0
+    rows.push(...kept)
+  }
+
+  return {
+    rows,
+    errors,
+    year: years.size === 1 ? [...years][0] : null,
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.controller.ts
@@ -30,6 +30,7 @@ import { CompanyTimelineItemDto } from './dto/company-timeline-item.dto'
 import { CreateCompanyDto } from './dto/create-company.dto'
 import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { UpdateCompanyIsatDto } from './dto/update-company-isat.dto'
 import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 import { ICompanyService } from './company.service.interface'
 
@@ -89,6 +90,21 @@ export class CompanyController {
     @CurrentAdminUser() admin: UserModel,
   ): Promise<CompanyDto> {
     return this.companyService.updateStatus(id, dto, admin.id)
+  }
+
+  @Patch(':id/isat')
+  @ApiParam({ name: 'id', type: String })
+  @DoeResponse({
+    operationId: 'updateCompanyIsat',
+    type: CompanyDto,
+    include404: true,
+  })
+  async updateIsat(
+    @Param('id') id: string,
+    @Body() dto: UpdateCompanyIsatDto,
+    @CurrentAdminUser() admin: UserModel,
+  ): Promise<CompanyDto> {
+    return this.companyService.updateIsat(id, dto, admin.id)
   }
 
   @Get(':id/timeline')

--- a/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.core.module.ts
@@ -6,12 +6,13 @@ import { NationalRegistryModule } from '@dmr.is/clients-national-registry'
 import { CompanyCommentCoreModule } from '../company-comment/company-comment.core.module'
 import { CompanyEventCoreModule } from '../company-event/company-event.core.module'
 import { CompanyModel } from './models/company.model'
+import { IsatCategoryModel } from './models/isat-category.model'
 import { CompanyService } from './company.service'
 import { ICompanyService } from './company.service.interface'
 
 @Module({
   imports: [
-    SequelizeModule.forFeature([CompanyModel]),
+    SequelizeModule.forFeature([CompanyModel, IsatCategoryModel]),
     NationalRegistryModule,
     CompanyEventCoreModule,
     CompanyCommentCoreModule,

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.interface.ts
@@ -6,6 +6,7 @@ import { GetCompaniesQueryDto } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
 import { SubsidiaryReportSnapshotLookup } from './dto/subsidiary-report-snapshot-lookup.dto'
 import { SubsidiaryReportSnapshotSourceDto } from './dto/subsidiary-report-snapshot-source.dto'
+import { UpdateCompanyIsatDto } from './dto/update-company-isat.dto'
 import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 
 export {
@@ -32,6 +33,11 @@ export interface ICompanyService {
   updateStatus(
     id: string,
     dto: UpdateCompanyStatusDto,
+    actorUserId: string,
+  ): Promise<CompanyDto>
+  updateIsat(
+    id: string,
+    dto: UpdateCompanyIsatDto,
     actorUserId: string,
   ): Promise<CompanyDto>
   getTimeline(id: string): Promise<CompanyTimelineItemDto[]>

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
 import { getModelToken } from '@nestjs/sequelize'
 import { Test } from '@nestjs/testing'
 
@@ -13,6 +13,7 @@ import { ICompanyEventService } from '../company-event/company-event.service.int
 import { CompanyTimelineItemKindEnum } from './dto/company-timeline-item.dto'
 import { CompanySizeEnum, CompanyStatusEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
+import { IsatCategoryModel } from './models/isat-category.model'
 import { CompanyService } from './company.service'
 
 const mockLogger = {
@@ -32,11 +33,13 @@ describe('CompanyService', () => {
   let emitStatusChanged: jest.Mock
   let eventsByCompanyId: jest.Mock
   let commentsByCompanyId: jest.Mock
+  let isatFindByPk: jest.Mock
 
   beforeEach(async () => {
     findOneOrThrow = jest.fn()
     findOne = jest.fn()
     create = jest.fn()
+    isatFindByPk = jest.fn()
     getEntityByNationalId = jest.fn()
     emitCreated = jest.fn()
     emitStatusChanged = jest.fn()
@@ -54,6 +57,10 @@ describe('CompanyService', () => {
         {
           provide: getModelToken(CompanyModel),
           useValue: { findOneOrThrow, findOne, create },
+        },
+        {
+          provide: getModelToken(IsatCategoryModel),
+          useValue: { findByPk: isatFindByPk },
         },
         {
           provide: ICompanyEventService,
@@ -387,6 +394,86 @@ describe('CompanyService', () => {
       ).rejects.toThrow(NotFoundException)
 
       expect(emitStatusChanged).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateIsat', () => {
+    it('sets a valid ÍSAT code after validating it exists', async () => {
+      const update = jest.fn()
+      findOneOrThrow
+        .mockResolvedValueOnce({
+          id: 'company-1',
+          isatCategoryCode: null,
+          update,
+          fromModel: () => ({ id: 'company-1' }),
+        })
+        .mockResolvedValueOnce({
+          fromModel: () => ({ id: 'company-1', isatCategoryCode: '01110' }),
+        })
+      isatFindByPk.mockResolvedValue({ code: '01110' })
+
+      const result = await service.updateIsat(
+        'company-1',
+        { isatCategoryCode: '01110' },
+        'admin-1',
+      )
+
+      expect(isatFindByPk).toHaveBeenCalledWith('01110')
+      expect(update).toHaveBeenCalledWith({ isatCategoryCode: '01110' })
+      expect(result.isatCategoryCode).toBe('01110')
+    })
+
+    it('rejects an unknown ÍSAT code and does not update', async () => {
+      const update = jest.fn()
+      findOneOrThrow.mockResolvedValueOnce({
+        id: 'company-1',
+        isatCategoryCode: null,
+        update,
+        fromModel: () => ({ id: 'company-1' }),
+      })
+      isatFindByPk.mockResolvedValue(null)
+
+      await expect(
+        service.updateIsat(
+          'company-1',
+          { isatCategoryCode: 'nope' },
+          'admin-1',
+        ),
+      ).rejects.toThrow(BadRequestException)
+
+      expect(update).not.toHaveBeenCalled()
+    })
+
+    it('clears the classification when passed null (no code lookup)', async () => {
+      const update = jest.fn()
+      findOneOrThrow
+        .mockResolvedValueOnce({
+          id: 'company-1',
+          isatCategoryCode: '01110',
+          update,
+          fromModel: () => ({ id: 'company-1' }),
+        })
+        .mockResolvedValueOnce({
+          fromModel: () => ({ id: 'company-1', isatCategoryCode: null }),
+        })
+
+      const result = await service.updateIsat(
+        'company-1',
+        { isatCategoryCode: null },
+        'admin-1',
+      )
+
+      expect(isatFindByPk).not.toHaveBeenCalled()
+      expect(update).toHaveBeenCalledWith({ isatCategoryCode: null })
+      expect(result.isatCategoryCode).toBeNull()
+    })
+
+    it('throws NotFoundException when the company does not exist', async () => {
+      findOneOrThrow.mockRejectedValue(new NotFoundException())
+
+      await expect(
+        service.updateIsat('missing', { isatCategoryCode: '01110' }, 'admin-1'),
+      ).rejects.toThrow(NotFoundException)
     })
   })
 

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -1,6 +1,7 @@
 import { literal, Op, Order, WhereOptions } from 'sequelize'
 
 import {
+  BadRequestException,
   ConflictException,
   Inject,
   Injectable,
@@ -28,9 +29,11 @@ import {
   CompanySortDirectionEnum,
 } from './dto/get-companies-query.dto'
 import { GetCompaniesResponseDto } from './dto/get-companies-response.dto'
+import { UpdateCompanyIsatDto } from './dto/update-company-isat.dto'
 import { UpdateCompanyStatusDto } from './dto/update-company-status.dto'
 import { CompanySizeEnum } from './models/company.enums'
 import { CompanyModel } from './models/company.model'
+import { IsatCategoryModel } from './models/isat-category.model'
 import { buildCompanyExpiryWhere, buildCompanyStatusWhere } from './utils/filters'
 import {
   CreateCompanyInput,
@@ -50,6 +53,8 @@ export class CompanyService implements ICompanyService {
     private readonly nationalRegistryService: INationalRegistryService,
     @InjectModel(CompanyModel)
     private readonly companyModel: typeof CompanyModel,
+    @InjectModel(IsatCategoryModel)
+    private readonly isatCategoryModel: typeof IsatCategoryModel,
     @Inject(ICompanyEventService)
     private readonly companyEventService: ICompanyEventService,
     @Inject(ICompanyCommentService)
@@ -305,6 +310,47 @@ export class CompanyService implements ICompanyService {
     )
 
     return company.fromModel()
+  }
+
+  /**
+   * Admin-owned ÍSAT2008 classification (statistics data). Independent of the
+   * report-submission snapshot — see db/README.md. Pass `isatCategoryCode: null`
+   * to clear. The FK also guards bad codes; we validate up-front for a clean 400.
+   */
+  async updateIsat(
+    id: string,
+    dto: UpdateCompanyIsatDto,
+    actorUserId: string,
+  ): Promise<CompanyDto> {
+    const company = await this.companyModel.findOneOrThrow(
+      { where: { id } },
+      `Company "${id}" not found`,
+    )
+
+    const code = dto.isatCategoryCode ?? null
+
+    if (code !== null) {
+      const category = await this.isatCategoryModel.findByPk(code)
+      if (!category) {
+        throw new BadRequestException(`Unknown ÍSAT2008 code "${code}"`)
+      }
+    }
+
+    this.logger.info(
+      `Updating company ${id} ÍSAT: ${company.isatCategoryCode ?? '∅'} → ${
+        code ?? '∅'
+      } (by ${actorUserId})`,
+      { context: LOGGING_CONTEXT },
+    )
+
+    await company.update({ isatCategoryCode: code })
+
+    const updated = await this.companyModel.findOneOrThrow({
+      where: { id },
+      include: [{ model: IsatCategoryModel, as: 'isatCategory' }],
+    })
+
+    return updated.fromModel()
   }
 
   async getTimeline(id: string): Promise<CompanyTimelineItemDto[]> {

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
@@ -1,3 +1,5 @@
+import { ApiPropertyOptional } from '@nestjs/swagger'
+
 import {
   ApiBoolean,
   ApiEnum,
@@ -8,6 +10,7 @@ import {
 } from '@dmr.is/decorators'
 
 import { CompanySizeEnum, CompanyStatusEnum } from '../models/company.enums'
+import { IsatCategoryDto } from './isat-category.dto'
 
 export class CompanyDto {
   @ApiUUId()
@@ -36,4 +39,14 @@ export class CompanyDto {
 
   @ApiBoolean()
   salaryReportRequiredOverride!: boolean
+
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      'Normalized ÍSAT2008 leaf code (admin-owned statistics field), e.g. "01110".',
+  })
+  isatCategoryCode!: string | null
+
+  @ApiPropertyOptional({ type: IsatCategoryDto, nullable: true })
+  isatCategory!: IsatCategoryDto | null
 }

--- a/apps/directorate-of-equality-api/src/modules/company/dto/isat-category.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/isat-category.dto.ts
@@ -1,0 +1,15 @@
+import { ApiString } from '@dmr.is/decorators'
+
+export class IsatCategoryDto {
+  @ApiString({ description: 'Normalized ÍSAT2008 leaf code, e.g. "01110".' })
+  code!: string
+
+  @ApiString({ description: 'Display (dotted) form, e.g. "01.11.0".' })
+  codeDotted!: string
+
+  @ApiString({ description: 'Icelandic description.' })
+  description!: string
+
+  @ApiString({ description: 'English description.' })
+  descriptionEn!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/company/dto/update-company-isat.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/update-company-isat.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString } from 'class-validator'
+
+import { ApiOptionalString } from '@dmr.is/decorators'
+
+export class UpdateCompanyIsatDto {
+  @ApiOptionalString({
+    nullable: true,
+    description:
+      'Normalized ÍSAT2008 leaf code, e.g. "01110". Null clears the classification.',
+  })
+  @IsOptional()
+  @IsString()
+  isatCategoryCode!: string | null
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
@@ -35,6 +35,10 @@ export enum CompanySizeEnum {
  *   INACTIVE → no longer operating (e.g. bankruptcy, merged into another
  *              company). Set by an admin; the reason is captured on the
  *              `company_event` STATUS_CHANGED row, not here.
+ *   UNKNOWN  → the company is in our register but absent from the latest
+ *              authoritative annual import — it should be in the list, so
+ *              something is off, but we don't yet know what. Set by the
+ *              company import; flips back to ACTIVE when it reappears.
  *
  * Status changes are recorded as `company_event` STATUS_CHANGED events
  * (with from/to status + optional reason), so the full history is explorable
@@ -43,4 +47,5 @@ export enum CompanySizeEnum {
 export enum CompanyStatusEnum {
   ACTIVE = 'ACTIVE',
   INACTIVE = 'INACTIVE',
+  UNKNOWN = 'UNKNOWN',
 }

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
@@ -7,6 +7,7 @@ import { PostcodeModel } from '../../location/models/postcode.model'
 import type { CreateReportCompanySnapshotDto } from '../../report-create/dto/create-report.dto'
 import type { CompanyDto } from '../dto/company.dto'
 import { CompanySizeEnum, CompanyStatusEnum } from './company.enums'
+import { IsatCategoryModel } from './isat-category.model'
 
 type CompanyAttributes = {
   name: string
@@ -17,6 +18,7 @@ type CompanyAttributes = {
   postcodeId: string | null
   salaryReportRequired: boolean
   salaryReportRequiredOverride: boolean
+  isatCategoryCode: string | null
 }
 
 type CompanyCreateAttributes = {
@@ -28,6 +30,7 @@ type CompanyCreateAttributes = {
   postcodeId?: string | null
   salaryReportRequired?: boolean
   salaryReportRequiredOverride?: boolean
+  isatCategoryCode?: string | null
 }
 
 @MutableTable({ tableName: DoeModels.COMPANY })
@@ -81,6 +84,17 @@ export class CompanyModel extends MutableModel<
   })
   salaryReportRequiredOverride!: boolean
 
+  @ForeignKey(() => IsatCategoryModel)
+  @Column({ type: DataType.TEXT, allowNull: true, field: 'isat_category_code' })
+  isatCategoryCode!: string | null
+
+  @BelongsTo(() => IsatCategoryModel, {
+    foreignKey: 'isatCategoryCode',
+    targetKey: 'code',
+    as: 'isatCategory',
+  })
+  isatCategory?: IsatCategoryModel | null
+
   static fromModel(model: CompanyModel): CompanyDto {
     return {
       id: model.id,
@@ -92,9 +106,16 @@ export class CompanyModel extends MutableModel<
       postcodeId: model.postcodeId,
       salaryReportRequired: model.salaryReportRequired,
       salaryReportRequiredOverride: model.salaryReportRequiredOverride,
+      isatCategoryCode: model.isatCategoryCode,
+      isatCategory: model.isatCategory
+        ? IsatCategoryModel.fromModel(model.isatCategory)
+        : null,
     }
   }
 
+  // NOTE: company-level ISAT (isatCategoryCode) is admin-owned statistics data
+  // and is intentionally NOT snapshotted here — report_company.isat_category is
+  // an independent free-text submission snapshot. See db/README.md.
   static toSnapshot(dto: CompanyDto): CreateReportCompanySnapshotDto {
     return {
       companyId: dto.id,

--- a/apps/directorate-of-equality-api/src/modules/company/models/isat-category.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/isat-category.model.ts
@@ -1,0 +1,47 @@
+import { Column, DataType, Model, PrimaryKey, Table } from 'sequelize-typescript'
+
+import { DoeModels } from '../../../core/constants'
+import type { IsatCategoryDto } from '../dto/isat-category.dto'
+
+/**
+ * ÍSAT2008 industry classification (Hagstofan). Reference data — seeded with the
+ * 665 leaf (5-digit / two-dot) codes; this migration only creates the table.
+ * `code` is the normalized form (e.g. "01110") and the natural PK that
+ * `company.isat_category_code` references; `code_dotted` (e.g. "01.11.0") is for
+ * display. Static lookup, so no created_at/updated_at. See db/README.md.
+ */
+type IsatCategoryAttributes = {
+  code: string
+  codeDotted: string
+  description: string
+  descriptionEn: string
+}
+
+@Table({ tableName: DoeModels.ISAT_CATEGORY, timestamps: false })
+export class IsatCategoryModel extends Model<IsatCategoryAttributes> {
+  @PrimaryKey
+  @Column({ type: DataType.TEXT })
+  code!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false, field: 'code_dotted' })
+  codeDotted!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false })
+  description!: string
+
+  @Column({ type: DataType.TEXT, allowNull: false, field: 'description_en' })
+  descriptionEn!: string
+
+  static fromModel(model: IsatCategoryModel): IsatCategoryDto {
+    return {
+      code: model.code,
+      codeDotted: model.codeDotted,
+      description: model.description,
+      descriptionEn: model.descriptionEn,
+    }
+  }
+
+  fromModel(): IsatCategoryDto {
+    return IsatCategoryModel.fromModel(this)
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/swagger/doe-web.swagger.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/swagger/doe-web.swagger.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 
 import { AdminReportApiModule } from '../admin-report/admin-report.api.module'
 import { CompanyApiModule } from '../company/company.api.module'
+import { CompanyImportApiModule } from '../company-import/company-import.api.module'
 import { ConfigApiModule } from '../config/config.api.module'
 import { ReportApiModule } from '../report/report.api.module'
 import { ReportCommentApiModule } from '../report-comment/report-comment.api.module'
@@ -14,6 +15,7 @@ import { UserApiModule } from '../user/user.api.module'
   imports: [
     AdminReportApiModule,
     CompanyApiModule,
+    CompanyImportApiModule,
     UserApiModule,
     ConfigApiModule,
     ReportApiModule,

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -452,6 +452,569 @@
         "tags": ["Companies"]
       }
     },
+    "/api/v1/companies/{id}/status": {
+      "patch": {
+        "operationId": "updateCompanyStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCompanyStatusDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/isat": {
+      "patch": {
+        "operationId": "updateCompanyIsat",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateCompanyIsatDto" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/timeline": {
+      "get": {
+        "operationId": "getCompanyTimeline",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CompanyTimelineItemDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/comments": {
+      "get": {
+        "operationId": "getCompanyComments",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/CompanyCommentDto" }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      },
+      "post": {
+        "operationId": "createCompanyComment",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCompanyCommentDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyCommentDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/{id}/comments/{commentId}": {
+      "delete": {
+        "operationId": "deleteCompanyComment",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "commentId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Companies"]
+      }
+    },
+    "/api/v1/companies/import/preview": {
+      "post": {
+        "operationId": "previewCompanyImport",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" }
+                },
+                "required": ["file"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyImportResultDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Company Import"]
+      }
+    },
+    "/api/v1/companies/import/apply": {
+      "post": {
+        "operationId": "applyCompanyImport",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" }
+                },
+                "required": ["file"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompanyImportResultDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Company Import"]
+      }
+    },
     "/api/v1/users/me": {
       "get": {
         "operationId": "getMyUser",
@@ -2360,6 +2923,72 @@
         "summary": "",
         "tags": ["Report Statistics"]
       }
+    },
+    "/api/v1/reports/{reportId}/pdf": {
+      "get": {
+        "operationId": "getReportPdf",
+        "parameters": [
+          {
+            "name": "reportId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generates and returns the report as a PDF. The layout (\"Jafnlaunaúttekt\" or \"Jafnréttisáætlun\") is chosen from the report type.",
+            "content": {
+              "application/pdf": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Report PDF"]
+      }
     }
   },
   "info": {
@@ -2687,6 +3316,32 @@
         "enum": ["name", "employeeCount"]
       },
       "CompanySortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
+      "CompanyStatusEnum": {
+        "type": "string",
+        "enum": ["ACTIVE", "INACTIVE", "UNKNOWN"]
+      },
+      "IsatCategoryDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Normalized ÍSAT2008 leaf code, e.g. \"01110\"."
+          },
+          "codeDotted": {
+            "type": "string",
+            "description": "Display (dotted) form, e.g. \"01.11.0\"."
+          },
+          "description": {
+            "type": "string",
+            "description": "Icelandic description."
+          },
+          "descriptionEn": {
+            "type": "string",
+            "description": "English description."
+          }
+        },
+        "required": ["code", "codeDotted", "description", "descriptionEn"]
+      },
       "CompanyDto": {
         "type": "object",
         "properties": {
@@ -2696,14 +3351,33 @@
             "allOf": [{ "$ref": "#/components/schemas/CompanySizeEnum" }]
           },
           "nationalId": { "type": "string" },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "address": { "type": "string", "nullable": true },
+          "postcodeId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "salaryReportRequired": { "type": "boolean" },
-          "salaryReportRequiredOverride": { "type": "boolean" }
+          "salaryReportRequiredOverride": { "type": "boolean" },
+          "isatCategoryCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "Normalized ÍSAT2008 leaf code (admin-owned statistics field), e.g. \"01110\"."
+          },
+          "isatCategory": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/IsatCategoryDto" }]
+          }
         },
         "required": [
           "id",
           "name",
           "employeeCountCategory",
           "nationalId",
+          "status",
           "salaryReportRequired",
           "salaryReportRequiredOverride"
         ]
@@ -2765,6 +3439,261 @@
           }
         },
         "required": ["nationalId", "name", "employeeCountCategory"]
+      },
+      "UpdateCompanyStatusDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Optional reason for the change, e.g. bankruptcy or merger."
+          }
+        },
+        "required": ["status"]
+      },
+      "UpdateCompanyIsatDto": {
+        "type": "object",
+        "properties": {
+          "isatCategoryCode": {
+            "type": "string",
+            "nullable": true,
+            "description": "Normalized ÍSAT2008 leaf code, e.g. \"01110\". Null clears the classification."
+          }
+        }
+      },
+      "CompanyTimelineItemKindEnum": {
+        "type": "string",
+        "enum": ["EVENT", "COMMENT"]
+      },
+      "CompanyEventTypeEnum": {
+        "type": "string",
+        "enum": ["CREATED", "STATUS_CHANGED"]
+      },
+      "CompanyEventDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "companyId": { "type": "string", "format": "uuid" },
+          "eventType": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyEventTypeEnum" }]
+          },
+          "actorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "fromStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "toStatus": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyStatusEnum" }]
+          },
+          "reason": { "type": "string", "nullable": true },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": ["id", "companyId", "eventType", "status", "createdAt"]
+      },
+      "CompanyCommentDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "companyId": { "type": "string", "format": "uuid" },
+          "authorUserId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "authorName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full name of the admin who authored the comment."
+          },
+          "body": {
+            "type": "string",
+            "description": "Plain text comment body"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": ["id", "companyId", "body", "createdAt"]
+      },
+      "CompanyTimelineItemDto": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CompanyTimelineItemKindEnum" }
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          },
+          "event": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyEventDto" }]
+          },
+          "comment": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/CompanyCommentDto" }]
+          }
+        },
+        "required": ["kind", "createdAt"]
+      },
+      "CreateCompanyCommentDto": {
+        "type": "object",
+        "properties": {
+          "body": { "type": "string", "description": "Plain text comment body" }
+        },
+        "required": ["body"]
+      },
+      "CompanyImportOutcomeEnum": {
+        "type": "string",
+        "enum": [
+          "CREATED",
+          "UPDATED",
+          "UNCHANGED",
+          "MARKED_UNKNOWN",
+          "REACTIVATED"
+        ]
+      },
+      "CompanyImportFieldChangeDto": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "Company field that changed, e.g. \"name\"."
+          },
+          "from": {
+            "type": "string",
+            "nullable": true,
+            "description": "Previous value."
+          },
+          "to": {
+            "type": "string",
+            "nullable": true,
+            "description": "New value from the file."
+          }
+        },
+        "required": ["field"]
+      },
+      "CompanyImportRowResultDto": {
+        "type": "object",
+        "properties": {
+          "nationalId": { "type": "string" },
+          "name": { "type": "string" },
+          "outcome": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CompanyImportOutcomeEnum" }
+            ]
+          },
+          "changedFields": {
+            "description": "Field-level diff (UPDATED / REACTIVATED only).",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportFieldChangeDto"
+            }
+          },
+          "note": {
+            "type": "string",
+            "nullable": true,
+            "description": "Soft notice, e.g. an unresolved postcode that was left unset."
+          }
+        },
+        "required": ["nationalId", "name", "outcome", "changedFields"]
+      },
+      "CompanyImportErrorDto": {
+        "type": "object",
+        "properties": {
+          "row": {
+            "type": "number",
+            "description": "Spreadsheet row number (1-based, incl. header)."
+          },
+          "nationalId": { "type": "string", "nullable": true },
+          "reason": {
+            "type": "string",
+            "description": "Why the row was rejected."
+          }
+        },
+        "required": ["row", "reason"]
+      },
+      "CompanyImportResultDto": {
+        "type": "object",
+        "properties": {
+          "committed": {
+            "type": "boolean",
+            "description": "false = preview (no writes); true = applied (committed)."
+          },
+          "year": {
+            "type": "number",
+            "nullable": true,
+            "description": "Reporting year (TEKJUAR) from the file, if consistent."
+          },
+          "noticeCount": {
+            "type": "number",
+            "description": "Notice from a soft issue, e.g. an unresolved postcode."
+          },
+          "created": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportRowResultDto"
+            }
+          },
+          "updated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportRowResultDto"
+            }
+          },
+          "unchanged": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportRowResultDto"
+            }
+          },
+          "markedUnknown": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportRowResultDto"
+            }
+          },
+          "reactivated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompanyImportRowResultDto"
+            }
+          },
+          "invalid": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CompanyImportErrorDto" }
+          }
+        },
+        "required": [
+          "committed",
+          "noticeCount",
+          "created",
+          "updated",
+          "unchanged",
+          "markedUnknown",
+          "reactivated",
+          "invalid"
+        ]
       },
       "UserDto": {
         "type": "object",
@@ -3181,6 +4110,11 @@
             "type": "string",
             "format": "uuid",
             "nullable": true
+          },
+          "authorName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Full name of the authoring reviewer. Null for company-authored comments (no individual person)."
           },
           "visibility": {
             "allOf": [{ "$ref": "#/components/schemas/CommentVisibilityEnum" }]

--- a/apps/directorate-of-equality-web/src/components/companies/CompanyImportModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyImportModal.tsx
@@ -1,0 +1,281 @@
+'use client'
+
+import { useRef, useState } from 'react'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+import { Modal } from '@dmr.is/ui/components/Modal/Modal'
+
+import type {
+  CompanyImportResultDto,
+  CompanyImportRowResultDto,
+} from '../../gen/fetch/types.gen'
+import { companiesText } from '../../lib/text'
+import { useTRPC } from '../../lib/trpc/client/trpc'
+import { formatNationalId } from '../../lib/utils'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const t = companiesText.importModal
+
+// Row-result sections, in the order shown. `invalid` is rendered separately.
+const ROW_SECTIONS: {
+  key: keyof Pick<
+    CompanyImportResultDto,
+    'created' | 'updated' | 'reactivated' | 'markedUnknown' | 'unchanged'
+  >
+  label: string
+}[] = [
+  { key: 'created', label: t.sections.created },
+  { key: 'updated', label: t.sections.updated },
+  { key: 'reactivated', label: t.sections.reactivated },
+  { key: 'markedUnknown', label: t.sections.markedUnknown },
+  { key: 'unchanged', label: t.sections.unchanged },
+]
+
+const RowItem = ({ row }: { row: CompanyImportRowResultDto }) => (
+  <Box paddingY="smallGutter">
+    <Text variant="small" fontWeight="semiBold">
+      {row.name}{' '}
+      <Text variant="small" as="span" color="dark300">
+        {formatNationalId(row.nationalId)}
+      </Text>
+    </Text>
+    {row.changedFields.map((c, i) => (
+      <Text key={i} variant="small" color="dark400">
+        {c.field}: {c.from ?? '—'} → {c.to ?? '—'}
+      </Text>
+    ))}
+    {row.note && (
+      <Text variant="small" color="yellow600">
+        {row.note}
+      </Text>
+    )}
+  </Box>
+)
+
+export const CompanyImportModal = ({ isOpen, onClose }: Props) => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [fileName, setFileName] = useState<string | null>(null)
+  const [fileBase64, setFileBase64] = useState<string | null>(null)
+  const [result, setResult] = useState<CompanyImportResultDto | null>(null)
+
+  const previewMutation = useMutation({
+    ...trpc.company.importPreview.mutationOptions(),
+    onSuccess: (res) => setResult(res),
+    onError: () => toast.error(t.errorToast),
+  })
+
+  const applyMutation = useMutation({
+    ...trpc.company.importApply.mutationOptions(),
+    onSuccess: (res) => {
+      setResult(res)
+      queryClient.invalidateQueries({ queryKey: trpc.company.list.queryKey() })
+      toast.success(t.successToast)
+    },
+    onError: () => toast.error(t.errorToast),
+  })
+
+  const reset = () => {
+    setFileName(null)
+    setFileBase64(null)
+    setResult(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
+
+  const handleClose = () => {
+    reset()
+    onClose()
+  }
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setFileName(file.name)
+    setResult(null)
+    const reader = new FileReader()
+    reader.onload = () => {
+      const base64 = (reader.result as string).split(',')[1]
+      setFileBase64(base64)
+      previewMutation.mutate({ file: base64 })
+    }
+    reader.readAsDataURL(file)
+  }
+
+  const committed = !!result?.committed
+  const isLoading = previewMutation.isPending
+
+  return (
+    <Modal
+      baseId="company-import-modal"
+      isVisible={isOpen}
+      title={t.title}
+      onVisibilityChange={(visible) => {
+        if (!visible) handleClose()
+      }}
+      toggleClose={handleClose}
+      width="large"
+    >
+      <Stack space={3}>
+        <Text variant="small">{t.description}</Text>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".xlsx"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+
+        <Inline space={2} alignY="center">
+          <Button
+            variant="ghost"
+            size="small"
+            icon="documents"
+            iconType="outline"
+            loading={isLoading}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            {result ? t.chooseAnother : t.chooseFile}
+          </Button>
+          {fileName && (
+            <Text variant="small" color="dark300">
+              {fileName}
+            </Text>
+          )}
+        </Inline>
+
+        {result && (
+          <Stack space={3}>
+            {committed && (
+              <Box background="blue100" padding={2} borderRadius="large">
+                <Text variant="small" fontWeight="semiBold" color="blue600">
+                  {t.committedBanner}
+                </Text>
+              </Box>
+            )}
+
+            <Inline space={2}>
+              {result.year != null && (
+                <Text variant="small" color="dark400">
+                  {t.yearLabel}: {result.year}
+                </Text>
+              )}
+              {result.noticeCount > 0 && (
+                <Text variant="small" color="yellow600">
+                  {result.noticeCount} {t.noticeCount}
+                </Text>
+              )}
+            </Inline>
+
+            <ImportSummary result={result} />
+
+            {ROW_SECTIONS.map(({ key, label }) => {
+              const rows = result[key]
+              if (!rows.length) return null
+              return (
+                <Box key={key}>
+                  <Text variant="eyebrow" color="dark400">
+                    {label} ({rows.length})
+                  </Text>
+                  <Box
+                    background="dark100"
+                    padding={2}
+                    borderRadius="large"
+                    marginTop={1}
+                  >
+                    {rows.map((row) => (
+                      <RowItem key={row.nationalId} row={row} />
+                    ))}
+                  </Box>
+                </Box>
+              )
+            })}
+
+            {result.invalid.length > 0 && (
+              <Box>
+                <Text variant="eyebrow" color="red600">
+                  {t.sections.invalid} ({result.invalid.length})
+                </Text>
+                <Box
+                  background="red100"
+                  padding={2}
+                  borderRadius="large"
+                  marginTop={1}
+                >
+                  {result.invalid.map((err, i) => (
+                    <Text key={i} variant="small" color="red600">
+                      {t.rowPrefix} {err.row}
+                      {err.nationalId
+                        ? ` (${formatNationalId(err.nationalId)})`
+                        : ''}
+                      : {err.reason}
+                    </Text>
+                  ))}
+                </Box>
+              </Box>
+            )}
+          </Stack>
+        )}
+
+        <Inline justifyContent="flexEnd" space={2}>
+          <Button variant="ghost" size="small" onClick={handleClose}>
+            {committed ? t.close : t.cancel}
+          </Button>
+          {result && !committed && (
+            <Button
+              size="small"
+              loading={applyMutation.isPending}
+              onClick={() => fileBase64 && applyMutation.mutate({ file: fileBase64 })}
+            >
+              {t.confirm}
+            </Button>
+          )}
+        </Inline>
+      </Stack>
+    </Modal>
+  )
+}
+
+const ImportSummary = ({ result }: { result: CompanyImportResultDto }) => (
+  <Inline space={2}>
+    <Summary label={companiesText.importModal.sections.created} n={result.created.length} />
+    <Summary label={companiesText.importModal.sections.updated} n={result.updated.length} />
+    <Summary
+      label={companiesText.importModal.sections.reactivated}
+      n={result.reactivated.length}
+    />
+    <Summary
+      label={companiesText.importModal.sections.markedUnknown}
+      n={result.markedUnknown.length}
+    />
+    <Summary
+      label={companiesText.importModal.sections.unchanged}
+      n={result.unchanged.length}
+    />
+    <Summary label={companiesText.importModal.sections.invalid} n={result.invalid.length} />
+  </Inline>
+)
+
+const Summary = ({ label, n }: { label: string; n: number }) => (
+  <Box background="dark100" paddingX={2} paddingY={1} borderRadius="large">
+    <Text variant="small" fontWeight="semiBold">
+      {n}
+    </Text>
+    <Text variant="eyebrow" color="dark300">
+      {label}
+    </Text>
+  </Box>
+)

--- a/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
@@ -14,6 +14,7 @@ import {
   CompanyFilter,
   type CompanyFilters,
 } from '../../components/companies/CompanyFilter'
+import { CompanyImportModal } from '../../components/companies/CompanyImportModal'
 import { CompanyTable } from '../../components/companies/CompanyTable'
 import { CreateCompanyModal } from '../../components/companies/CreateCompanyModal'
 import {
@@ -24,12 +25,13 @@ import {
 } from '../../gen/fetch'
 import { useCompanies } from '../../hooks/useCompanies'
 import { useIsTablet } from '../../hooks/useIsTablet'
-import { serverErrorText } from '../../lib/text'
+import { companiesText, serverErrorText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
 export const CompaniesContainer = () => {
   const { isTablet } = useIsTablet()
   const [isModalOpen, setIsModalOpen] = useState(false)
+  const [isImportOpen, setIsImportOpen] = useState(false)
 
   const { data, isError, filter, setFilter, resetFilter } = useCompanies({
     pageSize: 10,
@@ -109,7 +111,7 @@ export const CompaniesContainer = () => {
   }, [data, filters.dailyFines])
 
   const newButton = (
-    <Box display="flex" marginTop={2}>
+    <Box display="flex" flexDirection="column" rowGap={1} marginTop={2}>
       <Button
         icon="add"
         iconType="outline"
@@ -120,6 +122,17 @@ export const CompaniesContainer = () => {
         fluid
       >
         Nýtt fyrirtæki
+      </Button>
+      <Button
+        icon="upload"
+        iconType="outline"
+        onClick={() => setIsImportOpen(true)}
+        size="small"
+        variant="utility"
+        colorScheme="white"
+        fluid
+      >
+        {companiesText.importModal.button}
       </Button>
     </Box>
   )
@@ -162,6 +175,10 @@ export const CompaniesContainer = () => {
       <CreateCompanyModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
+      />
+      <CompanyImportModal
+        isOpen={isImportOpen}
+        onClose={() => setIsImportOpen(false)}
       />
     </GridContainer>
   )

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -255,6 +255,33 @@ export const companiesText = {
     successToast: 'Fyrirtæki skráð',
     errorToast: 'Villa við skráningu fyrirtækis',
   },
+  importModal: {
+    title: 'Flytja inn fyrirtækjaskrá',
+    description:
+      'Veldu Excel-skrá (.xlsx) með árlegri fyrirtækjaskrá. Skráin er staðreyndaruppspretta — fyrirtæki eru stofnuð, uppfærð eða merkt óþekkt eftir innihaldi hennar.',
+    button: 'Flytja inn skrá',
+    chooseFile: 'Velja skrá',
+    reading: 'Les skrá…',
+    yearLabel: 'Tekjuár',
+    noChanges: 'Engar breytingar fundust í skránni.',
+    noticeCount: 'athugasemd(ir)',
+    confirm: 'Staðfesta innflutning',
+    cancel: 'Hætta við',
+    close: 'Loka',
+    chooseAnother: 'Velja aðra skrá',
+    successToast: 'Innflutningur staðfestur',
+    errorToast: 'Villa við innflutning',
+    committedBanner: 'Innflutningur staðfestur',
+    sections: {
+      created: 'Ný fyrirtæki',
+      updated: 'Uppfærð',
+      reactivated: 'Endurvirkjuð',
+      markedUnknown: 'Merkt óþekkt (vantar í skrá)',
+      unchanged: 'Óbreytt',
+      invalid: 'Ógildar línur',
+    },
+    rowPrefix: 'Lína',
+  },
 }
 
 export const usersText = {

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -35,4 +35,25 @@ export const companyRouter = router({
   create: protectedProcedure
     .input(zCreateCompanyBody)
     .mutation(({ ctx, input }) => ctx.api.createCompany({ body: input })),
+
+  // Annual register import. The file arrives base64-encoded (tRPC has no
+  // multipart), is rebuilt into a Blob, and forwarded to the multipart API.
+  // `preview` writes nothing; `apply` commits. Same input shape for both.
+  importPreview: protectedProcedure
+    .input(z.object({ file: z.string() }))
+    .mutation(({ ctx, input }) =>
+      ctx.api.previewCompanyImport({ body: { file: toXlsxBlob(input.file) } }),
+    ),
+
+  importApply: protectedProcedure
+    .input(z.object({ file: z.string() }))
+    .mutation(({ ctx, input }) =>
+      ctx.api.applyCompanyImport({ body: { file: toXlsxBlob(input.file) } }),
+    ),
 })
+
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+const toXlsxBlob = (base64: string): Blob =>
+  new Blob([Buffer.from(base64, 'base64')], { type: XLSX_MIME })


### PR DESCRIPTION
### Company import & ÍSAT2008 handling
Adds industry classification to companies and an admin Excel import that keeps the company register in sync with an authoritative annual file.

#### ÍSAT2008 classification

- New `isat_category` reference table seeded with the 665 leaf (5-digit) ÍSAT2008 codes.
- `company.isat_category_code` (nullable FK) holds a company's classification — admin-owned statistics data, independent of the report-submission snapshot (`company_report.isat_category` is left untouched).
- `PATCH /companies/:id/isat` as an API-level override (no UI).

#### Company import (annual register)

- `POST /companies/import/preview` and `/apply` — admin uploads the `.xlsx` register; the file is the source of truth, reconciled against `company` by kennitala.
- Per company: create (new), update (changed fields), unchanged, mark `UNKNOWN` (in our DB but absent from the file), reactivate (reappears after UNKNOWN/INACTIVE), or reject (invalid kennitala / unknown ÍSAT / duplicate).
- `preview` writes nothing and returns the full categorized diff; `apply` commits in one transaction. New `CompanyStatusEnum.UNKNOWN`.
- Only import-driven status flips emit `company_event` rows; field edits are audited via the summary + a structured log line.

Migrations: isat_category table + company.isat_category_code; company_status_enum gains UNKNOWN.

#### Admin UI for the annual company-register import

Adds the admin-facing screen for the company import (backend in the previous PR).

- New "Flytja inn skrá" action on the Companies page opens an import modal.
- Preview → confirm flow: pick an .xlsx, see a full categorized diff (created / updated with per-field from → to / reactivated / marked-unknown / unchanged / invalid rows) with no writes, then confirm to commit.
- On confirm, the companies list refreshes and a success toast shows.
- New tRPC procedures company.importPreview / company.importApply bridge the upload (base64 → Blob) to the multipart API endpoints. Icelandic strings added under companiesText.importModal.