### PR TITLE
feat(doe): Salary renewal window block

### DIFF
--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -99,8 +99,8 @@ State-by-state:
 - **`POSTPONED`** — applies to `SALARY` reports only. The company submitted with all outliers deferred (`outliers[]` rows persisted with null explanation columns). The report is **not pickable** by reviewers — `assign()` rejects this status, `approve()` rejects this status. The applicant resolves the postponement via `PUT /api/v1/application/reports/:providerId/outliers`, which fills in the explanation fields and transitions the row to `SUBMITTED` (emitting a `STATUS_CHANGED` + an `EDITED` event). Reviewers can read the report and its content while it sits here, but cannot act on it.
 - **`IN_REVIEW`** — a reviewer has picked up the report. (If you want reviewer-assignment tracking, stamp `reviewer_user_id` on pickup; currently it's stamped on the final decision.) In-place applicant edits are allowed in this state via the two PUT endpoints (equality body / outliers), each emitting an `EDITED` event; status is preserved so the reviewer keeps their pickup.
 - **`DENIED`** — reviewer rejected the submission. `reviewer_user_id` set on the report. Denial reason is stored on the `STATUS_CHANGED` event (`reason` column) rather than the report row — keeps the audit trail self-contained. **Terminal state.** This denied row stays as audit forever and is never mutated. The company submits afresh via the upstream application portal, which produces a new `provider_id` and a new `report` row.
-- **`APPROVED`** — reviewer accepted. `approved_at` set, `valid_until = approved_at + 3 years`. A `public_report` row is inserted as part of this transition. `approve()` additionally gates on every outlier row having all four explanation fields filled — a belt-and-suspenders check on top of the `POSTPONED → SUBMITTED` resolution flow.
-- **`SUPERSEDED`** — a newer report **of the same `type`** from the same company has been approved. Old `valid_until` gets stamped to `now()`. Only one `APPROVED` report per `(company, type)` pair is "current" at any time — an approved `SALARY` does **not** supersede an approved `EQUALITY` and vice versa, since every company needs both kinds active simultaneously (equality universally, salary for ≥50-employee companies).
+- **`APPROVED`** — reviewer accepted. `approved_at` set, `valid_until = approved_at + 3 years`. The parent company's matching next-due column is advanced to the same `valid_until` (`next_salary_report_due_at` for a `SALARY` approval, `next_equality_report_due_at` for `EQUALITY`), keeping it the live source of truth for the renewal-window check. A `public_report` row is inserted as part of this transition. `approve()` additionally gates on every outlier row having all four explanation fields filled — a belt-and-suspenders check on top of the `POSTPONED → SUBMITTED` resolution flow.
+- **`SUPERSEDED`** — a newer report **of the same `type`** from the same company has been approved. Old `valid_until` gets stamped to `now()`. This does **not** touch the company's `next_*_report_due_at` — that was already advanced to the new report's `valid_until` by the approval above; the superseded row is no longer the company's current obligation. Only one `APPROVED` report per `(company, type)` pair is "current" at any time — an approved `SALARY` does **not** supersede an approved `EQUALITY` and vice versa, since every company needs both kinds active simultaneously (equality universally, salary for ≥50-employee companies).
 
 ## Outlier deadlines
 
@@ -139,6 +139,21 @@ Two resubmission triggers:
 
 1. **Denial** — reviewer denied the current submission. The denied row stays as audit forever and is never mutated. A redo always comes through as a fresh upstream application — new `provider_id` → new `report` row → fresh review queue entry. A future PUT-edit endpoint is planned to allow targeted in-place edits to a denied row after admin/applicant communication, but that is distinct from resubmission; resubmission is always a new row.
 2. **Three-year expiry** — approved report is aging out. Companies are notified ~3 months before `valid_until`. A new report is drafted and submitted. On approval, the old report transitions to `SUPERSEDED`.
+
+### Salary renewal window (the "not too early" gate)
+
+Salary reports run on a 3-year cadence, but a company may only submit a **new** salary report once its current one is **due in 6 months or less** — it cannot renew arbitrarily early. The window is measured against `company.next_salary_report_due_at`:
+
+- `next_salary_report_due_at IS NULL` (no obligation on record / first-timer) → **allowed**.
+- due date already in the past (overdue) → **allowed**.
+- due date strictly more than 6 months in the future → **blocked**.
+
+The rule is enforced two ways, both reading the same logic so they cannot drift:
+
+- **Pre-flight:** `GET /api/v1/application/reports/salary/eligibility` returns `{ eligible, reason, dueAt, earliestSubmissionDate }`. The application portal calls it to decide whether to let a company into the salary flow at all; `reason = RENEWAL_WINDOW_NOT_OPEN` when blocked.
+- **At submit:** `POST /api/v1/application/reports/salary` throws **409 Conflict** when the window isn't open. Only the company-facing portal path is gated — admin/system-created reports are not.
+
+The 6-month window is a hardcoded constant (`SALARY_RENEWAL_WINDOW_MONTHS`), matching the hardcoded 3-year validity rule.
 
 ## Provider correlation
 
@@ -212,7 +227,7 @@ No accrual table and no cron: the fines themselves live outside this system, so 
 
 ### Overdue reports (the prompt to act)
 
-So admins know **when** to consider starting the fines process, the company list surfaces overdue obligations. `company.next_equality_report_due_at` / `next_salary_report_due_at` hold each company's next due dates (seeded; nullable when there's no obligation). Two derived booleans, `equalityReportOverdue` / `salaryReportOverdue` (computed in SQL on read, not stored), are `true` when the matching due date is in the past. They drive an overdue indicator in the UI plus an `overdue` list filter and a `nextReportDue` sort, so an admin can spot a lapsed company and decide whether to flag it into the fines process.
+So admins know **when** to consider starting the fines process, the company list surfaces overdue obligations. `company.next_equality_report_due_at` / `next_salary_report_due_at` hold each company's next due dates — seeded for the launch cohort, then advanced by the approval flow (`approve()` sets them to the new report's `valid_until`); nullable when there's no obligation. Two derived booleans, `equalityReportOverdue` / `salaryReportOverdue` (computed in SQL on read, not stored), are `true` when the matching due date is in the past. They drive an overdue indicator in the UI plus an `overdue` list filter and a `nextReportDue` sort, so an admin can spot a lapsed company and decide whether to flag it into the fines process.
 
 ## Quarantine
 
