### PR TITLE
fix(doe): tRPC routing audit — correctness, performance, and consistency

### DIFF
--- a/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
@@ -1,24 +1,23 @@
 'use client'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Divider } from '@dmr.is/ui/components/island-is/Divider'
 import { Inline } from '@dmr.is/ui/components/island-is/Inline'
 import { LinkV2 } from '@dmr.is/ui/components/island-is/LinkV2'
+import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Tag } from '@dmr.is/ui/components/island-is/Tag'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 
-import {
-  type CompanyDto,
-  type ReportListItemDto,
-} from '../../gen/fetch/types.gen'
+import { type CompanyDto, ReportStatusEnum } from '../../gen/fetch/types.gen'
 import { companiesText, sharedText } from '../../lib/text'
+import { useTRPC } from '../../lib/trpc/client/trpc'
 import { COMPANY_SIZE_LABEL, formatNationalId } from '../../lib/utils'
 import * as styles from './CompanyExpandedRow.css'
 
 type Props = {
   company: CompanyDto
-  approvedReports: ReportListItemDto[]
 }
 
 const formatDate = (iso: string | null | undefined) => {
@@ -31,11 +30,7 @@ type FieldRow = { label: string; value: React.ReactNode }
 const FieldGrid = ({ fields }: { fields: FieldRow[] }) => (
   <div className={styles.grid}>
     {fields.map(({ label, value }) => (
-      <Box
-        key={label}
-        padding={1}
-        className={styles.item}
-      >
+      <Box key={label} padding={1} className={styles.item}>
         <Box display="flex">
           <div className={styles.label}>
             <Text variant="small" fontWeight="semiBold">
@@ -91,7 +86,20 @@ const ReportStatusTag = ({ status }: { status: string }) => {
   )
 }
 
-export const CompanyExpandedRow = ({ company, approvedReports }: Props) => {
+export const CompanyExpandedRow = ({ company }: Props) => {
+  const trpc = useTRPC()
+  const { data, isLoading } = useQuery(
+    trpc.reports.list.queryOptions(
+      {
+        q: company.nationalId,
+        status: [ReportStatusEnum.APPROVED],
+        pageSize: 100,
+      },
+      { staleTime: 30_000 },
+    ),
+  )
+
+  const approvedReports = data?.reports ?? []
   const equalityReports = approvedReports.filter((r) => r.type === 'EQUALITY')
   const salaryReports = approvedReports.filter((r) => r.type === 'SALARY')
   const contactReport = equalityReports[0] ?? salaryReports[0]
@@ -148,72 +156,73 @@ export const CompanyExpandedRow = ({ company, approvedReports }: Props) => {
     <Box background="blue100" padding={2}>
       <FieldGrid fields={companyFields} />
 
-      {(equalityReports.length > 0 || salaryReports.length > 0) && (
-        <>
-          <Box paddingY={2}>
-            <Divider />
-          </Box>
-          <Stack space={2}>
-            <Text variant="eyebrow">{sharedText.files}</Text>
-            {equalityReports.map((r) => (
-              <LinkV2
-                key={r.id}
-                href={`/yfirlit/${r.id}`}
-                aria-label={`${companiesText.expandedRow.viewReport}: ${sharedText.typeLabels.EQUALITY}`}
+      <Box paddingY={2}>
+        <Divider />
+      </Box>
+
+      {isLoading ? (
+        <SkeletonLoader repeat={2} height={56} space={2} />
+      ) : equalityReports.length > 0 || salaryReports.length > 0 ? (
+        <Stack space={2}>
+          <Text variant="eyebrow">{sharedText.files}</Text>
+          {equalityReports.map((r) => (
+            <LinkV2
+              key={r.id}
+              href={`/yfirlit/${r.id}`}
+              aria-label={`${companiesText.expandedRow.viewReport}: ${sharedText.typeLabels.EQUALITY}`}
+            >
+              <Box
+                background="white"
+                borderRadius="standard"
+                padding={2}
+                display="flex"
+                justifyContent="spaceBetween"
+                alignItems="center"
+                className={styles.reportCard}
               >
-                <Box
-                  background="white"
-                  borderRadius="standard"
-                  padding={2}
-                  display="flex"
-                  justifyContent="spaceBetween"
-                  alignItems="center"
-                  className={styles.reportCard}
-                >
-                  <Stack space={1}>
-                    <Text variant="small" fontWeight="semiBold">
-                      {sharedText.typeLabels.EQUALITY}
-                    </Text>
-                    <Text variant="small" color="dark300">
-                      {companiesText.expandedRow.validUntilPrefix}{' '}
-                      {formatDate(r.validUntil)}
-                    </Text>
-                  </Stack>
-                  <ReportStatusTag status={r.status} />
-                </Box>
-              </LinkV2>
-            ))}
-            {salaryReports.map((r) => (
-              <LinkV2
-                key={r.id}
-                href={`/yfirlit/${r.id}`}
-                aria-label={`${companiesText.expandedRow.viewReport}: ${sharedText.typeLabels.SALARY}`}
+                <Stack space={1}>
+                  <Text variant="small" fontWeight="semiBold">
+                    {sharedText.typeLabels.EQUALITY}
+                  </Text>
+                  <Text variant="small" color="dark300">
+                    {companiesText.expandedRow.validUntilPrefix}{' '}
+                    {formatDate(r.validUntil)}
+                  </Text>
+                </Stack>
+                <ReportStatusTag status={r.status} />
+              </Box>
+            </LinkV2>
+          ))}
+          {salaryReports.map((r) => (
+            <LinkV2
+              key={r.id}
+              href={`/yfirlit/${r.id}`}
+              aria-label={`${companiesText.expandedRow.viewReport}: ${sharedText.typeLabels.SALARY}`}
+            >
+              <Box
+                background="white"
+                borderRadius="standard"
+                padding={2}
+                display="flex"
+                justifyContent="spaceBetween"
+                alignItems="center"
+                className={styles.reportCard}
               >
-                <Box
-                  background="white"
-                  borderRadius="standard"
-                  padding={2}
-                  display="flex"
-                  justifyContent="spaceBetween"
-                  alignItems="center"
-                  className={styles.reportCard}
-                >
-                  <Stack space={1}>
-                    <Text variant="small" fontWeight="semiBold">
-                      {sharedText.typeLabels.SALARY}
-                    </Text>
-                    <Text variant="small" color="dark300">
-                      {companiesText.expandedRow.validUntilPrefix}{' '}
-                      {formatDate(r.validUntil)}
-                    </Text>
-                  </Stack>
-                  <ReportStatusTag status={r.status} />
-                </Box>
-              </LinkV2>
-            ))}
-          </Stack>
-        </>
-      )}
+                <Stack space={1}>
+                  <Text variant="small" fontWeight="semiBold">
+                    {sharedText.typeLabels.SALARY}
+                  </Text>
+                  <Text variant="small" color="dark300">
+                    {companiesText.expandedRow.validUntilPrefix}{' '}
+                    {formatDate(r.validUntil)}
+                  </Text>
+                </Stack>
+                <ReportStatusTag status={r.status} />
+              </Box>
+            </LinkV2>
+          ))}
+        </Stack>
+      ) : null}
     </Box>
   )
 }

--- a/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyTable.tsx
@@ -10,26 +10,17 @@ import { Tooltip } from '@dmr.is/ui/components/island-is/Tooltip'
 import { Table, TableCell } from '@dmr.is/ui/components/Tables/Table'
 import { type TableCellItem } from '@dmr.is/ui/components/Tables/Table'
 
-import {
-  type CompanyDto,
-  type Paging,
-  type ReportListItemDto,
-} from '../../gen/fetch/types.gen'
+import { type CompanyDto, type Paging } from '../../gen/fetch/types.gen'
 import { NAV_PATHS } from '../../lib/constants'
 import { companiesText, overviewText, sharedText } from '../../lib/text'
 import { COMPANY_SIZE_LABEL, formatNationalId } from '../../lib/utils'
 import { CompanyExpandedRow } from './CompanyExpandedRow'
-import {
-  normalizeId,
-  REPORT_STATUS_LABEL,
-  REPORT_STATUS_TAG_VARIANT,
-} from './companyStatus'
+import { REPORT_STATUS_LABEL, REPORT_STATUS_TAG_VARIANT } from './companyStatus'
 
 import { type ColumnDef, type SortingState } from '@tanstack/react-table'
 
 type Props = {
   rows: CompanyDto[]
-  approvedReports: ReportListItemDto[]
   paging: Paging
   onPageChange: (page: number) => void
   sorting?: SortingState
@@ -38,7 +29,6 @@ type Props = {
 
 export const CompanyTable = ({
   rows,
-  approvedReports,
   paging,
   onPageChange,
   sorting,
@@ -138,16 +128,7 @@ export const CompanyTable = ({
           showPageSizeSelect={false}
           noDataMessage={companiesText.noData}
           getRowHref={(row) => `${NAV_PATHS.fyrirtaeki.href}/${row.id}`}
-          getRowExpanded={(company) => (
-            <CompanyExpandedRow
-              company={company}
-              approvedReports={approvedReports.filter(
-                (r) =>
-                  normalizeId(r.companyNationalId) ===
-                  normalizeId(company.nationalId),
-              )}
-            />
-          )}
+          getRowExpanded={(company) => <CompanyExpandedRow company={company} />}
         />
       </Stack>
     </Box>

--- a/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CreateCompanyModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
@@ -15,7 +16,7 @@ import { companiesText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 import { employeeCountCategoryFromCount } from './companyStatus'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 type Props = {
   isOpen: boolean

--- a/apps/directorate-of-equality-web/src/components/company/company-timeline/CompanyTimeline.tsx
+++ b/apps/directorate-of-equality-web/src/components/company/company-timeline/CompanyTimeline.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Input } from '@dmr.is/ui/components/island-is/Input'
@@ -19,7 +20,7 @@ import { companiesText } from '../../../lib/text'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
 import { TimelineFeed } from '../../report/report-tabs/comments/timeline/TimelineFeed'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 const t = companiesText.detailView
 

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/EmployeeSelect.tsx
@@ -1,12 +1,13 @@
 'use client'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { Select } from '@dmr.is/ui/components/island-is/Select'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 
 import { reportText } from '../../../lib/text'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 type Props = {
   reportId: string

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from 'react'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
+
 import { Tabs } from '@island.is/island-ui/core'
 
 import { CommentsContainer } from '../../../containers/report/CommentsContainer'
@@ -18,7 +20,7 @@ import { CompanyInfoTab } from './company-tab/CompanyInfoTab'
 import { EqualityReportTab } from './equality-tab/EqualityReportTab'
 import { SalaryReportTab } from './salary-tab/SalaryReportTab'
 
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { keepPreviousData } from '@tanstack/react-query'
 import { type SortingState } from '@tanstack/react-table'
 
 type ReportTabsProps = {

--- a/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/companies/CompaniesContainer.tsx
@@ -21,7 +21,6 @@ import {
   CompanyExpiryFilterEnum,
   CompanyReportStatusEnum,
   CompanySizeEnum,
-  ReportStatusEnum,
 } from '../../gen/fetch'
 import { useCompanies } from '../../hooks/useCompanies'
 import { useIsTablet } from '../../hooks/useIsTablet'
@@ -52,13 +51,6 @@ export const CompaniesContainer = () => {
   })
 
   const trpc = useTRPC()
-  const { data: reportsData } = useQuery(
-    trpc.reports.list.queryOptions({
-      status: [ReportStatusEnum.APPROVED],
-      pageSize: 500,
-    }),
-  )
-  const approvedReports = reportsData?.reports ?? []
 
   const { data: regionsData } = useQuery(
     trpc.location.regions.queryOptions(undefined, {
@@ -218,7 +210,6 @@ export const CompaniesContainer = () => {
           {data?.paging && (
             <CompanyTable
               rows={rows}
-              approvedReports={approvedReports}
               paging={data.paging}
               onPageChange={(p) => setFilter({ page: p })}
               sorting={sorting}

--- a/apps/directorate-of-equality-web/src/containers/company/CompanyFormContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/company/CompanyFormContainer.tsx
@@ -33,7 +33,9 @@ export function CompanyFormContainer({ company }: CompanyFormContainerProps) {
   const queryClient = useQueryClient()
 
   const invalidateCompany = () => {
-    queryClient.invalidateQueries({ queryKey: trpc.company.get.queryKey() })
+    queryClient.invalidateQueries({
+      queryKey: trpc.company.get.queryKey({ id: company.id }),
+    })
     queryClient.invalidateQueries({
       queryKey: trpc.company.getTimeline.queryKey({ id: company.id }),
     })

--- a/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 
+import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 
 import { CommentsForm } from '../../components/report/report-tabs/comments/CommentsForm'
@@ -12,7 +13,7 @@ import {
 import { reportText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 type CommentsContainerProps = {
   reportId: string

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportCommentsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportCommentsRouter.ts
@@ -2,19 +2,10 @@ import {
   zCreateReportCommentBody,
   zCreateReportCommentPath,
   zDeleteReportCommentPath,
-  zGetReportCommentsPath,
 } from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
 
 export const reportCommentsRouter = router({
-  list: protectedProcedure
-    .input(zGetReportCommentsPath)
-    .query(({ ctx, input }) =>
-      ctx.api.getReportComments({
-        path: { reportId: input.reportId },
-      }),
-    ),
-
   create: protectedProcedure
     .input(zCreateReportCommentPath.extend(zCreateReportCommentBody.shape))
     .mutation(({ ctx, input }) =>


### PR DESCRIPTION
## Changes made


### Bug fix
`CompanyFormContainer` was calling `trpc.company.get.queryKey() `without an ID on mutation success, which invalidated every cached company-detail query in the app. Now targets only the current company.

### Performance
Removed a `reports.list { pageSize: 500 }` prefetch from the companies list page that fetched all approved reports upfront for a client-side join. The expanded row now fetches its own reports lazily (only when opened), with a skeleton loader while they load.

### Dead code
 Removed `reportComments.list `from the tRPC router — comments are read from` reports.getById.timeline` throughout the UI, making the dedicated list procedure unreachable.

### Consistency:
Normalised `useQuery` imports to use the project wrapper (`@dmr.is/trpc/client/trpc`) instead of `@tanstack/react-query `directly across `CommentsContainer`, `ReportTabs`, `CompanyTimeline`, `EmployeeSelect`, and `CreateCompanyModal`. `ReportSidebarContainer` is left on the direct tanstack import since it uses `initialData`, which relies on tanstack's overloaded types for non-undefined narrowing.

## Test plan

- [ ]  Companies list page loads without the 500-report prefetch appearing in network tab
- [ ]  Expanding a company row fetches and displays approved reports correctly
- [ ]  Toggling fines/quarantine on a company detail page invalidates only that company's cache (no other detail pages refetch)
- [ ]  Report comments can be created and deleted; sidebar and tabs stay in sync
- [ ]  No TypeScript errors (`tsc --noEmit`)