### PR TITLE
feat(doe): Company report status

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.spec.ts
@@ -47,6 +47,16 @@ describe('CompanyService', () => {
     eventsByCompanyId = jest.fn().mockResolvedValue([])
     commentsByCompanyId = jest.fn().mockResolvedValue([])
 
+    // `.scope('withReportStatus')` returns a scoped copy of the model; the
+    // service then calls findOne/findOneOrThrow on it. Resolve scope back to
+    // the same mock so those calls land on the shared jest.fns.
+    const companyModelMock: Record<string, unknown> = {
+      findOneOrThrow,
+      findOne,
+      create,
+    }
+    companyModelMock.scope = jest.fn(() => companyModelMock)
+
     const module = await Test.createTestingModule({
       providers: [
         CompanyService,
@@ -57,7 +67,7 @@ describe('CompanyService', () => {
         },
         {
           provide: getModelToken(CompanyModel),
-          useValue: { findOneOrThrow, findOne, create },
+          useValue: companyModelMock,
         },
         {
           provide: getModelToken(IsatCategoryModel),
@@ -153,6 +163,15 @@ describe('CompanyService', () => {
           employeeCountCategory: CompanySizeEnum.UNKNOWN,
         }),
       )
+      // loadCompanyDto re-reads the created row through the report-status scope.
+      findOneOrThrow.mockResolvedValue(
+        makeCompanyModel({
+          id: 'company-2',
+          name: 'Registry Name ehf.',
+          nationalId: '6601234567',
+          employeeCountCategory: CompanySizeEnum.UNKNOWN,
+        }),
+      )
 
       const result = await service.getOrCreateByNationalId(
         '6601234567',
@@ -176,6 +195,14 @@ describe('CompanyService', () => {
       findOne.mockResolvedValue(null)
       getEntityByNationalId.mockResolvedValue({ entity: null })
       create.mockResolvedValue(
+        makeCompanyModel({
+          id: 'company-3',
+          name: 'Body-provided name',
+          nationalId: '7701234567',
+          employeeCountCategory: CompanySizeEnum.UNKNOWN,
+        }),
+      )
+      findOneOrThrow.mockResolvedValue(
         makeCompanyModel({
           id: 'company-3',
           name: 'Body-provided name',
@@ -315,6 +342,8 @@ describe('CompanyService', () => {
           status: CompanyStatusEnum.ACTIVE,
         }),
       )
+      // loadCompanyDto re-reads the created row through the report-status scope.
+      findOneOrThrow.mockResolvedValue(makeCompanyModel({ id: 'company-9' }))
 
       await service.create({
         name: 'New ehf.',

--- a/apps/directorate-of-equality-api/src/modules/company/company.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/company.service.ts
@@ -62,6 +62,29 @@ export class CompanyService implements ICompanyService {
     private readonly companyCommentService: ICompanyCommentService,
   ) {}
 
+  /**
+   * `CompanyModel` scoped to also select the derived `reportStatus`. The cast
+   * restores the custom `*OrThrow` statics that Sequelize's `.scope()` erases
+   * from the return type.
+   */
+  private get companyWithReportStatus(): typeof CompanyModel {
+    return this.companyModel.scope('withReportStatus') as typeof CompanyModel
+  }
+
+  /**
+   * Re-read a company through the `withReportStatus` scope and map it to a DTO.
+   * Used after a write (create) where the in-memory instance has no computed
+   * `reportStatus` virtual yet.
+   */
+  private async loadCompanyDto(id: string): Promise<CompanyDto> {
+    const company = await this.companyWithReportStatus.findOneOrThrow(
+      { where: { id } },
+      companyMessages.notFound(id),
+    )
+
+    return company.fromModel()
+  }
+
   async getAll(query: GetCompaniesQueryDto): Promise<GetCompaniesResponseDto> {
     const { limit, offset } = getLimitAndOffset(query)
 
@@ -111,14 +134,15 @@ export class CompanyService implements ICompanyService {
           ]
         : [['name', sortDir]]
 
-    const { rows, count } = await this.companyModel.findAndCountAll({
-      where,
-      order,
-      limit,
-      offset,
-      distinct: true,
-      col: 'id',
-    })
+    const { rows, count } = await this.companyWithReportStatus
+      .findAndCountAll({
+        where,
+        order,
+        limit,
+        offset,
+        distinct: true,
+        col: 'id',
+      })
 
     const companies = rows.map((c) => c.fromModel())
     const paging = generatePaging(companies, query.page, query.pageSize, count)
@@ -130,12 +154,7 @@ export class CompanyService implements ICompanyService {
       context: LOGGING_CONTEXT,
     })
 
-    const company = await this.companyModel.findOneOrThrow(
-      { where: { id } },
-      companyMessages.notFound(id),
-    )
-
-    return company.fromModel()
+    return this.loadCompanyDto(id)
   }
 
   async rskLookup(nationalId: string): Promise<CompanyLookupDto> {
@@ -180,7 +199,7 @@ export class CompanyService implements ICompanyService {
 
     await this.companyEventService.emitCreated(company.id, company.status)
 
-    return company.fromModel()
+    return this.loadCompanyDto(company.id)
   }
 
   async getByNationalId(nationalId: string): Promise<CompanyDto> {
@@ -188,7 +207,7 @@ export class CompanyService implements ICompanyService {
       context: LOGGING_CONTEXT,
     })
 
-    const company = await this.companyModel.findOneOrThrow(
+    const company = await this.companyWithReportStatus.findOneOrThrow(
       { where: { nationalId } },
       companyMessages.notFoundByNationalId(nationalId),
     )
@@ -200,9 +219,8 @@ export class CompanyService implements ICompanyService {
     nationalId: string,
     fallbackName?: string,
   ): Promise<CompanyDto> {
-    const existing = await this.companyModel.findOne({
-      where: { nationalId },
-    })
+    const existing = await this.companyWithReportStatus
+      .findOne({ where: { nationalId } })
 
     if (existing) {
       return existing.fromModel()
@@ -232,7 +250,7 @@ export class CompanyService implements ICompanyService {
 
     await this.companyEventService.emitCreated(company.id, company.status)
 
-    return company.fromModel()
+    return this.loadCompanyDto(company.id)
   }
 
   async getOrCreateSubsidiaryReportSnapshotSource(
@@ -283,7 +301,10 @@ export class CompanyService implements ICompanyService {
     dto: UpdateCompanyStatusDto,
     actorUserId: string,
   ): Promise<CompanyDto> {
-    const company = await this.companyModel.findOneOrThrow(
+    // Scoped read so the returned DTO carries reportStatus. The company's
+    // status column does not feed reportStatus, so the value loaded here stays
+    // correct after the update below.
+    const company = await this.companyWithReportStatus.findOneOrThrow(
       { where: { id } },
       companyMessages.notFound(id),
     )

--- a/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/company.dto.ts
@@ -9,7 +9,11 @@ import {
   ApiUUId,
 } from '@dmr.is/decorators'
 
-import { CompanySizeEnum, CompanyStatusEnum } from '../models/company.enums'
+import {
+  CompanyReportStatusEnum,
+  CompanySizeEnum,
+  CompanyStatusEnum,
+} from '../models/company.enums'
 import { IsatCategoryDto } from './isat-category.dto'
 
 export class CompanyDto {
@@ -49,4 +53,7 @@ export class CompanyDto {
 
   @ApiPropertyOptional({ type: IsatCategoryDto, nullable: true })
   isatCategory!: IsatCategoryDto | null
+
+  @ApiEnum(CompanyReportStatusEnum, { enumName: 'CompanyReportStatusEnum' })
+  reportStatus!: CompanyReportStatusEnum
 }

--- a/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/dto/get-companies-query.dto.ts
@@ -6,10 +6,13 @@ import { ApiProperty } from '@nestjs/swagger'
 import { ApiOptionalEnum, ApiOptionalString } from '@dmr.is/decorators'
 import { PagingQuery } from '@dmr.is/shared-dto'
 
-import { CompanySizeEnum } from '../models/company.enums'
-import { CompanyExpiryFilterEnum, CompanyStatusFilterEnum } from '../utils/filters'
+import {
+  CompanyReportStatusEnum,
+  CompanySizeEnum,
+} from '../models/company.enums'
+import { CompanyExpiryFilterEnum } from '../utils/filters'
 
-export { CompanyExpiryFilterEnum, CompanyStatusFilterEnum }
+export { CompanyExpiryFilterEnum }
 
 export enum CompanySortByEnum {
   NAME = 'name',
@@ -38,12 +41,12 @@ export class GetCompaniesQueryDto extends PagingQuery {
   employeeCountCategory?: CompanySizeEnum
 
   @ApiProperty({
-    enum: CompanyStatusFilterEnum,
-    enumName: 'CompanyStatusFilterEnum',
+    enum: CompanyReportStatusEnum,
+    enumName: 'CompanyReportStatusEnum',
     isArray: true,
     required: false,
     description:
-      'Return only companies that match at least one of the provided status values. Omit for no constraint.',
+      'Return only companies whose report status is one of the provided values (same status shown on each company). Omit for no constraint.',
   })
   @Transform(({ value }) => {
     if (value == null) return undefined
@@ -51,8 +54,8 @@ export class GetCompaniesQueryDto extends PagingQuery {
   })
   @IsOptional()
   @IsArray()
-  @IsEnum(CompanyStatusFilterEnum, { each: true })
-  companyStatus?: CompanyStatusFilterEnum[]
+  @IsEnum(CompanyReportStatusEnum, { each: true })
+  companyStatus?: CompanyReportStatusEnum[]
 
   @ApiProperty({
     enum: CompanyExpiryFilterEnum,

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.enums.ts
@@ -49,3 +49,27 @@ export enum CompanyStatusEnum {
   INACTIVE = 'INACTIVE',
   UNKNOWN = 'UNKNOWN',
 }
+
+/**
+ * Derived reporting-compliance status surfaced on `CompanyDto`. Not persisted —
+ * computed from the company's size/obligations and its reports (see
+ * `utils/report-status.ts`). A single value, evaluated in priority order; the
+ * first unmet obligation wins (most critical first).
+ *
+ *   MISSING_EQUALITY_REPORT → "Vantar jafnréttisáætlun": 25+ employees
+ *       (MEDIUM|LARGE) with no active/approved equality report.
+ *   MISSING_SALARY_REPORT   → "Vantar launagreiningu": a salary report is
+ *       required (50+/LARGE, or admin override — i.e. `salary_report_required`)
+ *       with no active/approved salary report.
+ *   MISSING_ACTION_PLAN     → "Vantar úrbótaáætlun": a salary report is
+ *       POSTPONED, i.e. it has pay-gap outliers whose explanations are still
+ *       deferred.
+ *   SATISFACTORY            → "Fullnægjandi": none of the above; the company
+ *       has met its obligations.
+ */
+export enum CompanyReportStatusEnum {
+  MISSING_EQUALITY_REPORT = 'MISSING_EQUALITY_REPORT',
+  MISSING_SALARY_REPORT = 'MISSING_SALARY_REPORT',
+  MISSING_ACTION_PLAN = 'MISSING_ACTION_PLAN',
+  SATISFACTORY = 'SATISFACTORY',
+}

--- a/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/models/company.model.ts
@@ -1,4 +1,10 @@
-import { BelongsTo, Column, DataType, ForeignKey } from 'sequelize-typescript'
+import {
+  BelongsTo,
+  Column,
+  DataType,
+  ForeignKey,
+  Scopes,
+} from 'sequelize-typescript'
 
 import { MutableModel, MutableTable } from '@dmr.is/shared-models-base'
 
@@ -6,7 +12,12 @@ import { DoeModels } from '../../../core/constants'
 import { PostcodeModel } from '../../location/models/postcode.model'
 import type { CreateReportCompanySnapshotDto } from '../../report-create/dto/create-report.dto'
 import type { CompanyDto } from '../dto/company.dto'
-import { CompanySizeEnum, CompanyStatusEnum } from './company.enums'
+import { companyReportStatusLiteral } from '../utils/report-status'
+import {
+  CompanyReportStatusEnum,
+  CompanySizeEnum,
+  CompanyStatusEnum,
+} from './company.enums'
 import { IsatCategoryModel } from './isat-category.model'
 
 type CompanyAttributes = {
@@ -33,6 +44,19 @@ type CompanyCreateAttributes = {
   isatCategoryCode?: string | null
 }
 
+/**
+ * `withReportStatus` selects the derived `reportStatus` alongside the stored
+ * columns. It is the read scope for every path that returns a `CompanyDto` —
+ * the value is computed in SQL (see `companyReportStatusLiteral`) so it can be
+ * filtered/sorted, and so the column matches the list status filter exactly.
+ */
+@Scopes(() => ({
+  withReportStatus: {
+    attributes: {
+      include: [[companyReportStatusLiteral(), 'reportStatus']],
+    },
+  },
+}))
 @MutableTable({ tableName: DoeModels.COMPANY })
 export class CompanyModel extends MutableModel<
   CompanyAttributes,
@@ -95,6 +119,12 @@ export class CompanyModel extends MutableModel<
   })
   isatCategory?: IsatCategoryModel | null
 
+  // Derived compliance status — not a stored column. Populated by the
+  // `withReportStatus` scope; undefined when the model is loaded outside it, so
+  // every CompanyDto read goes through that scope.
+  @Column(DataType.VIRTUAL)
+  reportStatus!: CompanyReportStatusEnum
+
   static fromModel(model: CompanyModel): CompanyDto {
     return {
       id: model.id,
@@ -110,6 +140,7 @@ export class CompanyModel extends MutableModel<
       isatCategory: model.isatCategory
         ? IsatCategoryModel.fromModel(model.isatCategory)
         : null,
+      reportStatus: model.reportStatus,
     }
   }
 

--- a/apps/directorate-of-equality-api/src/modules/company/utils/filters.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/utils/filters.ts
@@ -1,112 +1,21 @@
 import { literal, Op, WhereOptions } from 'sequelize'
 
 import { DoeModels } from '../../../core/constants'
-import { CompanySizeEnum } from '../models/company.enums'
-import { CompanyModel } from '../models/company.model'
+import { CompanyReportStatusEnum } from '../models/company.enums'
+import { COMPANY_QUERY_ALIAS,companyReportStatusCaseSql } from './report-status'
 
-export enum CompanyStatusFilterEnum {
-  MISSING_EQUALITY = 'missing-equality',
-  HAS_EQUALITY = 'has-equality',
-  MISSING_SALARY = 'missing-salary',
-  COMPLIANT = 'compliant',
-}
-
-// Sizes that carry no reporting obligation. UNKNOWN means we have not yet
-// classified the company, so it imposes nothing until an admin sets a size.
-const NO_REQUIREMENT_SIZES = [CompanySizeEnum.SMALL, CompanySizeEnum.UNKNOWN]
-// Sizes that must file an equality report (LARGE additionally needs salary).
-const EQUALITY_REQUIRED_SIZES = [CompanySizeEnum.MEDIUM, CompanySizeEnum.LARGE]
-
-function activeReportExists(type: 'SALARY' | 'EQUALITY'): string {
-  return `EXISTS (
-    SELECT 1 FROM "${DoeModels.COMPANY_REPORT}" cr
-    JOIN "${DoeModels.REPORT}" r ON r.id = cr.report_id
-    WHERE cr.company_id = "${CompanyModel.name}"."id"
-    AND r.type = '${type}'
-    AND r.status = 'APPROVED'
-    AND r.valid_until > NOW()
-  )`
-}
-
-const needsSalary: WhereOptions = {
-  [Op.or]: [{ salaryReportRequired: true }, { salaryReportRequiredOverride: true }],
-}
-
-const noSalaryNeeded: WhereOptions = {
-  salaryReportRequired: false,
-  salaryReportRequiredOverride: false,
-}
-
-function statusCondition(status: CompanyStatusFilterEnum): WhereOptions {
-  switch (status) {
-    case CompanyStatusFilterEnum.COMPLIANT:
-      return {
-        [Op.or]: [
-          // LARGE: salary requirement fulfilled
-          {
-            [Op.and]: [needsSalary, literal(activeReportExists('SALARY'))],
-          },
-          // MEDIUM: equality requirement fulfilled (no salary needed)
-          {
-            [Op.and]: [
-              noSalaryNeeded,
-              { employeeCountCategory: { [Op.in]: EQUALITY_REQUIRED_SIZES } },
-              literal(activeReportExists('EQUALITY')),
-            ],
-          },
-          // SMALL / UNKNOWN: no requirements and nothing submitted
-          {
-            [Op.and]: [
-              noSalaryNeeded,
-              { employeeCountCategory: { [Op.in]: NO_REQUIREMENT_SIZES } },
-              literal(`NOT ${activeReportExists('EQUALITY')}`),
-            ],
-          },
-        ],
-      }
-
-    case CompanyStatusFilterEnum.MISSING_SALARY:
-      // needsSalary flag drives this — equality is prerequisite, salary not yet filed
-      return {
-        [Op.and]: [
-          needsSalary,
-          literal(activeReportExists('EQUALITY')),
-          literal(`NOT ${activeReportExists('SALARY')}`),
-        ],
-      }
-
-    case CompanyStatusFilterEnum.HAS_EQUALITY:
-      return literal(activeReportExists('EQUALITY'))
-
-    case CompanyStatusFilterEnum.MISSING_EQUALITY:
-      return {
-        [Op.or]: [
-          // needsSalary flag set but equality (prerequisite) not yet filed
-          {
-            [Op.and]: [
-              needsSalary,
-              literal(`NOT ${activeReportExists('EQUALITY')}`),
-            ],
-          },
-          // MEDIUM/LARGE, no salary obligation, no equality
-          {
-            [Op.and]: [
-              noSalaryNeeded,
-              { employeeCountCategory: { [Op.in]: EQUALITY_REQUIRED_SIZES } },
-              literal(`NOT ${activeReportExists('EQUALITY')}`),
-            ],
-          },
-        ],
-      }
-  }
-}
-
+/**
+ * Filter the company list by compliance status. Filters on the very same
+ * `CASE` expression that drives the displayed `reportStatus` column (see
+ * `report-status.ts`), so the value an admin sees and the value they filter on
+ * are guaranteed to match.
+ */
 export function buildCompanyStatusWhere(
-  statuses: CompanyStatusFilterEnum[],
+  statuses: CompanyReportStatusEnum[],
 ): WhereOptions {
   if (!statuses.length) return {}
-  const conditions = statuses.map(statusCondition)
-  return conditions.length === 1 ? conditions[0] : { [Op.or]: conditions }
+  const values = statuses.map((status) => `'${status}'`).join(', ')
+  return literal(`${companyReportStatusCaseSql()} IN (${values})`)
 }
 
 export enum CompanyExpiryFilterEnum {
@@ -131,7 +40,7 @@ export function buildCompanyExpiryWhere(
       literal(`EXISTS (
         SELECT 1 FROM "${DoeModels.COMPANY_REPORT}" cr
         JOIN "${DoeModels.REPORT}" r ON r.id = cr.report_id
-        WHERE cr.company_id = "${CompanyModel.name}"."id"
+        WHERE cr.company_id = "${COMPANY_QUERY_ALIAS}"."id"
         AND r.status = 'APPROVED'
         AND r.valid_until > NOW()
         AND r.valid_until <= NOW() + ${interval}

--- a/apps/directorate-of-equality-api/src/modules/company/utils/report-status.ts
+++ b/apps/directorate-of-equality-api/src/modules/company/utils/report-status.ts
@@ -1,0 +1,73 @@
+import { literal } from 'sequelize'
+
+import { DoeModels } from '../../../core/constants'
+import { ReportStatusEnum, ReportTypeEnum } from '../../report/models/report.enums'
+import { CompanyReportStatusEnum, CompanySizeEnum } from '../models/company.enums'
+
+/**
+ * Alias under which Sequelize references the `company` table in the queries
+ * that build `CompanyDto` (the model name, not the table name). Correlated
+ * sub-selects below qualify the outer company row with it. Defined as a string
+ * — rather than `CompanyModel.name` — so this module stays free of a model
+ * import and can be consumed by the model's own scope without a cycle.
+ */
+export const COMPANY_QUERY_ALIAS = 'CompanyModel'
+
+/**
+ * Whether the company has a *valid* approved report of the given type. This is
+ * the shared definition of "has submitted" — kept identical for the displayed
+ * `reportStatus` column and the list status filter so the two never disagree.
+ * "Valid" = APPROVED and not past its `valid_until`.
+ */
+function activeReportExists(type: ReportTypeEnum): string {
+  return `EXISTS (
+    SELECT 1 FROM "${DoeModels.COMPANY_REPORT}" cr
+    JOIN "${DoeModels.REPORT}" r ON r.id = cr.report_id
+    WHERE cr.company_id = "${COMPANY_QUERY_ALIAS}"."id"
+    AND r.type = '${type}'
+    AND r.status = '${ReportStatusEnum.APPROVED}'
+    AND r.valid_until > NOW()
+  )`
+}
+
+/**
+ * Whether the company has a salary report still in POSTPONED — i.e. with
+ * pay-gap outliers whose explanations are deferred. This is the signal for an
+ * outstanding úrbótaáætlun.
+ */
+function postponedSalaryExists(): string {
+  return `EXISTS (
+    SELECT 1 FROM "${DoeModels.COMPANY_REPORT}" cr
+    JOIN "${DoeModels.REPORT}" r ON r.id = cr.report_id
+    WHERE cr.company_id = "${COMPANY_QUERY_ALIAS}"."id"
+    AND r.type = '${ReportTypeEnum.SALARY}'
+    AND r.status = '${ReportStatusEnum.POSTPONED}'
+  )`
+}
+
+// Salary report required: the size-driven flag (LARGE) or an admin override.
+const salaryRequired = `("${COMPANY_QUERY_ALIAS}"."salary_report_required" = true OR "${COMPANY_QUERY_ALIAS}"."salary_report_required_override" = true)`
+
+// Equality report required: 25+ employees (MEDIUM|LARGE), or a salary
+// obligation (which presupposes the equality plan).
+const equalityRequired = `("${COMPANY_QUERY_ALIAS}"."employee_count_category" IN ('${CompanySizeEnum.MEDIUM}', '${CompanySizeEnum.LARGE}') OR ${salaryRequired})`
+
+/**
+ * The single source of truth for a company's compliance status, as a SQL
+ * `CASE` yielding `CompanyReportStatusEnum` values in priority order (most
+ * critical first). Used both to populate the `reportStatus` column (via the
+ * model's `withReportStatus` scope) and to filter the company list, so the
+ * column an admin sees and the filter they apply can never diverge.
+ */
+export function companyReportStatusCaseSql(): string {
+  return `(CASE
+    WHEN ${equalityRequired} AND NOT ${activeReportExists(ReportTypeEnum.EQUALITY)} THEN '${CompanyReportStatusEnum.MISSING_EQUALITY_REPORT}'
+    WHEN ${salaryRequired} AND NOT ${activeReportExists(ReportTypeEnum.SALARY)} THEN '${CompanyReportStatusEnum.MISSING_SALARY_REPORT}'
+    WHEN ${postponedSalaryExists()} THEN '${CompanyReportStatusEnum.MISSING_ACTION_PLAN}'
+    ELSE '${CompanyReportStatusEnum.SATISFACTORY}'
+  END)`
+}
+
+export function companyReportStatusLiteral() {
+  return literal(companyReportStatusCaseSql())
+}

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -245,11 +245,11 @@
             "name": "companyStatus",
             "required": false,
             "in": "query",
-            "description": "Return only companies that match at least one of the provided status values. Omit for no constraint.",
+            "description": "Return only companies whose report status is one of the provided values (same status shown on each company). Omit for no constraint.",
             "schema": {
               "type": "array",
               "items": {
-                "$ref": "#/components/schemas/CompanyStatusFilterEnum"
+                "$ref": "#/components/schemas/CompanyReportStatusEnum"
               }
             }
           },
@@ -3303,13 +3303,13 @@
         "type": "string",
         "enum": ["UNKNOWN", "SMALL", "MEDIUM", "LARGE"]
       },
-      "CompanyStatusFilterEnum": {
+      "CompanyReportStatusEnum": {
         "type": "string",
         "enum": [
-          "missing-equality",
-          "has-equality",
-          "missing-salary",
-          "compliant"
+          "MISSING_EQUALITY_REPORT",
+          "MISSING_SALARY_REPORT",
+          "MISSING_ACTION_PLAN",
+          "SATISFACTORY"
         ]
       },
       "CompanyExpiryFilterEnum": {
@@ -3375,6 +3375,11 @@
           "isatCategory": {
             "nullable": true,
             "allOf": [{ "$ref": "#/components/schemas/IsatCategoryDto" }]
+          },
+          "reportStatus": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CompanyReportStatusEnum" }
+            ]
           }
         },
         "required": [
@@ -3384,7 +3389,8 @@
           "nationalId",
           "status",
           "salaryReportRequired",
-          "salaryReportRequiredOverride"
+          "salaryReportRequiredOverride",
+          "reportStatus"
         ]
       },
       "Paging": {

--- a/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
@@ -17,10 +17,9 @@ import { companiesText, sharedText } from '../../lib/text'
 import { COMPANY_SIZE_LABEL, formatNationalId } from '../../lib/utils'
 import { CompanyExpandedRow } from './CompanyExpandedRow'
 import {
-  deriveStatus,
   normalizeId,
-  STATUS_LABEL,
-  STATUS_TAG_VARIANT,
+  REPORT_STATUS_LABEL,
+  REPORT_STATUS_TAG_VARIANT,
 } from './companyStatus'
 
 import { type ColumnDef, type SortingState } from '@tanstack/react-table'
@@ -66,20 +65,20 @@ export const CompanyTable = ({
         header: sharedText.statusLabel,
         enableSorting: false,
         cell: ({ row }) => {
-          const status = deriveStatus(row.original, approvedReports)
+          const status = row.original.reportStatus
           return (
             <TableCell
               items={{
                 type: 'tag',
-                variant: STATUS_TAG_VARIANT[status],
-                children: STATUS_LABEL[status],
+                variant: REPORT_STATUS_TAG_VARIANT[status],
+                children: REPORT_STATUS_LABEL[status],
               }}
             />
           )
         },
       },
     ],
-    [approvedReports],
+    [],
   )
 
   return (

--- a/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
+++ b/apps/directorate-of-equality-web/src/components/companies/companyStatus.ts
@@ -1,35 +1,36 @@
 import {
-  type CompanyDto,
+  CompanyReportStatusEnum,
   CompanySizeEnum,
-  type ReportListItemDto,
 } from '../../gen/fetch/types.gen'
 
-export type CompanyStatus =
-  | 'missing-equality'
-  | 'has-equality'
-  | 'missing-salary'
-  | 'compliant'
-
-export const STATUS_LABEL: Record<CompanyStatus, string> = {
-  'missing-equality': 'Vantar jafnréttisáætlun',
-  'has-equality': 'Jafnréttisáætlun virk',
-  'missing-salary': 'Vantar launagreiningu',
-  compliant: 'Fullnægjandi',
+// Icelandic labels + tag colours for the company report status. The status
+// itself is computed server-side and returned on `CompanyDto.reportStatus`;
+// the same map drives both the list column and the status filter options so
+// the displayed value and the filter value always agree.
+export const REPORT_STATUS_LABEL: Record<CompanyReportStatusEnum, string> = {
+  [CompanyReportStatusEnum.MISSING_EQUALITY_REPORT]: 'Vantar jafnréttisáætlun',
+  [CompanyReportStatusEnum.MISSING_SALARY_REPORT]: 'Vantar launagreiningu',
+  [CompanyReportStatusEnum.MISSING_ACTION_PLAN]: 'Vantar úrbótaáætlun',
+  [CompanyReportStatusEnum.SATISFACTORY]: 'Fullnægjandi',
 }
 
-export const STATUS_TAG_VARIANT: Record<
-  CompanyStatus,
-  'red' | 'mint' | 'purple'
+export const REPORT_STATUS_TAG_VARIANT: Record<
+  CompanyReportStatusEnum,
+  'red' | 'mint' | 'purple' | 'blue'
 > = {
-  'missing-equality': 'red',
-  'has-equality': 'mint',
-  'missing-salary': 'purple',
-  compliant: 'mint',
+  [CompanyReportStatusEnum.MISSING_EQUALITY_REPORT]: 'red',
+  [CompanyReportStatusEnum.MISSING_SALARY_REPORT]: 'purple',
+  [CompanyReportStatusEnum.MISSING_ACTION_PLAN]: 'blue',
+  [CompanyReportStatusEnum.SATISFACTORY]: 'mint',
 }
 
-export const STATUS_FILTER_OPTIONS = (
-  ['missing-equality', 'has-equality', 'missing-salary', 'compliant'] as const
-).map((value) => ({ value, label: STATUS_LABEL[value] }))
+// Priority order — most critical first — matching the server's evaluation.
+export const STATUS_FILTER_OPTIONS = [
+  CompanyReportStatusEnum.MISSING_EQUALITY_REPORT,
+  CompanyReportStatusEnum.MISSING_SALARY_REPORT,
+  CompanyReportStatusEnum.MISSING_ACTION_PLAN,
+  CompanyReportStatusEnum.SATISFACTORY,
+].map((value) => ({ value, label: REPORT_STATUS_LABEL[value] }))
 
 export const EXPIRES_FILTER_OPTIONS = [
   { value: '30d', label: 'Rennur út innan 30 daga' },
@@ -52,55 +53,4 @@ export const employeeCountCategoryFromCount = (
   if (count >= 50) return CompanySizeEnum.LARGE
   if (count >= 25) return CompanySizeEnum.MEDIUM
   return CompanySizeEnum.SMALL
-}
-
-function getActiveReportTypes(
-  company: CompanyDto,
-  approvedReports: ReportListItemDto[],
-) {
-  const now = new Date()
-  const companyId = normalizeId(company.nationalId)
-  const companyReports = companyId
-    ? approvedReports.filter(
-        (r) => normalizeId(r.companyNationalId) === companyId,
-      )
-    : []
-
-  const hasActive = (type: 'EQUALITY' | 'SALARY') =>
-    companyReports.some(
-      (r) => r.type === type && (!r.validUntil || new Date(r.validUntil) > now),
-    )
-
-  const needsSalary =
-    company.salaryReportRequired || company.salaryReportRequiredOverride
-
-  return {
-    hasEquality: hasActive('EQUALITY'),
-    hasSalary: hasActive('SALARY'),
-    needsSalary,
-  }
-}
-
-export function deriveStatus(
-  company: CompanyDto,
-  approvedReports: ReportListItemDto[],
-): CompanyStatus {
-  const { hasEquality, hasSalary, needsSalary } = getActiveReportTypes(
-    company,
-    approvedReports,
-  )
-  // UNKNOWN and SMALL both carry no reporting obligation. UNKNOWN means the
-  // company size has not been classified yet, so we impose nothing until it is.
-  const noRequirement =
-    company.employeeCountCategory === CompanySizeEnum.SMALL ||
-    company.employeeCountCategory === CompanySizeEnum.UNKNOWN
-
-  if (needsSalary && hasSalary) return 'compliant' // LARGE: both reports filed
-  if (needsSalary && hasEquality) return 'missing-salary' // LARGE: equality done, salary missing
-  if (needsSalary) return 'missing-equality' // LARGE: equality is the prerequisite
-  // No salary requirement below this line
-  if (!noRequirement && hasEquality) return 'compliant' // MEDIUM with equality: obligation met
-  if (!noRequirement) return 'missing-equality' // MEDIUM without equality
-  if (hasEquality) return 'has-equality' // SMALL/UNKNOWN voluntary submission
-  return 'compliant' // SMALL/UNKNOWN with nothing: no obligation
 }

--- a/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
@@ -19,8 +19,8 @@ import { CompanyTable } from '../../components/companies/CompanyTable'
 import { CreateCompanyModal } from '../../components/companies/CreateCompanyModal'
 import {
   CompanyExpiryFilterEnum,
+  CompanyReportStatusEnum,
   CompanySizeEnum,
-  CompanyStatusFilterEnum,
   ReportStatusEnum,
 } from '../../gen/fetch'
 import { useCompanies } from '../../hooks/useCompanies'
@@ -41,7 +41,7 @@ export const CompaniesContainer = () => {
     employees: filter.employeeCountCategory
       ? [filter.employeeCountCategory]
       : [],
-    status: (filter.companyStatus ?? []) as CompanyStatusFilterEnum[],
+    status: (filter.companyStatus ?? []) as CompanyReportStatusEnum[],
     expires: (filter.expiresWithin ?? []) as CompanyExpiryFilterEnum[],
     dailyFines: [],
   })
@@ -75,7 +75,7 @@ export const CompaniesContainer = () => {
   const handleFiltersChange = (key: keyof CompanyFilters, val: string[]) => {
     setFilters((prev) => ({ ...prev, [key]: val }))
     if (key === 'status') {
-      setFilter({ companyStatus: val as CompanyStatusFilterEnum[], page: 1 })
+      setFilter({ companyStatus: val as CompanyReportStatusEnum[], page: 1 })
     } else if (key === 'employees') {
       // API supports a single employeeCountCategory; pass first selected value.
       // Multi-select >1 categories would require an API change.

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/companyRouter.ts
@@ -13,7 +13,12 @@ const zGetCompaniesQuery = z.object({
   employeeCountCategory: z.enum(['UNKNOWN', 'SMALL', 'MEDIUM', 'LARGE']).optional(),
   companyStatus: z
     .array(
-      z.enum(['missing-equality', 'has-equality', 'missing-salary', 'compliant']),
+      z.enum([
+        'MISSING_EQUALITY_REPORT',
+        'MISSING_SALARY_REPORT',
+        'MISSING_ACTION_PLAN',
+        'SATISFACTORY',
+      ]),
     )
     .optional(),
   expiresWithin: z.array(z.enum(['30d', '3m', 'soon'])).optional(),


### PR DESCRIPTION
Introduce CompanyReportStatusEnum and update related DTOs and models

- Added CompanyReportStatusEnum to represent the reporting compliance status of companies.
- Updated CompanyDto to include reportStatus field using CompanyReportStatusEnum.
- Modified GetCompaniesQueryDto to filter companies based on reportStatus.
- Refactored company.enums.ts to define the new report status enum with appropriate descriptions.
- Enhanced CompanyModel to compute reportStatus using a SQL CASE expression.
- Updated filters to utilize the new report status for filtering companies.
- Created report-status.ts utility for SQL logic related to report status evaluation.
- Adjusted clientConfig.json to reflect changes in API documentation for report status.
- Updated CompanyTable component to display report status correctly.
- Refined companyStatus.ts to remove legacy status handling and align with new report status.
- Modified CompaniesContainer to handle filtering based on the new report status.
- Updated companyRouter to validate companyStatus using the new enum values.