### PR TITLE
feat(doe): System soft auto review

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260629-report-event-system-auto-review.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260629-report-event-system-auto-review.js
@@ -1,0 +1,46 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    await queryInterface.sequelize.query(`
+      ALTER TYPE report_event_type_enum ADD VALUE IF NOT EXISTS 'SYSTEM_AUTO_REVIEW';
+    `)
+
+    // New enum type + column for the system's auto-review verdict. Nullable;
+    // only SYSTEM_AUTO_REVIEW events set it.
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'report_event_system_decision_enum') THEN
+          CREATE TYPE report_event_system_decision_enum AS ENUM ('AUTO_APPROVE', 'NEEDS_REVIEW');
+        END IF;
+      END $$;
+
+      ALTER TABLE report_event
+        ADD COLUMN IF NOT EXISTS system_decision report_event_system_decision_enum;
+
+      COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    // Postgres cannot drop an enum value, so the SYSTEM_AUTO_REVIEW event-type
+    // value is left in place. Drop the column and its enum type, removing any
+    // audit-only rows that depend on it.
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+      DELETE FROM report_event WHERE event_type = 'SYSTEM_AUTO_REVIEW';
+
+      ALTER TABLE report_event DROP COLUMN IF EXISTS system_decision;
+
+      DROP TYPE IF EXISTS report_event_system_decision_enum;
+
+      COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.constants.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.constants.ts
@@ -1,0 +1,22 @@
+export const AUTO_REVIEW_LOGGING_CONTEXT = 'ReportAutoReviewService'
+
+/**
+ * SOFT PHASE SWITCH. While false, the system records what it *would* decide but
+ * never acts on it — a human still reviews every report. Flipping this to true
+ * (and wiring the `systemApprove` branch in the create flow) turns the audit
+ * into real automation. Kept as a single constant so the flip is one edit.
+ */
+export const AUTO_REVIEW_ENFORCE = false
+
+/**
+ * PROVISIONAL auto-approve thresholds. The directorate has not finalised the
+ * real criteria; these placeholders let the soft audit produce a verdict so we
+ * can measure how the rule behaves on live submissions. Tune the values — or
+ * replace the whole decision body in the service — once the formula is agreed.
+ */
+export const AUTO_REVIEW_THRESHOLDS = {
+  /** Max share of a report's employees flagged as outliers, still approvable. */
+  maxOutlierRatio: 0.1,
+  /** Max absolute male/female base-pay gap percent, still approvable. */
+  maxGapPercent: 5,
+}

--- a/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.core.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { ReportModel } from '../report/models/report.model'
+import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportResultModel } from '../report-result/models/report-result.model'
+import { ReportAutoReviewService } from './report-auto-review.service'
+import { IReportAutoReviewService } from './report-auto-review.service.interface'
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([
+      ReportModel,
+      ReportResultModel,
+      ReportEmployeeModel,
+      ReportEmployeeOutlierModel,
+    ]),
+  ],
+  providers: [
+    {
+      provide: IReportAutoReviewService,
+      useClass: ReportAutoReviewService,
+    },
+  ],
+  exports: [IReportAutoReviewService],
+})
+export class ReportAutoReviewCoreModule {}

--- a/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.interface.ts
@@ -1,0 +1,42 @@
+import { ReportTypeEnum } from '../report/models/report.enums'
+import { AutoReviewDecisionEnum } from '../report/models/report-event.model'
+
+export const IReportAutoReviewService = Symbol('IReportAutoReviewService')
+
+/**
+ * The raw inputs the verdict was reached from, snapshotted so a later analysis
+ * can see *why* the system decided what it did without recomputing. Stored on
+ * the verdict (not yet persisted as columns — `reason` carries the human
+ * summary onto the event).
+ */
+export type AutoReviewSignals = {
+  reportType: ReportTypeEnum
+  totalEmployees: number
+  outlierEmployees: number
+  /** outlierEmployees / totalEmployees, or null when there are no employees. */
+  outlierRatio: number | null
+  /** Absolute male/female base-pay gap percent, or null when not computable. */
+  gapPercent: number | null
+  /** Same metric on the company's previous approved salary report, if any. */
+  previousGapPercent: number | null
+  /** Whether the gap shrank vs the previous report; null when no prior report. */
+  gapImproved: boolean | null
+}
+
+export type AutoReviewVerdict = {
+  decision: AutoReviewDecisionEnum
+  /** Human-readable, admin-facing summary. Persisted on the event's `reason`. */
+  reason: string
+  signals: AutoReviewSignals
+}
+
+/**
+ * Decides whether a freshly submitted report *would* be auto-approved. During
+ * the soft phase the verdict is recorded for audit only and never changes the
+ * report's status — see how the create flow consumes it. The decision rule is
+ * intentionally isolated here so it can be swapped wholesale once the
+ * directorate finalises the criteria.
+ */
+export interface IReportAutoReviewService {
+  evaluate(reportId: string): Promise<AutoReviewVerdict>
+}

