### PR TITLE
fix(doe): add missing enum values for fines and quarantine company events

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260626-company-event-type-enum-fines-quarantine.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260626-company-event-type-enum-fines-quarantine.js
@@ -1,0 +1,44 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // ALTER TYPE ... ADD VALUE cannot run inside a transaction.
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'FINES_STARTED';
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'FINES_STOPPED';
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'QUARANTINED';
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'UNQUARANTINED';
+    `)
+  },
+
+  async down(queryInterface) {
+    // Postgres does not support removing enum values directly.
+    // Recreate the enum without the added values and update the column.
+    await queryInterface.sequelize.query(`
+    BEGIN;
+
+    ALTER TABLE company_event
+      ALTER COLUMN event_type TYPE TEXT;
+
+    DELETE FROM company_event
+      WHERE event_type IN ('FINES_STARTED', 'FINES_STOPPED', 'QUARANTINED', 'UNQUARANTINED');
+
+    DROP TYPE company_event_type_enum;
+
+    CREATE TYPE company_event_type_enum AS ENUM ('CREATED', 'STATUS_CHANGED');
+
+    ALTER TABLE company_event
+      ALTER COLUMN event_type TYPE company_event_type_enum
+        USING event_type::company_event_type_enum;
+
+    COMMIT;
+    `)
+  },
+}


### PR DESCRIPTION
### Problem

Two migrations landed in sequence last week:

**m-20260623-company-fines-flag** — added company.fines_started
**m-20260623-company-quarantine-flag** — added company.quarantined

Both migrations added columns to the company table and the corresponding event types (FINES_STARTED, FINES_STOPPED, QUARANTINED, UNQUARANTINED) were added to the `CompanyEventTypeEnum` TypeScript enum in the model. However, neither migration extended the Postgres `company_event_type_enum` type with those values.

This caused a SequelizeDatabaseError: invalid input value for enum `company_event_type_enum` at runtime whenever an admin tried to start daily fines or quarantine a company, because Sequelize was inserting a value the database didn't recognise.

### **Fix**
**m-20260626-company-event-type-enum-fines-quarantine** adds the four missing values to the Postgres enum:


ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'FINES_STARTED';
ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'FINES_STOPPED';
ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'QUARANTINED';
ALTER TYPE company_event_type_enum ADD VALUE IF NOT EXISTS 'UNQUARANTINED';

Each statement runs outside a transaction, which is required by Postgres — ALTER TYPE ... ADD VALUE cannot execute inside an explicit BEGIN/COMMIT block.

The down migration handles the lack of a native DROP VALUE in Postgres by converting the column to TEXT, dropping the type, recreating it with only the original two values, and casting back — after first deleting any rows that used the removed values (audit rows are immutable anyway).

**Testing**
Run sequelize db:migrate and retry starting daily fines or quarantining a company through the admin UI — the SequelizeDatabaseError will no longer occur.

