### PR TITLE
fix(doe): Submitted tab - filters for delayed outlier report

### DIFF
--- a/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
+++ b/apps/directorate-of-equality-web/src/components/companies/CompanyExpandedRow.tsx
@@ -31,11 +31,7 @@ type FieldRow = { label: string; value: React.ReactNode }
 const FieldGrid = ({ fields }: { fields: FieldRow[] }) => (
   <div className={styles.grid}>
     {fields.map(({ label, value }) => (
-      <Box
-        key={label}
-        padding={1}
-        className={styles.item}
-      >
+      <Box key={label} padding={1} className={styles.item}>
         <Box display="flex">
           <div className={styles.label}>
             <Text variant="small" fontWeight="semiBold">

--- a/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.css.ts
+++ b/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.css.ts
@@ -6,3 +6,7 @@ export const dateSection = style({
   borderBottomLeftRadius: '8px',
   borderBottomRightRadius: '8px',
 })
+
+export const delayedSection = style({
+  marginTop: -32,
+})

--- a/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/filter/ReportFilter.tsx
@@ -4,6 +4,7 @@ import { Accordion } from '@dmr.is/ui/components/island-is/Accordion'
 import { AccordionItem } from '@dmr.is/ui/components/island-is/AccordionItem'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Checkbox } from '@dmr.is/ui/components/island-is/Checkbox'
 import { DatePicker } from '@dmr.is/ui/components/island-is/DatePicker'
 import { Filter } from '@dmr.is/ui/components/island-is/Filter'
 import { FilterInput } from '@dmr.is/ui/components/island-is/FilterInput'
@@ -39,6 +40,8 @@ type Props = {
   onDateFromChange: (date: Date | undefined) => void
   onDateToChange: (date: Date | undefined) => void
   onReset: () => void
+  showDelayed?: boolean
+  onShowDelayedChange?: (value: boolean) => void
 }
 
 export const ReportFilter = ({
@@ -59,6 +62,8 @@ export const ReportFilter = ({
   onDateFromChange,
   onDateToChange,
   onReset,
+  showDelayed,
+  onShowDelayedChange,
 }: Props) => {
   const { isMobile } = useIsMobile()
   const { isTablet } = useIsTablet()
@@ -66,6 +71,12 @@ export const ReportFilter = ({
   const handleReset = () => {
     onDateFromChange(undefined)
     onDateToChange(undefined)
+    onStatusChange(null)
+    onTypeChange(null)
+    onReviewerChange(null)
+    onHasImprovementPlanChange(null)
+    onQChange(null)
+    if (onShowDelayedChange) onShowDelayedChange(false)
     onReset()
   }
 
@@ -220,6 +231,23 @@ export const ReportFilter = ({
             </Accordion>
           </Box>
         </Box>
+        {onShowDelayedChange !== undefined && (
+          <Box
+            paddingX={3}
+            paddingY={2}
+            background="white"
+            className={styles.delayedSection}
+          >
+            <Box borderTopWidth="standard" borderColor="blue200" width="full" />
+            <Box paddingTop={2}>
+              <Checkbox
+                label={overviewText.filter.showDelayed}
+                checked={showDelayed ?? false}
+                onChange={(e) => onShowDelayedChange(e.target.checked)}
+              />
+            </Box>
+          </Box>
+        )}
       </Filter>
     </Box>
   )

--- a/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { parseAsStringLiteral, useQueryState } from 'nuqs'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import { useQuery } from '@dmr.is/trpc/client/trpc'
 import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
@@ -44,7 +44,11 @@ import { type ColumnDef } from '@tanstack/react-table'
 
 type TabId = 'innsendingar' | 'i-vinnslu' | 'afgreitt'
 
-const SUBMITTED = [ReportStatusEnum.SUBMITTED, ReportStatusEnum.POSTPONED]
+const SUBMITTED = [ReportStatusEnum.SUBMITTED]
+const SUBMITTED_WITH_DELAYED = [
+  ReportStatusEnum.SUBMITTED,
+  ReportStatusEnum.POSTPONED,
+]
 const IN_REVIEW = [ReportStatusEnum.IN_REVIEW]
 const PROCESSED = [
   ReportStatusEnum.APPROVED,
@@ -74,12 +78,7 @@ const ALL_STATUS_OPTIONS: FilterOption[] = (
 ).map((value) => ({ value, label: sharedText.statusLabels[value] }))
 
 const EXCLUDED_FROM_STATUS_FILTER: Record<TabId, string[]> = {
-  // tab 1 is locked to SUBMITTED + POSTPONED (see SUBMITTED above); let the
-  // admin narrow to either one, but exclude every other status so they can't
-  // escape the tab's domain
-  innsendingar: ALL_STATUS_OPTIONS.map((o) => o.value).filter(
-    (v) => v !== ReportStatusEnum.SUBMITTED && v !== ReportStatusEnum.POSTPONED,
-  ),
+  innsendingar: ALL_STATUS_OPTIONS.map((o) => o.value),
   'i-vinnslu': ALL_STATUS_OPTIONS.map((o) => o.value),
   // tab 3 shows ONLY the three processed statuses — exclude everything else
   afgreitt: ['DRAFT', 'SUBMITTED', 'IN_REVIEW', 'POSTPONED'],
@@ -201,7 +200,15 @@ export const ReportsContainer = () => {
     ] as const).withDefault('innsendingar'),
   )
 
-  const fixedStatus = TAB_FIXED_STATUS[activeTab]
+  const [showDelayed, setShowDelayed] = useState(false)
+
+  const fixedStatus = useMemo(() => {
+    if (activeTab === 'innsendingar') {
+      return showDelayed ? SUBMITTED_WITH_DELAYED : SUBMITTED
+    }
+    return TAB_FIXED_STATUS[activeTab]
+  }, [activeTab, showDelayed])
+
   const fixedQuery = fixedStatus ? { status: fixedStatus } : undefined
 
   const { data, isLoading, isError, filter, setFilter, resetFilter } =
@@ -235,6 +242,7 @@ export const ReportsContainer = () => {
 
   const handleTabChange = (tab: string) => {
     resetFilter()
+    setShowDelayed(false)
     setActiveTab(tab as TabId)
   }
 
@@ -298,6 +306,12 @@ export const ReportsContainer = () => {
                 setFilter({ createdTo: d.toISOString() })
               }}
               onReset={resetFilter}
+              showDelayed={
+                activeTab === 'innsendingar' ? showDelayed : undefined
+              }
+              onShowDelayedChange={
+                activeTab === 'innsendingar' ? setShowDelayed : undefined
+              }
             />
             {!isMobile && (
               <Stack space={2}>

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -72,6 +72,7 @@ export const overviewText = {
     dateTo: 'Til',
     dateToPlaceholder: 'Veldu dagsetningu',
     clearDates: 'Hreinsa dagsetningar',
+    showDelayed: 'Sýna frestaðar úrbótaráætlanir',
   },
   createEqualityReport: {
     drawerLabel: 'Skrá jafnréttisáætlun',


### PR DESCRIPTION
## What

- Removes "Frestað" (Postponed) from the status filter options on the Innsendingar tab — the status filter category is no longer shown on that tab at all
- Changes the default query for the Innsendingar tab to show only SUBMITTED reports; POSTPONED reports (delayed improvement plans) are hidden by default
- Adds a standalone checkbox "Sýna frestaðar úrbótaráætlanir" inside the filter panel, below the date range accordion — checking it extends the query to also include POSTPONED reports
- The checkbox resets to unchecked when switching tabs or clicking "Hreinsa allar síur"