--- a/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.spec.ts
@@ -1,0 +1,181 @@
+import { getModelToken } from '@nestjs/sequelize'
+import { Test } from '@nestjs/testing'
+
+import { LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import { ReportTypeEnum } from '../report/models/report.enums'
+import { ReportModel } from '../report/models/report.model'
+import { AutoReviewDecisionEnum } from '../report/models/report-event.model'
+import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportResultModel } from '../report-result/models/report-result.model'
+import { ReportAutoReviewService } from './report-auto-review.service'
+
+const mockLogger = {
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}
+
+const REPORT_ID = 'report-1'
+const PREVIOUS_REPORT_ID = 'report-0'
+
+// Builds a persisted-result row exposing just the male/female base-pay gap the
+// evaluator reads.
+const resultWithGap = (maleFemale: number | null) => ({
+  baseSnapshot: { totals: { salaryDifferences: { maleFemale } } },
+})
+
+describe('ReportAutoReviewService', () => {
+  let service: ReportAutoReviewService
+  let reportFindOne: jest.Mock
+  let resultFindOne: jest.Mock
+  let employeeCount: jest.Mock
+  let outlierCount: jest.Mock
+
+  beforeEach(async () => {
+    reportFindOne = jest.fn()
+    resultFindOne = jest.fn()
+    employeeCount = jest.fn()
+    outlierCount = jest.fn()
+
+    const module = await Test.createTestingModule({
+      providers: [
+        ReportAutoReviewService,
+        { provide: LOGGER_PROVIDER, useValue: mockLogger },
+        { provide: getModelToken(ReportModel), useValue: { findOne: reportFindOne } },
+        {
+          provide: getModelToken(ReportResultModel),
+          useValue: { findOne: resultFindOne },
+        },
+        {
+          provide: getModelToken(ReportEmployeeModel),
+          useValue: { count: employeeCount },
+        },
+        {
+          provide: getModelToken(ReportEmployeeOutlierModel),
+          useValue: { count: outlierCount },
+        },
+      ],
+    }).compile()
+
+    service = module.get(ReportAutoReviewService)
+  })
+
+  // Arranges a salary report with `total` employees, `outliers` flagged, a
+  // current male/female gap, and optionally a previous approved report + gap.
+  const arrangeSalary = (opts: {
+    total: number
+    outliers: number
+    gap: number | null
+    previousGap?: number | null
+  }) => {
+    reportFindOne.mockResolvedValueOnce({
+      id: REPORT_ID,
+      type: ReportTypeEnum.SALARY,
+      companyNationalId: '5500000000',
+    })
+    employeeCount.mockResolvedValue(opts.total)
+    outlierCount.mockResolvedValue(opts.outliers)
+
+    // First result lookup = current report's gap.
+    resultFindOne.mockResolvedValueOnce(resultWithGap(opts.gap))
+
+    if (opts.previousGap === undefined) {
+      // No previous approved report.
+      reportFindOne.mockResolvedValueOnce(null)
+    } else {
+      reportFindOne.mockResolvedValueOnce({ id: PREVIOUS_REPORT_ID })
+      resultFindOne.mockResolvedValueOnce(resultWithGap(opts.previousGap))
+    }
+  }
+
+  it('abstains (NEEDS_REVIEW) for EQUALITY reports without touching salary signals', async () => {
+    reportFindOne.mockResolvedValueOnce({
+      id: REPORT_ID,
+      type: ReportTypeEnum.EQUALITY,
+    })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+    expect(verdict.signals.reportType).toBe(ReportTypeEnum.EQUALITY)
+    expect(employeeCount).not.toHaveBeenCalled()
+    expect(outlierCount).not.toHaveBeenCalled()
+  })
+
+  it('abstains when the report cannot be found', async () => {
+    reportFindOne.mockResolvedValueOnce(null)
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+  })
+
+  it('auto-approves a salary report with no outliers', async () => {
+    arrangeSalary({ total: 20, outliers: 0, gap: 0 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.AUTO_APPROVE)
+    expect(verdict.signals.outlierEmployees).toBe(0)
+  })
+
+  it('auto-approves outliers within bounds when there is no prior report', async () => {
+    arrangeSalary({ total: 20, outliers: 1, gap: 3 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.AUTO_APPROVE)
+    expect(verdict.signals.outlierRatio).toBeCloseTo(0.05)
+    expect(verdict.signals.gapImproved).toBeNull()
+  })
+
+  it('routes to review when the outlier share exceeds the threshold', async () => {
+    arrangeSalary({ total: 10, outliers: 3, gap: 2 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+    expect(verdict.reason).toContain('hlutfall frávika')
+  })
+
+  it('routes to review when the pay gap exceeds the threshold', async () => {
+    arrangeSalary({ total: 20, outliers: 1, gap: 8 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+    expect(verdict.reason).toContain('launamunur')
+  })
+
+  it('uses the absolute gap so a large negative gap still trips the threshold', async () => {
+    arrangeSalary({ total: 20, outliers: 1, gap: -8 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+    expect(verdict.signals.gapPercent).toBe(8)
+  })
+
+  it('routes to review when the gap worsened versus the previous approved report', async () => {
+    arrangeSalary({ total: 20, outliers: 1, gap: 3, previousGap: 2 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.NEEDS_REVIEW)
+    expect(verdict.signals.gapImproved).toBe(false)
+    expect(verdict.reason).toContain('jókst')
+  })
+
+  it('auto-approves when the gap improved versus the previous approved report', async () => {
+    arrangeSalary({ total: 20, outliers: 1, gap: 3, previousGap: 5 })
+
+    const verdict = await service.evaluate(REPORT_ID)
+
+    expect(verdict.decision).toBe(AutoReviewDecisionEnum.AUTO_APPROVE)
+    expect(verdict.signals.gapImproved).toBe(true)
+    expect(verdict.signals.previousGapPercent).toBe(5)
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-auto-review/report-auto-review.service.ts
@@ -1,0 +1,220 @@
+import { Op } from 'sequelize'
+
+import { Inject, Injectable } from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
+
+import {
+  ReportModel,
+  ReportStatusEnum,
+  ReportTypeEnum,
+} from '../report/models/report.model'
+import { AutoReviewDecisionEnum } from '../report/models/report-event.model'
+import { ReportEmployeeModel } from '../report-employee/models/report-employee.model'
+import { ReportEmployeeOutlierModel } from '../report-employee/models/report-employee-outlier.model'
+import { ReportResultModel } from '../report-result/models/report-result.model'
+import {
+  AUTO_REVIEW_LOGGING_CONTEXT,
+  AUTO_REVIEW_THRESHOLDS,
+} from './report-auto-review.constants'
+import {
+  AutoReviewSignals,
+  AutoReviewVerdict,
+  IReportAutoReviewService,
+} from './report-auto-review.service.interface'
+
+const LOGGING_CONTEXT = AUTO_REVIEW_LOGGING_CONTEXT
+
+const fmtPercent = (value: number): string => `${Math.round(value * 10) / 10}%`
+
+@Injectable()
+export class ReportAutoReviewService implements IReportAutoReviewService {
+  constructor(
+    @Inject(LOGGER_PROVIDER) private readonly logger: Logger,
+    @InjectModel(ReportModel)
+    private readonly reportModel: typeof ReportModel,
+    @InjectModel(ReportResultModel)
+    private readonly reportResultModel: typeof ReportResultModel,
+    @InjectModel(ReportEmployeeModel)
+    private readonly reportEmployeeModel: typeof ReportEmployeeModel,
+    @InjectModel(ReportEmployeeOutlierModel)
+    private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
+  ) {}
+
+  async evaluate(reportId: string): Promise<AutoReviewVerdict> {
+    const report = await this.reportModel.findOne({ where: { id: reportId } })
+
+    // Defensive: should never happen — the caller just created the row.
+    if (!report) {
+      this.logger.warn(
+        `Auto-review asked to evaluate missing report ${reportId}`,
+        { context: LOGGING_CONTEXT, reportId },
+      )
+      return this.abstain(
+        ReportTypeEnum.SALARY,
+        'Skýrsla fannst ekki — krefst handvirkrar yfirferðar.',
+      )
+    }
+
+    // EQUALITY reports are narrative — there is nothing quantitative to assess
+    // yet, so the system abstains and routes them to a human.
+    if (report.type !== ReportTypeEnum.SALARY) {
+      return this.abstain(
+        report.type,
+        'Jafnlaunaskýrslur eru ekki metnar sjálfvirkt — krefst handvirkrar yfirferðar.',
+      )
+    }
+
+    const signals = await this.collectSalarySignals(report)
+    return this.decide(signals)
+  }
+
+  /** Gathers the salary-report inputs the decision rule reads. */
+  private async collectSalarySignals(
+    report: ReportModel,
+  ): Promise<AutoReviewSignals> {
+    const totalEmployees = await this.reportEmployeeModel.count({
+      where: { reportId: report.id },
+    })
+
+    const outlierEmployees = await this.reportEmployeeOutlierModel.count({
+      include: [
+        {
+          model: ReportEmployeeModel,
+          as: 'reportEmployee',
+          where: { reportId: report.id },
+          required: true,
+        },
+      ],
+    })
+
+    const gapPercent = await this.readGapPercent(report.id)
+    const previousGapPercent = await this.readPreviousGapPercent(report)
+
+    const outlierRatio =
+      totalEmployees > 0 ? outlierEmployees / totalEmployees : null
+
+    const gapImproved =
+      gapPercent !== null && previousGapPercent !== null
+        ? gapPercent < previousGapPercent
+        : null
+
+    return {
+      reportType: ReportTypeEnum.SALARY,
+      totalEmployees,
+      outlierEmployees,
+      outlierRatio,
+      gapPercent,
+      previousGapPercent,
+      gapImproved,
+    }
+  }
+
+  /**
+   * Absolute male/female base-pay gap percent from the persisted result
+   * snapshot. Absolute because the magnitude of the gap is what matters, not
+   * its direction. Null when no result row exists or the metric is uncomputable
+   * (e.g. a cohort is empty).
+   */
+  private async readGapPercent(reportId: string): Promise<number | null> {
+    const result = await this.reportResultModel.findOne({
+      where: { reportId },
+    })
+    const maleFemale = result?.baseSnapshot?.totals?.salaryDifferences?.maleFemale
+    return maleFemale === null || maleFemale === undefined
+      ? null
+      : Math.abs(maleFemale)
+  }
+
+  /**
+   * The same gap metric on the company's most recent *approved* salary report,
+   * so the rule can ask "did the gap improve since last time?". Matched on the
+   * company national id the report was filed under.
+   */
+  private async readPreviousGapPercent(
+    report: ReportModel,
+  ): Promise<number | null> {
+    const previous = await this.reportModel.findOne({
+      where: {
+        companyNationalId: report.companyNationalId,
+        type: ReportTypeEnum.SALARY,
+        status: ReportStatusEnum.APPROVED,
+        id: { [Op.ne]: report.id },
+      },
+      order: [['approvedAt', 'DESC']],
+    })
+    if (!previous) return null
+    return this.readGapPercent(previous.id)
+  }
+
+  /**
+   * PROVISIONAL decision rule. No outliers → auto-approve. With outliers, the
+   * report still auto-approves only if the outlier share and pay gap are within
+   * the configured bounds and the gap did not worsen versus the last approved
+   * report; otherwise it is routed to manual review with the failing reasons.
+   * Replace this body (not its callers) when the real criteria land.
+   */
+  private decide(signals: AutoReviewSignals): AutoReviewVerdict {
+    const { maxOutlierRatio, maxGapPercent } = AUTO_REVIEW_THRESHOLDS
+
+    if (signals.outlierEmployees === 0) {
+      return {
+        decision: AutoReviewDecisionEnum.AUTO_APPROVE,
+        reason: 'Engin frávik greind — uppfyllir skilyrði sjálfvirkrar samþykktar.',
+        signals,
+      }
+    }
+
+    const failures: string[] = []
+
+    if (signals.outlierRatio !== null && signals.outlierRatio > maxOutlierRatio) {
+      failures.push(
+        `hlutfall frávika ${fmtPercent(signals.outlierRatio * 100)} yfir mörkum (${fmtPercent(maxOutlierRatio * 100)})`,
+      )
+    }
+
+    if (signals.gapPercent !== null && signals.gapPercent > maxGapPercent) {
+      failures.push(
+        `launamunur ${fmtPercent(signals.gapPercent)} yfir mörkum (${fmtPercent(maxGapPercent)})`,
+      )
+    }
+
+    if (signals.gapImproved === false) {
+      failures.push('launamunur jókst frá síðustu samþykktri skýrslu')
+    }
+
+    if (failures.length > 0) {
+      return {
+        decision: AutoReviewDecisionEnum.NEEDS_REVIEW,
+        reason: `Krefst yfirferðar: ${failures.join('; ')}.`,
+        signals,
+      }
+    }
+
+    return {
+      decision: AutoReviewDecisionEnum.AUTO_APPROVE,
+      reason: 'Frávik innan marka — uppfyllir skilyrði sjálfvirkrar samþykktar.',
+      signals,
+    }
+  }
+
+  private abstain(
+    reportType: ReportTypeEnum,
+    reason: string,
+  ): AutoReviewVerdict {
+    return {
+      decision: AutoReviewDecisionEnum.NEEDS_REVIEW,
+      reason,
+      signals: {
+        reportType,
+        totalEmployees: 0,
+        outlierEmployees: 0,
+        outlierRatio: null,
+        gapPercent: null,
+        previousGapPercent: null,
+        gapImproved: null,
+      },
+    }
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.core.module.ts
@@ -6,6 +6,7 @@ import { CompanyReportModel } from '../company/models/company-report.model'
 import { ConfigCoreModule } from '../config/config.core.module'
 import { ReportModel } from '../report/models/report.model'
 import { ReportEventModel } from '../report/models/report-event.model'
+import { ReportAutoReviewCoreModule } from '../report-auto-review/report-auto-review.core.module'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
@@ -37,6 +38,7 @@ import { IReportCreateService } from './report-create.service.interface'
       ReportSubCriterionStepModel,
     ]),
     ReportResultCoreModule,
+    ReportAutoReviewCoreModule,
     ConfigCoreModule,
   ],
   providers: [

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.spec.ts
@@ -21,6 +21,8 @@ import {
 } from '../report/models/report.enums'
 import { ReportModel } from '../report/models/report.model'
 import { ReportEventModel } from '../report/models/report-event.model'
+import { AutoReviewDecisionEnum } from '../report/models/report-event.model'
+import { IReportAutoReviewService } from '../report-auto-review/report-auto-review.service.interface'
 import { ReportCriterionTypeEnum } from '../report-criterion/models/report-criterion.model'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
@@ -71,6 +73,7 @@ describe('ReportCreateService', () => {
   let subCriterionCreate: jest.Mock
   let subCriterionStepBulkCreate: jest.Mock
   let reportResultCreateForReport: jest.Mock
+  let autoReviewEvaluate: jest.Mock
   let configGetByKey: jest.Mock
 
   beforeEach(async () => {
@@ -128,6 +131,11 @@ describe('ReportCreateService', () => {
     reportResultCreateForReport = jest
       .fn()
       .mockResolvedValue({ id: 'result-1' })
+    autoReviewEvaluate = jest.fn().mockResolvedValue({
+      decision: AutoReviewDecisionEnum.AUTO_APPROVE,
+      reason: 'Engin frávik greind.',
+      signals: {},
+    })
     // Default to a generous threshold so existing fixtures (no salary
     // outliers in their parsed payload) don't accidentally flip into
     // outlier-detected territory and fail submit-side guard checks.
@@ -206,6 +214,10 @@ describe('ReportCreateService', () => {
           useValue: { createForReport: reportResultCreateForReport },
         },
         {
+          provide: IReportAutoReviewService,
+          useValue: { evaluate: autoReviewEvaluate },
+        },
+        {
           provide: IConfigService,
           useValue: { getByKey: configGetByKey },
         },
@@ -282,6 +294,19 @@ describe('ReportCreateService', () => {
         eventType: 'SUBMITTED',
         reportStatus: 'SUBMITTED',
         actorUserId: null,
+        companyId: PARENT_COMPANY_ID,
+      }),
+    )
+
+    // Soft auto-review verdict recorded as a system event (no human actor).
+    expect(autoReviewEvaluate).toHaveBeenCalledWith(REPORT_ID)
+    expect(reportEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reportId: REPORT_ID,
+        eventType: 'SYSTEM_AUTO_REVIEW',
+        actorUserId: null,
+        systemDecision: AutoReviewDecisionEnum.AUTO_APPROVE,
+        reason: 'Engin frávik greind.',
         companyId: PARENT_COMPANY_ID,
       }),
     )
@@ -618,6 +643,16 @@ describe('ReportCreateService', () => {
         reportStatus: 'SUBMITTED',
         actorUserId: null,
         companyId: PARENT_COMPANY_ID,
+      }),
+    )
+
+    // EQUALITY reports are still audited — the evaluator abstains internally.
+    expect(autoReviewEvaluate).toHaveBeenCalledWith(REPORT_ID)
+    expect(reportEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reportId: REPORT_ID,
+        eventType: 'SYSTEM_AUTO_REVIEW',
+        actorUserId: null,
       }),
     )
   })

--- a/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-create/report-create.service.ts
@@ -29,9 +29,12 @@ import {
   ReportTypeEnum,
 } from '../report/models/report.model'
 import {
+  AutoReviewDecisionEnum,
   ReportEventModel,
   ReportEventTypeEnum,
 } from '../report/models/report-event.model'
+import { AUTO_REVIEW_ENFORCE } from '../report-auto-review/report-auto-review.constants'
+import { IReportAutoReviewService } from '../report-auto-review/report-auto-review.service.interface'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
@@ -85,6 +88,8 @@ export class ReportCreateService implements IReportCreateService {
     private readonly reportSubCriterionStepModel: typeof ReportSubCriterionStepModel,
     @Inject(IReportResultService)
     private readonly reportResultService: IReportResultService,
+    @Inject(IReportAutoReviewService)
+    private readonly autoReviewService: IReportAutoReviewService,
     @Inject(IConfigService)
     private readonly configService: IConfigService,
   ) {}
@@ -337,7 +342,14 @@ export class ReportCreateService implements IReportCreateService {
       companyId: submittingCompany.companyId,
     })
 
-    // 11. WITHDRAWN audit events — one per predecessor we just retired, each
+    // 11. Soft auto-review — record what the system would decide. Audit only.
+    await this.recordAutoReview(
+      report.id,
+      initialStatus,
+      submittingCompany.companyId,
+    )
+
+    // 12. WITHDRAWN audit events — one per predecessor we just retired, each
     //     linked to the new report that replaced it.
     await this.emitWithdrawnEvents(withdrawnReportIds, report.id)
 
@@ -400,9 +412,58 @@ export class ReportCreateService implements IReportCreateService {
       companyId: submittingCompany.companyId,
     })
 
+    await this.recordAutoReview(
+      report.id,
+      ReportStatusEnum.SUBMITTED,
+      submittingCompany.companyId,
+    )
+
     await this.emitWithdrawnEvents(withdrawnReportIds, report.id)
 
     return { reportId: report.id }
+  }
+
+  /**
+   * Soft auto-review: ask the system what it *would* decide and record the
+   * verdict as a SYSTEM_AUTO_REVIEW event (actorUserId null — no human actor).
+   * The report's status is never changed here. The `AUTO_REVIEW_ENFORCE` branch
+   * is the single seam to flip when the directorate moves from soft audit to
+   * real automation; until then it stays dark.
+   */
+  private async recordAutoReview(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    companyId: string,
+  ): Promise<void> {
+    const verdict = await this.autoReviewService.evaluate(reportId)
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.SYSTEM_AUTO_REVIEW,
+      reportStatus,
+      actorUserId: null,
+      reason: verdict.reason,
+      systemDecision: verdict.decision,
+      companyId,
+    })
+
+    this.logger.info(
+      `Auto-review verdict ${verdict.decision} for report ${reportId}`,
+      { context: LOGGING_CONTEXT, reportId, decision: verdict.decision },
+    )
+
+    if (
+      AUTO_REVIEW_ENFORCE &&
+      verdict.decision === AutoReviewDecisionEnum.AUTO_APPROVE
+    ) {
+      // TODO: enforcement path — transition the report to APPROVED via a
+      // system actor (extract the side-effect core of
+      // ReportWorkflowService.approve so a null-actor path can call it).
+      this.logger.info(
+        `AUTO_REVIEW_ENFORCE on — would auto-approve report ${reportId}`,
+        { context: LOGGING_CONTEXT, reportId },
+      )
+    }
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-event.dto.ts
@@ -8,7 +8,10 @@ import {
 } from '@dmr.is/decorators'
 
 import { ReportStatusEnum } from '../models/report.model'
-import { ReportEventTypeEnum } from '../models/report-event.model'
+import {
+  AutoReviewDecisionEnum,
+  ReportEventTypeEnum,
+} from '../models/report-event.model'
 
 export class ReportEventDto {
   @ApiUUId()
@@ -55,6 +58,12 @@ export class ReportEventDto {
 
   @ApiOptionalUuid({ nullable: true })
   companyId!: string | null
+
+  @ApiOptionalEnum(AutoReviewDecisionEnum, {
+    enumName: 'AutoReviewDecisionEnum',
+    nullable: true,
+  })
+  systemDecision!: AutoReviewDecisionEnum | null
 
   @ApiDateTime()
   createdAt!: Date

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -16,6 +16,19 @@ export enum ReportEventTypeEnum {
   SUPERSEDED = 'SUPERSEDED',
   EDITED = 'EDITED',
   WITHDRAWN = 'WITHDRAWN',
+  SYSTEM_AUTO_REVIEW = 'SYSTEM_AUTO_REVIEW',
+}
+
+/**
+ * The verdict the system reaches on a freshly submitted report. Recorded on a
+ * SYSTEM_AUTO_REVIEW event for audit only — during the soft phase it never
+ * changes the report's status (see ReportAutoReviewService). `system_decision`
+ * is a first-class column so "how often would we have auto-approved?" is a
+ * direct query, not an inference from an overloaded status field.
+ */
+export enum AutoReviewDecisionEnum {
+  AUTO_APPROVE = 'AUTO_APPROVE',
+  NEEDS_REVIEW = 'NEEDS_REVIEW',
 }
 
 type ReportEventAttributes = {
@@ -29,6 +42,7 @@ type ReportEventAttributes = {
   reason: string | null
   relatedReportId: string | null
   companyId: string | null
+  systemDecision: AutoReviewDecisionEnum | null
 }
 
 type ReportEventCreateAttributes = {
@@ -42,6 +56,7 @@ type ReportEventCreateAttributes = {
   reason?: string | null
   relatedReportId?: string | null
   companyId?: string | null
+  systemDecision?: AutoReviewDecisionEnum | null
 }
 
 @ImmutableTable({ tableName: DoeModels.REPORT_EVENT })
@@ -100,6 +115,13 @@ export class ReportEventModel extends ImmutableModel<
   @Column({ type: DataType.UUID, allowNull: true, field: 'company_id' })
   companyId!: string | null
 
+  @Column({
+    type: DataType.ENUM(...Object.values(AutoReviewDecisionEnum)),
+    allowNull: true,
+    field: 'system_decision',
+  })
+  systemDecision!: AutoReviewDecisionEnum | null
+
   @BelongsTo(() => ReportModel, { foreignKey: 'reportId', as: 'report' })
   report?: ReportModel
 
@@ -137,6 +159,7 @@ export class ReportEventModel extends ImmutableModel<
       reason: model.reason,
       relatedReportId: model.relatedReportId,
       companyId: model.companyId,
+      systemDecision: model.systemDecision,
       createdAt: model.createdAt,
     }
   }

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -4712,8 +4712,13 @@
           "STATUS_CHANGED",
           "SUPERSEDED",
           "EDITED",
-          "WITHDRAWN"
+          "WITHDRAWN",
+          "SYSTEM_AUTO_REVIEW"
         ]
+      },
+      "AutoReviewDecisionEnum": {
+        "type": "string",
+        "enum": ["AUTO_APPROVE", "NEEDS_REVIEW"]
       },
       "ReportEventDto": {
         "type": "object",
@@ -4753,6 +4758,10 @@
             "nullable": true
           },
           "companyId": { "type": "string", "format": "uuid", "nullable": true },
+          "systemDecision": {
+            "nullable": true,
+            "allOf": [{ "$ref": "#/components/schemas/AutoReviewDecisionEnum" }]
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time",

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/timeline/timelineHelpers.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/timeline/timelineHelpers.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  AutoReviewDecisionEnum,
   CommentVisibilityEnum,
   ReportEventTypeEnum,
   ReportRoleEnum,
@@ -59,7 +60,20 @@ export function timelineEntryText(
 
   if (!item.event) return null
 
-  const { eventType, actorName, assignedUserName, toStatus } = item.event
+  const { eventType, actorName, assignedUserName, toStatus, systemDecision } =
+    item.event
+
+  if (eventType === ReportEventTypeEnum.SYSTEM_AUTO_REVIEW) {
+    // Soft auto-review verdict — system actor, no name. The `reason` renders as
+    // the entry body; this is just the headline. Status is never changed yet.
+    return (
+      <>
+        {systemDecision === AutoReviewDecisionEnum.AUTO_APPROVE
+          ? reportText.timeline.systemAutoReviewApprove
+          : reportText.timeline.systemAutoReviewNeedsReview}
+      </>
+    )
+  }
 
   if (eventType === ReportEventTypeEnum.SUBMITTED) {
     return companyName ? (

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -238,6 +238,8 @@ export const reportText = {
     reminderTierTwoWeeks: 'Tveggja vikna áminning',
     reminderTierDue: 'Áminning á skiladegi',
     reminderDueDatePrefix: 'skiladagur',
+    systemAutoReviewApprove: 'Kerfið myndi samþykkja skýrsluna sjálfvirkt',
+    systemAutoReviewNeedsReview: 'Kerfið myndi senda skýrsluna í yfirferð',
   },
   salaryStatsLoadError: 'Villa við að hlaða tölfræðigögn fyrir skýrslu',
   salaryStatsLoadErrorMessage:


### PR DESCRIPTION
Adds a **soft auto-review** to the directorate-of-equality report flow. On every
  report submission the system now evaluates whether it *would* auto-approve the
  report and records that verdict as an audit event — **without ever changing the
  report's status**. A human still reviews everything; the system's opinion just
  sits alongside the submission.

  - New `SYSTEM_AUTO_REVIEW` report event (system actor, `actorUserId: null`),
    emitted right after `SUBMITTED` in both the salary and equality create paths.
  - New first-class `system_decision` column on `report_event`
    (`AUTO_APPROVE` / `NEEDS_REVIEW`), plus a human-readable `reason`.
  - New `ReportAutoReviewService` evaluator (isolated module) producing the verdict:
    - **Salary, no outliers** → `AUTO_APPROVE`.
    - **Salary, with outliers** → checks outlier share, male/female pay-gap
      magnitude, and improvement vs the company's last *approved* salary report.
    - **Equality** → abstains (`NEEDS_REVIEW`) — nothing quantitative to assess.
  - Report timeline renders the verdict headline; the `reason` shows as the body.
  - DB migration for the new enum value, decision enum type, and column.

  ## Why

  The directorate wants to move toward auto-approving straightforward reports, but
  the approval criteria aren't finalised. Rather than wait, this ships the decision
  engine in **audit-only mode** so we can observe how the rule behaves on real
  submissions — measuring "how often would we have auto-approved?" directly from
  `system_decision` — before trusting it to act.

  The verdict is a **first-class column**, not an inference from an overloaded
  status field, precisely because that measurement is the point of this phase.

  ## Soft → live

  The thresholds and the entire decision body are **provisional** and isolated in
  one place, so the rule swaps out cleanly once the real formula lands
  (`report-auto-review.constants.ts` + `ReportAutoReviewService.decide`).

  Going from audit to enforcement is gated behind a single constant,
  `AUTO_REVIEW_ENFORCE`. When flipped on, the marked seam in the create flow is
  where a `systemApprove` call goes. It's left as a `TODO` deliberately: real
  approval has side effects (`approved_at` / `valid_until`, superseding the prior
  report) and `approve()` currently hard-requires a reviewer actor, so enabling it
  means extracting approve's core into a null-actor-safe path — out of scope here.

  ## Notes

  - Icelandic copy (verdict reasons + timeline headlines) is provisional.
  - Threshold values (`maxOutlierRatio: 0.1`, `maxGapPercent: 5`) are placeholders.