@@ -231,6 +246,7 @@ The `application` module is the company-admin API surface. It reuses reviewer-si
 
 - `GET /api/v1/application/company` resolves the JWT national ID to a live `company` row.
 - `GET /api/v1/application/reports/equality/active` returns the company's active equality report: `type = EQUALITY`, `status = APPROVED`, `valid_until > now()`, joined through `company_report.company_id`. If multiple active rows exist, the service orders by `approved_at DESC` and returns the most recently approved row.
+- `GET /api/v1/application/reports/salary/eligibility` returns whether the company may submit a salary report right now (the renewal-window check — see "Salary renewal window"). Always 200; `eligible = false` with `reason = RENEWAL_WINDOW_NOT_OPEN` when the due date is more than 6 months out.
 - `POST /api/v1/application/reports/equality` and `POST /api/v1/application/reports/salary` accept application-facing bodies with one explicit `company` object for the authenticated parent and an optional `subsidiaries[]` array containing subsidiary names/national IDs. Missing or empty `subsidiaries` means no subsidiaries. The application service maps that to the internal `companies[]` snapshot shape before delegating to report-create.
 - `GET /api/v1/application/reports/:providerId` is company-facing detail, not the reviewer detail DTO. Lookup is by the upstream `(provider_type, provider_id)` tuple rather than internal `report.id` (the applicant never sees the DoE-side id). The optional `providerType` query parameter defaults to `ISLAND_IS` for the island.is application portal. The resolved company must own the parent `company_report` row (`parent_company_id IS NULL`). The response includes all participating company snapshots, external comments only, salary result/outlier data for salary reports, the linked equality summary for salary reports, equality narrative content for equality reports, and the latest denial reason when the report is `DENIED`. It does not expose the reviewer event timeline or internal comments.
 - `POST /api/v1/application/reports/:providerId/comments` posts an external comment on the applicant's own report.
