### PR TITLE
feat(ojoi): Option to reopen application

### DIFF
--- a/apps/official-journal-admin-api/src/app/application/application.controller.ts
+++ b/apps/official-journal-admin-api/src/app/application/application.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Inject, Param, Put, UseGuards } from '@nestjs/common'
+import {
+  ApiBearerAuth,
+  ApiNoContentResponse,
+  ApiOperation,
+} from '@nestjs/swagger'
+
+import { UserRoleEnum } from '@dmr.is/constants'
+import { Roles } from '@dmr.is/decorators'
+import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+import { IApplicationService } from '@dmr.is/ojoi-modules'
+import { RoleGuard } from '@dmr.is/ojoi-modules/guards/auth'
+import { UUIDValidationPipe } from '@dmr.is/pipelines'
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+import { ResultWrapper } from '@dmr.is/types'
+
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, RoleGuard)
+@Roles(UserRoleEnum.Admin)
+@Controller({
+  version: '1',
+  path: 'applications',
+})
+export class ApplicationController {
+  constructor(
+    @Inject(IApplicationService)
+    private readonly applicationService: IApplicationService,
+
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Recovery action: forces a stuck application back to the draft_retry state so
+   * the applicant can edit and resubmit. Intended for applications that ended up
+   * in the submitted state without a case being created (e.g. island.is errored
+   * before reaching our post-application endpoint). Only applications currently in
+   * the submitted state can be re-opened.
+   */
+  @Put(':id/reopen')
+  @ApiOperation({ operationId: 'reopenApplication' })
+  @ApiNoContentResponse()
+  async reopenApplication(
+    @Param('id', new UUIDValidationPipe()) id: string,
+  ): Promise<void> {
+    this.logger.info(`Re-opening application<${id}>`)
+
+    ResultWrapper.unwrap(await this.applicationService.reopenApplication(id))
+  }
+}

--- a/apps/official-journal-admin-api/src/app/case/case.module.ts
+++ b/apps/official-journal-admin-api/src/app/case/case.module.ts
@@ -5,6 +5,7 @@ import {
   AdvertTypeAdminController,
   AdvertTypeController,
   AdvertTypeModule,
+  ApplicationModule,
   CommentModuleV2,
   InstitutionAdminController,
   InstitutionController,
@@ -18,6 +19,7 @@ import {
   UserModule,
 } from '@dmr.is/ojoi-modules'
 
+import { ApplicationController } from '../application/application.controller'
 import { CaseController } from './case.controller'
 
 @Module({
@@ -31,9 +33,11 @@ import { CaseController } from './case.controller'
     AdvertTypeModule,
     UserModule,
     PriceModule,
+    ApplicationModule,
   ],
   controllers: [
     CaseController,
+    ApplicationController,
     AdvertTypeAdminController,
     SignatureController,
     AdvertTypeController,

--- a/apps/official-journal-web/clientConfig.json
+++ b/apps/official-journal-web/clientConfig.json
@@ -2412,6 +2412,22 @@
         "summary": ""
       }
     },
+    "/api/v1/applications/{id}/reopen": {
+      "put": {
+        "operationId": "reopenApplication",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "204": { "description": "" } },
+        "security": [{ "bearer": [] }],
+        "summary": ""
+      }
+    },
     "/api/v1/advert-types/types": {
       "post": {
         "operationId": "createType",

--- a/apps/official-journal-web/next-env.d.ts
+++ b/apps/official-journal-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./../../apps/official-journal-web/dist/.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/official-journal-web/src/app/(protected)/enduropna-umsokn/page.tsx
+++ b/apps/official-journal-web/src/app/(protected)/enduropna-umsokn/page.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useState } from 'react'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
+import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
+import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
+import { Input } from '@dmr.is/ui/components/island-is/Input'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+
+import { Section } from '../../../components/section/Section'
+import { useTRPC } from '../../../lib/trpc/client/trpc'
+
+import { useMutation } from '@tanstack/react-query'
+
+export default function ReopenApplicationPage() {
+  const trpc = useTRPC()
+  const [applicationId, setApplicationId] = useState<string>('')
+
+  const reopenMutation = useMutation(
+    trpc.reopenApplication.mutationOptions({
+      onSuccess: () => {
+        toast.success('Umsókn enduropnuð', {
+          toastId: 'reopenApplication',
+        })
+      },
+      onError: () => {
+        toast.error('Ekki tókst að enduropna umsókn', {
+          toastId: 'reopenApplication',
+        })
+      },
+    }),
+  )
+
+  return (
+    <Section paddingTop="content">
+      <GridContainer>
+        <GridRow>
+          <GridColumn
+            span={['12/12', '12/12', '12/12', '10/12']}
+            offset={['0', '0', '0', '1/12']}
+          >
+            <Text marginBottom={4}>
+              Enduropna umsókn sem sat föst í innsendri stöðu án þess að mál hafi
+              verið stofnað (t.d. vegna villu við innsendingu) svo umsækjandi geti
+              opnað hana aftur og sent inn að nýju. Aðeins er hægt að enduropna
+              umsóknir sem eru í stöðunni innsend. Þetta input tekur við auðkenni
+              (UUID) umsóknar.
+            </Text>
+            <Stack space={2}>
+              <Input
+                name="application-id"
+                type="text"
+                label="Auðkenni umsóknar"
+                placeholder="a12c3d4e-5f67-8h90-1i23-j45k6l7m8n9o0"
+                backgroundColor="white"
+                onChange={(e) => {
+                  setApplicationId(e.target.value)
+                }}
+              />
+              <Box>
+                <Button
+                  variant="ghost"
+                  size="small"
+                  icon="arrowForward"
+                  iconType="outline"
+                  type="button"
+                  disabled={!applicationId}
+                  loading={reopenMutation.isPending}
+                  onClick={() => reopenMutation.mutate({ id: applicationId })}
+                >
+                  Enduropna umsókn
+                </Button>
+              </Box>
+            </Stack>
+          </GridColumn>
+        </GridRow>
+      </GridContainer>
+    </Section>
+  )
+}

--- a/apps/official-journal-web/src/lib/trpc/server/routers/_app.ts
+++ b/apps/official-journal-web/src/lib/trpc/server/routers/_app.ts
@@ -1,4 +1,5 @@
 import { mergeRouters } from '../trpc'
+import { applicationsRouter } from './applicationsRouter'
 import { attachmentsRouter } from './attachmentsRouter'
 import { casesRouter } from './casesRouter'
 import { categoriesRouter } from './categoriesRouter'
@@ -17,6 +18,7 @@ export const appRouter = mergeRouters(
   casesRouter,
   commentsRouter,
   publishRouter,
+  applicationsRouter,
   categoriesRouter,
   mainCategoriesRouter,
   typesRouter,

--- a/apps/official-journal-web/src/lib/trpc/server/routers/applicationsRouter.ts
+++ b/apps/official-journal-web/src/lib/trpc/server/routers/applicationsRouter.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+import { protectedProcedure, router } from '../trpc'
+
+export const applicationsRouter = router({
+  reopenApplication: protectedProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.api.reopenApplication({ id: input.id })
+    }),
+})

--- a/libs/official-journal/modules/src/application/application.service.interface.ts
+++ b/libs/official-journal/modules/src/application/application.service.interface.ts
@@ -33,6 +33,15 @@ export interface IApplicationService {
 
   submitApplication(id: string, event: ApplicationEvent): Promise<ResultWrapper>
 
+  /**
+   * Re-opens a submitted application by moving it back to the draft_retry state.
+   * Intended to recover applications that ended up stuck in the submitted state
+   * (e.g. island.is errored before a case was created on our side).
+   * Only applications currently in the submitted state can be re-opened.
+   * @param id Application id
+   */
+  reopenApplication(id: string): Promise<ResultWrapper>
+
   postApplication(id: string): Promise<ResultWrapper>
 
   getComments(applicationId: string): Promise<ResultWrapper<GetComments>>

--- a/libs/official-journal/modules/src/application/application.service.ts
+++ b/libs/official-journal/modules/src/application/application.service.ts
@@ -13,7 +13,11 @@ import {
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
-import { ApplicationEvent, AttachmentTypeParam } from '@dmr.is/constants'
+import {
+  ApplicationEvent,
+  ApplicationStates,
+  AttachmentTypeParam,
+} from '@dmr.is/constants'
 import { LogAndHandle, Transactional } from '@dmr.is/decorators'
 import { type Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 import {
@@ -197,6 +201,19 @@ export class ApplicationService implements IApplicationService {
     }
 
     return ResultWrapper.ok()
+  }
+
+  @LogAndHandle()
+  async reopenApplication(id: string): Promise<ResultWrapper> {
+    const { application } = (await this.getApplication(id)).unwrap()
+
+    if (application.state !== ApplicationStates.SUBMITTED) {
+      throw new BadRequestException(
+        `Application<${id}> cannot be re-opened from state<${application.state}>, only submitted applications can be re-opened`,
+      )
+    }
+
+    return this.submitApplication(id, ApplicationEvent.Edit)
   }
 
   @LogAndHandle()


### PR DESCRIPTION
## Re-open stuck OJOI applications

Adds a recovery action to force an application back to `draft_retry` so the applicant can edit and resubmit.

### Why
An island.is submission error can leave an application in `submitted` state without a case ever being created on our side. None of the existing case-driven re-open paths can reach these orphaned applications, so there was no way to recover them.

### What
- **libs**: new `reopenApplication(id)` service method — only re-opens applications currently in `submitted` (throws otherwise), then fires the `EDIT` event (`submitted → draft_retry`) via X-Road. No case required.
- **admin-api**: `PUT /api/v1/applications/:id/reopen` (admin auth).
- **web**: page at `/enduropna-umsokn` (not in nav) where an admin pastes an application UUID and re-opens it