@@ -380,8 +396,8 @@ DoE staff (reviewers). Matches convention used by other apps in the repo (e.g. `
 | `salary_report_required_override` | `boolean`                                           |
 | `fines_started`                   | `boolean` (default `false`)                         |
 | `quarantined`                     | `boolean` (default `false`)                         |
-| `next_equality_report_due_at`     | `timestamptz` (nullable)                            |
-| `next_salary_report_due_at`       | `timestamptz` (nullable)                            |
+| `next_equality_report_due_at`     | `timestamptz` (nullable — seeded, then advanced to `valid_until` on each EQUALITY approval) |
+| `next_salary_report_due_at`       | `timestamptz` (nullable — seeded, then advanced to `valid_until` on each SALARY approval; gates the salary renewal window) |
 | `isat_category_code`              | `text` `fk → isat_category(code)` (nullable)        |
 
 `status` is `ACTIVE` while a company is in the authoritative register and `INACTIVE`

--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -46,6 +46,7 @@ import { EditEqualityContentDto } from './dto/edit-equality-content.dto'
 import { EditOutliersDto } from './dto/edit-outliers.dto'
 import { SalaryAnalysisRequestDto } from './dto/salary-analysis.request.dto'
 import { SalaryAnalysisResponseDto } from './dto/salary-analysis.response.dto'
+import { SalaryReportEligibilityDto } from './dto/salary-report-eligibility.dto'
 import { SubmitApplicationReportCommentDto } from './dto/submit-application-report-comment.dto'
 import { SubmitEqualityReportDto } from './dto/submit-equality-report.dto'
 import { SubmitSalaryReportDto } from './dto/submit-salary-report.dto'
@@ -148,6 +149,19 @@ export class ApplicationController {
     @CurrentCompany() company: CompanyDto,
   ): Promise<EqualityReportSummaryDto> {
     return this.applicationService.getActiveEqualityReport(company)
+  }
+
+  @Get('reports/salary/eligibility')
+  @DoeResponse({
+    operationId: 'getApplicationSalaryReportEligibility',
+    description:
+      "Pre-flight check of whether the resolved company may submit a salary report right now. Salary reports run on a 3-year cadence and may only be renewed once the current one is due in 6 months or less; this endpoint returns that verdict (with a machine-readable reason when blocked) so the application portal can gate entry into the flow. The same rule is enforced as a 409 on `POST reports/salary`.",
+    type: SalaryReportEligibilityDto,
+  })
+  async getSalaryReportEligibility(
+    @CurrentCompany() company: CompanyDto,
+  ): Promise<SalaryReportEligibilityDto> {
+    return this.applicationService.getSalaryReportEligibility(company)
   }
 
   @Post('reports/salary')

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
@@ -10,6 +10,7 @@ import { EditEqualityContentDto } from './dto/edit-equality-content.dto'
 import { EditOutliersDto } from './dto/edit-outliers.dto'
 import { SalaryAnalysisRequestDto } from './dto/salary-analysis.request.dto'
 import { SalaryAnalysisResponseDto } from './dto/salary-analysis.response.dto'
+import { SalaryReportEligibilityDto } from './dto/salary-report-eligibility.dto'
 import { SubmitApplicationReportCommentDto } from './dto/submit-application-report-comment.dto'
 import { SubmitEqualityReportDto } from './dto/submit-equality-report.dto'
 import { SubmitSalaryReportDto } from './dto/submit-salary-report.dto'
@@ -30,6 +31,7 @@ export interface IApplicationService {
   getActiveEqualityReport(
     company: CompanyDto,
   ): Promise<EqualityReportSummaryDto>
+  getSalaryReportEligibility(company: CompanyDto): SalaryReportEligibilityDto
   getReport(
     providerId: string,
     company: CompanyDto,

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -1,5 +1,6 @@
 import {
   BadRequestException,
+  ConflictException,
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common'
@@ -11,6 +12,7 @@ import { LOGGER_PROVIDER } from '@dmr.is/logging'
 import { ICompanyService } from '../company/company.service.interface'
 import { CompanyDto } from '../company/dto/company.dto'
 import {
+  CompanyReportStatusEnum,
   CompanySizeEnum,
   CompanyStatusEnum,
 } from '../company/models/company.enums'
@@ -65,6 +67,15 @@ const COMPANY: CompanyDto = {
   postcodeId: null,
   salaryReportRequired: true,
   salaryReportRequiredOverride: false,
+  finesStarted: false,
+  quarantined: false,
+  nextEqualityReportDueAt: null,
+  nextSalaryReportDueAt: null,
+  isatCategoryCode: null,
+  isatCategory: null,
+  reportStatus: CompanyReportStatusEnum.SATISFACTORY,
+  equalityReportOverdue: false,
+  salaryReportOverdue: false,
 }
 
 describe('ApplicationService', () => {
@@ -383,6 +394,52 @@ describe('ApplicationService', () => {
       )
       expect(getOrCreateSubsidiaryReportSnapshotSource).not.toHaveBeenCalled()
       expect(createSalary).not.toHaveBeenCalled()
+    })
+
+    it('blocks (409) when the renewal window is not open yet (due date > 6 months out)', async () => {
+      const input = makeSubmitSalaryInput()
+      const farFuture = new Date()
+      farFuture.setFullYear(farFuture.getFullYear() + 2)
+      const company = { ...COMPANY, nextSalaryReportDueAt: farFuture }
+
+      await expect(service.submitSalary(input, company)).rejects.toThrow(
+        ConflictException,
+      )
+      expect(createSalary).not.toHaveBeenCalled()
+    })
+
+    it('allows submission when the due date is within 6 months', async () => {
+      const input = makeSubmitSalaryInput()
+      const soon = new Date()
+      soon.setMonth(soon.getMonth() + 3)
+      const company = { ...COMPANY, nextSalaryReportDueAt: soon }
+
+      await service.submitSalary(input, company)
+
+      expect(createSalary).toHaveBeenCalled()
+    })
+  })
+
+  describe('getSalaryReportEligibility', () => {
+    it('is eligible when there is no due date', () => {
+      const result = service.getSalaryReportEligibility(COMPANY)
+
+      expect(result.eligible).toBe(true)
+      expect(result.reason).toBeNull()
+      expect(result.dueAt).toBeNull()
+    })
+
+    it('is ineligible with a reason when the due date is more than 6 months out', () => {
+      const farFuture = new Date()
+      farFuture.setFullYear(farFuture.getFullYear() + 2)
+      const company = { ...COMPANY, nextSalaryReportDueAt: farFuture }
+
+      const result = service.getSalaryReportEligibility(company)
+
+      expect(result.eligible).toBe(false)
+      expect(result.reason).toBe('RENEWAL_WINDOW_NOT_OPEN')
+      expect(result.dueAt).toEqual(farFuture)
+      expect(result.earliestSubmissionDate).toBeInstanceOf(Date)
     })
   })
 

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -2,6 +2,7 @@ import { Op } from 'sequelize'
 
 import {
   BadRequestException,
+  ConflictException,
   Inject,
   Injectable,
   InternalServerErrorException,
@@ -77,6 +78,7 @@ import {
   SalaryAnalysisOutlierDto,
   SalaryAnalysisResponseDto,
 } from './dto/salary-analysis.response.dto'
+import { SalaryReportEligibilityDto } from './dto/salary-report-eligibility.dto'
 import { SubmitApplicationReportCommentDto } from './dto/submit-application-report-comment.dto'
 import { SubmitEqualityReportDto } from './dto/submit-equality-report.dto'
 import type {
@@ -86,6 +88,7 @@ import type {
 import { SubmitSalaryReportDto } from './dto/submit-salary-report.dto'
 import { EQUALITY_REPORT_TEMPLATE_BASE64 } from './equality-template/template-data'
 import { buildEqualityReportTemplateHtml } from './equality-template/template-html'
+import { evaluateSalaryRenewalEligibility } from './lib/salary-renewal-eligibility'
 import { IApplicationService } from './application.service.interface'
 
 const LOGGING_CONTEXT = 'ApplicationService'
@@ -194,8 +197,29 @@ export class ApplicationService implements IApplicationService {
       identifier: input.identifier,
     })
 
+    // Renewal-window gate: a company may only submit a salary report once its
+    // current one is due in 6 months or less. Same verdict the eligibility
+    // endpoint returns, so the pre-check and this block cannot drift. Only the
+    // company-facing portal path is gated — admin/system creation is not.
+    const eligibility = this.getSalaryReportEligibility(company)
+    if (!eligibility.eligible) {
+      throw new ConflictException(
+        `Salary report renewal window is not open yet for company "${company.id}"; earliest submission ${eligibility.earliestSubmissionDate?.toISOString() ?? 'n/a'}`,
+      )
+    }
+
     const createInput = await this.createSalaryReportInput(input, company)
     return this.reportCreateService.createSalary(createInput)
+  }
+
+  getSalaryReportEligibility(company: CompanyDto): SalaryReportEligibilityDto {
+    const { eligible, reason, dueAt, earliestSubmissionDate } =
+      evaluateSalaryRenewalEligibility(
+        company.nextSalaryReportDueAt ?? null,
+        new Date(),
+      )
+
+    return { eligible, reason, dueAt, earliestSubmissionDate }
   }
 
   async submitEquality(

--- a/apps/directorate-of-equality-api/src/modules/application/dto/salary-report-eligibility.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/salary-report-eligibility.dto.ts
@@ -1,0 +1,41 @@
+import {
+  ApiBoolean,
+  ApiOptionalDateTime,
+  ApiOptionalEnum,
+} from '@dmr.is/decorators'
+
+import { SalaryReportEligibilityReasonEnum } from '../lib/salary-renewal-eligibility'
+
+/**
+ * Verdict for whether a company may submit a salary report right now. Returned
+ * by `GET application/reports/salary/eligibility` so the application portal can
+ * gate entry into the salary flow, and surfaced (as a 409) when a submission is
+ * attempted too early.
+ */
+export class SalaryReportEligibilityDto {
+  @ApiBoolean({
+    description: 'Whether the company may submit a salary report right now.',
+  })
+  eligible!: boolean
+
+  @ApiOptionalEnum(SalaryReportEligibilityReasonEnum, {
+    nullable: true,
+    description:
+      'Machine-readable reason when `eligible` is false; null when eligible.',
+  })
+  reason!: SalaryReportEligibilityReasonEnum | null
+
+  @ApiOptionalDateTime({
+    nullable: true,
+    description:
+      "The company's next salary-report due date (`next_salary_report_due_at`). Null when no obligation is on record.",
+  })
+  dueAt!: Date | null
+
+  @ApiOptionalDateTime({
+    nullable: true,
+    description:
+      'Earliest moment the company may submit (due date minus the 6-month window). Null when there is no due date to anchor on.',
+  })
+  earliestSubmissionDate!: Date | null
+}

--- a/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.spec.ts
@@ -1,0 +1,65 @@
+import {
+  evaluateSalaryRenewalEligibility,
+  SalaryReportEligibilityReasonEnum,
+} from './salary-renewal-eligibility'
+
+describe('salary-renewal-eligibility', () => {
+  describe('evaluateSalaryRenewalEligibility', () => {
+    const now = new Date('2026-06-24T00:00:00.000Z')
+
+    it('allows when there is no due date (first-timer / no obligation)', () => {
+      const result = evaluateSalaryRenewalEligibility(null, now)
+
+      expect(result).toEqual({
+        eligible: true,
+        reason: null,
+        dueAt: null,
+        earliestSubmissionDate: null,
+      })
+    })
+
+    it('allows when the due date is in the past (overdue)', () => {
+      const dueAt = new Date('2026-01-01T00:00:00.000Z')
+
+      const result = evaluateSalaryRenewalEligibility(dueAt, now)
+
+      expect(result.eligible).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('allows when the due date is exactly 6 months away (inclusive boundary)', () => {
+      // now + 6 months = 2026-12-24.
+      const dueAt = new Date('2026-12-24T00:00:00.000Z')
+
+      const result = evaluateSalaryRenewalEligibility(dueAt, now)
+
+      expect(result.eligible).toBe(true)
+      expect(result.reason).toBeNull()
+    })
+
+    it('allows when the due date is well within the window', () => {
+      const dueAt = new Date('2026-09-01T00:00:00.000Z')
+
+      const result = evaluateSalaryRenewalEligibility(dueAt, now)
+
+      expect(result.eligible).toBe(true)
+    })
+
+    it('blocks when the due date is more than 6 months away', () => {
+      // now + 6 months + 1 day = 2026-12-25.
+      const dueAt = new Date('2026-12-25T00:00:00.000Z')
+
+      const result = evaluateSalaryRenewalEligibility(dueAt, now)
+
+      expect(result.eligible).toBe(false)
+      expect(result.reason).toBe(
+        SalaryReportEligibilityReasonEnum.RENEWAL_WINDOW_NOT_OPEN,
+      )
+      expect(result.dueAt).toEqual(dueAt)
+      // earliest = dueAt - 6 months = 2026-06-25 (one day after `now`).
+      expect(result.earliestSubmissionDate).toEqual(
+        new Date('2026-06-25T00:00:00.000Z'),
+      )
+    })
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.ts
@@ -1,0 +1,73 @@
+/**
+ * Salary-report renewal window.
+ *
+ * Salary reports (launagreining) run on a 3-year cadence. A company may only
+ * submit a NEW salary report once its current one is "due in 6 months or less"
+ * — i.e. it cannot renew too early. The due date is read from
+ * `company.next_salary_report_due_at` (the regulatory due date, seeded for the
+ * launch cohort and thereafter advanced by the approval flow).
+ *
+ * Edge cases (both allowed):
+ *   - `dueAt == null` → no known obligation / first-timer → eligible.
+ *   - `dueAt` already in the past (overdue) → eligible.
+ *
+ * Blocked only when the due date is strictly more than the window out.
+ */
+export const SALARY_RENEWAL_WINDOW_MONTHS = 6
+
+export enum SalaryReportEligibilityReasonEnum {
+  /** Due date is more than `SALARY_RENEWAL_WINDOW_MONTHS` months away. */
+  RENEWAL_WINDOW_NOT_OPEN = 'RENEWAL_WINDOW_NOT_OPEN',
+}
+
+export interface SalaryRenewalEligibility {
+  eligible: boolean
+  reason: SalaryReportEligibilityReasonEnum | null
+  dueAt: Date | null
+  /**
+   * The earliest moment the company may submit (`dueAt` minus the window).
+   * Null only when there is no due date to anchor on.
+   */
+  earliestSubmissionDate: Date | null
+}
+
+/**
+ * Pure renewal-window decision. `now` is injected so the rule is deterministic
+ * and unit-testable.
+ */
+export function evaluateSalaryRenewalEligibility(
+  dueAt: Date | null,
+  now: Date,
+): SalaryRenewalEligibility {
+  if (dueAt === null) {
+    return {
+      eligible: true,
+      reason: null,
+      dueAt: null,
+      earliestSubmissionDate: null,
+    }
+  }
+
+  const earliestSubmissionDate = new Date(dueAt)
+  earliestSubmissionDate.setMonth(
+    earliestSubmissionDate.getMonth() - SALARY_RENEWAL_WINDOW_MONTHS,
+  )
+
+  // Window is open once we've reached the earliest date (inclusive). An overdue
+  // due date (in the past) trivially satisfies this and stays eligible.
+  if (now.getTime() >= earliestSubmissionDate.getTime()) {
+    return {
+      eligible: true,
+      reason: null,
+      dueAt,
+      earliestSubmissionDate,
+    }
+  }
+
+  return {
+    eligible: false,
+    reason: SalaryReportEligibilityReasonEnum.RENEWAL_WINDOW_NOT_OPEN,
+    dueAt,
+    earliestSubmissionDate,
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common'
 import { SequelizeModule } from '@nestjs/sequelize'
 
 import { ApplicationSystemCoreModule } from '../application-system/application-system.core.module'
+import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportModel } from '../report/models/report.model'
 import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
@@ -15,6 +16,7 @@ import { IReportWorkflowService } from './report-workflow.service.interface'
     SequelizeModule.forFeature([
       ReportModel,
       CompanyReportModel,
+      CompanyModel,
       UserModel,
       ReportOutlierGroupModel,
     ]),

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -45,6 +45,10 @@ describe('ReportWorkflowService', () => {
     findAll: jest.fn(),
   }
 
+  const companyModel = {
+    update: jest.fn(),
+  }
+
   const userModel = {
     findOne: jest.fn(),
   }
@@ -77,6 +81,7 @@ describe('ReportWorkflowService', () => {
       applicationSystemService as never,
       reportModel as never,
       companyReportModel as never,
+      companyModel as never,
       userModel as never,
       reportOutlierGroupModel as never,
     )
@@ -403,6 +408,38 @@ describe('ReportWorkflowService', () => {
       )
     })
 
+    it('advances the parent company next_salary_report_due_at to the new validUntil on a SALARY approval', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.SALARY })
+      reportModel.findAll.mockResolvedValue([])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })
+      companyReportModel.findAll.mockResolvedValue([{ reportId: 'report-1' }])
+
+      await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(companyModel.update).toHaveBeenCalledWith(
+        { nextSalaryReportDueAt: expect.any(Date) },
+        { where: { id: 'company-1' } },
+      )
+    })
+
+    it('advances next_equality_report_due_at (not salary) on an EQUALITY approval', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.EQUALITY })
+      reportModel.findAll.mockResolvedValue([])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      companyReportModel.findOne.mockResolvedValue({ companyId: 'company-1' })
+      companyReportModel.findAll.mockResolvedValue([{ reportId: 'report-1' }])
+
+      await service.approve(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(companyModel.update).toHaveBeenCalledWith(
+        { nextEqualityReportDueAt: expect.any(Date) },
+        { where: { id: 'company-1' } },
+      )
+    })
+
     it('does not supersede approved reports of a different type (SALARY approval leaves APPROVED EQUALITY untouched)', async () => {
       reportModel.update.mockResolvedValue([1])
       reportModel.findOne.mockResolvedValue({ type: ReportTypeEnum.SALARY })
@@ -451,6 +488,8 @@ describe('ReportWorkflowService', () => {
       reportOutlierGroupModel.findOne.mockResolvedValue(null)
       reportModel.update.mockResolvedValue([1])
       reportModel.findOne
+        // advance-due-date type lookup
+        .mockResolvedValueOnce({ type: ReportTypeEnum.EQUALITY })
         // supersede type lookup
         .mockResolvedValueOnce({ type: ReportTypeEnum.EQUALITY })
         // notify provider lookup

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -9,6 +9,7 @@ import { InjectModel } from '@nestjs/sequelize'
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { IApplicationSystemService } from '../application-system/application-system.service.interface'
+import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import {
   ReportModel,
@@ -41,6 +42,8 @@ export class ReportWorkflowService implements IReportWorkflowService {
     private readonly reportModel: typeof ReportModel,
     @InjectModel(CompanyReportModel)
     private readonly companyReportModel: typeof CompanyReportModel,
+    @InjectModel(CompanyModel)
+    private readonly companyModel: typeof CompanyModel,
     @InjectModel(UserModel)
     private readonly userModel: typeof UserModel,
     @InjectModel(ReportOutlierGroupModel)
@@ -220,6 +223,12 @@ export class ReportWorkflowService implements IReportWorkflowService {
       { where: { id: context.reportId } },
     )
 
+    // Keep the company's next-due date in step with the report's validity. The
+    // launch seed sets these dates initially (no reports exist yet); from then
+    // on every approval advances them, so `next_*_report_due_at` stays the live
+    // source of truth the salary renewal-window check reads.
+    await this.advanceCompanyReportDueDate(context.reportId, validUntil)
+
     await this.supersedePreviousApproved(context.reportId)
 
     await this.reportEventService.emitStatusChanged(
@@ -309,6 +318,46 @@ export class ReportWorkflowService implements IReportWorkflowService {
     }
   }
 
+  /**
+   * Mirror an approved report's `validUntil` onto its parent company's
+   * next-due column (`next_salary_report_due_at` for SALARY,
+   * `next_equality_report_due_at` for EQUALITY). The "due" date a company is
+   * measured against is the validity end of its current report, so the two are
+   * kept identical here. Subsidiaries carry no obligation of their own; only the
+   * parent (`parentCompanyId IS NULL`) snapshot is updated.
+   */
+  private async advanceCompanyReportDueDate(
+    reportId: string,
+    validUntil: Date,
+  ): Promise<void> {
+    const report = await this.reportModel.findOne({
+      where: { id: reportId },
+      attributes: ['type'],
+    })
+
+    if (!report) {
+      return
+    }
+
+    const parentSnapshot = await this.companyReportModel.findOne({
+      where: { reportId, parentCompanyId: null },
+      attributes: ['companyId'],
+    })
+
+    if (!parentSnapshot) {
+      return
+    }
+
+    const column =
+      report.type === ReportTypeEnum.SALARY
+        ? { nextSalaryReportDueAt: validUntil }
+        : { nextEqualityReportDueAt: validUntil }
+
+    await this.companyModel.update(column, {
+      where: { id: parentSnapshot.companyId },
+    })
+  }
+
   private async supersedePreviousApproved(reportId: string): Promise<void> {
     // Supersession is scoped to `(company, type)` — approving a new SALARY
     // must not invalidate a still-valid APPROVED EQUALITY (and vice versa).
@@ -359,6 +408,10 @@ export class ReportWorkflowService implements IReportWorkflowService {
       return
     }
 
+    // Close out the old report's validity at "now". Deliberately does NOT touch
+    // the company's next-due date — that was already advanced to the new
+    // report's validUntil in approve(); the superseded report is no longer the
+    // company's current obligation.
     await this.reportModel.update(
       { status: ReportStatusEnum.SUPERSEDED, validUntil: new Date() },
       { where: { id: toSupersede.map((r) => r.id) } },


### PR DESCRIPTION
#### Salary renewal window block.

Salary reports run on a 3-year cadence, but a company may only submit a **new** salary report once its current one is **due in 6 months or less** — it cannot renew arbitrarily early. The window is measured against `company.next_salary_report_due_at`