### PR TITLE
feat(doe): add grouping for outliers

### DIFF
--- a/apps/directorate-of-equality-api/db/seeders/seed-doe-scenarios.js
+++ b/apps/directorate-of-equality-api/db/seeders/seed-doe-scenarios.js
@@ -4,19 +4,19 @@
 const REVIEWER_ID = 'b4e98cee-a4d8-4924-90df-b820c4bc0801'
 
 // Global role UUIDs (shared across all salary reports)
-const ROLE_VERKEFNASTJORI = 'aa000001-0000-0000-0000-000000000001'
-const ROLE_SERFRAEDINGUR = 'aa000002-0000-0000-0000-000000000002'
-const ROLE_ADSTODARMADUR = 'aa000003-0000-0000-0000-000000000003'
+const ROLE_VERKEFNASTJORI = 'aa000001-0000-4000-8000-000000000001'
+const ROLE_SERFRAEDINGUR = 'aa000002-0000-4000-8000-000000000002'
+const ROLE_ADSTODARMADUR = 'aa000003-0000-4000-8000-000000000003'
 
 // Helper: pad a number into a UUID-shaped constant
 const cid = (n) =>
-  `c${String(n).padStart(7, '0')}-0000-0000-0000-${String(n).padStart(12, '0')}`
+  `c${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}`
 const eid = (n) =>
-  `e${String(n).padStart(7, '0')}-0000-0000-0000-${String(n).padStart(12, '0')}` // equality report
+  `e${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}` // equality report
 const sid = (n) =>
-  `b${String(n).padStart(7, '0')}-0000-0000-0000-${String(n).padStart(12, '0')}` // salary report (b = besold)
+  `b${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}` // salary report (b = besold)
 const uid = (n) =>
-  `f${String(n).padStart(7, '0')}-0000-0000-0000-${String(n).padStart(12, '0')}` // generic (f = fill-in)
+  `f${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}` // generic (f = fill-in)
 
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {

--- a/apps/directorate-of-equality-api/db/seeders/seed-doe-three-group-outliers.js
+++ b/apps/directorate-of-equality-api/db/seeders/seed-doe-three-group-outliers.js
@@ -1,12 +1,25 @@
 'use strict'
 
+// Test scenario: a single SALARY report whose detected outliers are split
+// across THREE explained outlier groups, to exercise the per-group tables in
+// the salary report tab (one table per group, group reason/action/signature
+// rendered below each table). Built from the same shared excel + analysis
+// fixtures as seed-doe-rich-scenario.js so the salary tab renders fully
+// (distribution chart, statistics, role results), then the outliers are
+// distributed round-robin across three groups.
+//
+// Additive + self-contained: uses its own company slot (N = 30) and id range
+// (uid 30000+), so `db:seed:all` runs it without touching other seeders. The
+// down() is scoped to this company only.
+
 const fs = require('fs')
 const path = require('path')
 
-// Reviewer from initial seed (matches seed-doe-scenarios.js)
+// Reviewer from initial seed (matches the other DoE seeders).
 const REVIEWER_ID = 'b4e98cee-a4d8-4924-90df-b820c4bc0801'
 
-// UUID helpers (same shape as seed-doe-scenarios.js so id ranges are distinct)
+// UUID helpers — valid v4 shape (version 4, variant 8) so they pass strict
+// UUID validation (zod `z.uuid()`) on the outliers `groupId` query param.
 const cid = (n) =>
   `c${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}`
 const eid = (n) =>
@@ -16,17 +29,18 @@ const sid = (n) =>
 const uid = (n) =>
   `f${String(n).padStart(7, '0')}-0000-4000-8000-${String(n).padStart(12, '0')}`
 
-// New company slot — does not collide with seed-doe-scenarios.js (1–28).
-const RICH_N = 29
-const RICH_CID = cid(RICH_N)
-const RICH_EQ = eid(RICH_N)
-const RICH_SAL = sid(RICH_N)
-const RICH_NATIONAL_ID = '5001010029'
-const RICH_COMPANY_NAME = 'Stóra Prófarasamsteypan hf.'
+// Company slot 30 — distinct from seed-doe-scenarios.js (1–28) and
+// seed-doe-rich-scenario.js (29).
+const N = 30
+const COMPANY_ID = cid(N)
+const EQ_REPORT_ID = eid(N)
+const SAL_REPORT_ID = sid(N)
+const NATIONAL_ID = '5001010030'
+const COMPANY_NAME = 'Þríhópa Prófunarfélagið hf.'
 
-// Auxiliary id counter; all uid() values for this seeder live above 20000
-// so they don't intersect with seed-doe-scenarios.js.
-let nextUid = 20000
+// Auxiliary id counter; all uid() values for this seeder live above 30000 so
+// they don't intersect the other DoE seeders.
+let nextUid = 30000
 const newUid = () => uid(nextUid++)
 
 // SQL string literal helpers ------------------------------------------------
@@ -104,7 +118,7 @@ function companySql() {
   return `
 BEGIN;
 INSERT INTO company (id, name, national_id, employee_count_category, salary_report_required_override)
-VALUES (${escStr(RICH_CID)}, ${escStr(RICH_COMPANY_NAME)}, ${escStr(RICH_NATIONAL_ID)}, 'LARGE', FALSE);
+VALUES (${escStr(COMPANY_ID)}, ${escStr(COMPANY_NAME)}, ${escStr(NATIONAL_ID)}, 'LARGE', FALSE);
 COMMIT;
   `
 }
@@ -122,30 +136,30 @@ INSERT INTO report (id, type, status, company_national_id, company_admin_name, c
   company_admin_gender, contact_name, contact_email, contact_phone,
   provider_type, provider_id, identifier, equality_report_content,
   reviewer_user_id, approved_at, valid_until)
-VALUES (${escStr(RICH_EQ)}, 'EQUALITY', 'APPROVED', ${escStr(RICH_NATIONAL_ID)},
-  'Sigrún Sigrúnardóttir', 'sigrun@storaprofunin.is', 'FEMALE',
-  'Sigrún Sigrúnardóttir', 'sigrun@storaprofunin.is', '999-9999',
-  'ISLAND_IS', 'prov-eq-029', 'JR-2026-029',
-  'Jafnréttisáætlun Stóru Prófarasamsteypunnar 2026–2029. Heildstæð áætlun með gagnsæjum launum og hlutlægum ráðningarferlum.',
+VALUES (${escStr(EQ_REPORT_ID)}, 'EQUALITY', 'APPROVED', ${escStr(NATIONAL_ID)},
+  'Þóra Þórsdóttir', 'thora@thrihopa.is', 'FEMALE',
+  'Þóra Þórsdóttir', 'thora@thrihopa.is', '888-8888',
+  'ISLAND_IS', 'prov-eq-030', 'JR-2026-030',
+  'Jafnréttisáætlun Þríhópa Prófunarfélagsins 2026–2029.',
   ${escStr(REVIEWER_ID)},
   NOW() - INTERVAL '30 days',
   NOW() - INTERVAL '30 days' + INTERVAL '3 years');
 
 INSERT INTO company_report (id, company_id, report_id, parent_company_id,
   name, national_id, address, city, postcode, employee_count_category, isat_category)
-VALUES (${escStr(eqCompanyReportId)}, ${escStr(RICH_CID)}, ${escStr(RICH_EQ)}, NULL,
-  ${escStr(RICH_COMPANY_NAME)}, ${escStr(RICH_NATIONAL_ID)}, 'Borgartún 29', 'Reykjavík', '105', 'LARGE', 'M');
+VALUES (${escStr(eqCompanyReportId)}, ${escStr(COMPANY_ID)}, ${escStr(EQ_REPORT_ID)}, NULL,
+  ${escStr(COMPANY_NAME)}, ${escStr(NATIONAL_ID)}, 'Borgartún 30', 'Reykjavík', '105', 'LARGE', 'M');
 
 INSERT INTO report_event (id, report_id, event_type, actor_user_id, report_status, company_id)
-VALUES (${escStr(evSubmitted)}, ${escStr(RICH_EQ)}, 'SUBMITTED', NULL, 'SUBMITTED', ${escStr(RICH_CID)});
+VALUES (${escStr(evSubmitted)}, ${escStr(EQ_REPORT_ID)}, 'SUBMITTED', NULL, 'SUBMITTED', ${escStr(COMPANY_ID)});
 INSERT INTO report_event (id, report_id, event_type, actor_user_id, report_status,
   from_status, to_status, company_id)
-VALUES (${escStr(evInReview)}, ${escStr(RICH_EQ)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'IN_REVIEW',
-  'SUBMITTED', 'IN_REVIEW', ${escStr(RICH_CID)});
+VALUES (${escStr(evInReview)}, ${escStr(EQ_REPORT_ID)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'IN_REVIEW',
+  'SUBMITTED', 'IN_REVIEW', ${escStr(COMPANY_ID)});
 INSERT INTO report_event (id, report_id, event_type, actor_user_id, report_status,
   from_status, to_status, company_id)
-VALUES (${escStr(evApproved)}, ${escStr(RICH_EQ)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'APPROVED',
-  'IN_REVIEW', 'APPROVED', ${escStr(RICH_CID)});
+VALUES (${escStr(evApproved)}, ${escStr(EQ_REPORT_ID)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'APPROVED',
+  'IN_REVIEW', 'APPROVED', ${escStr(COMPANY_ID)});
 
 COMMIT;
   `
@@ -154,7 +168,6 @@ COMMIT;
 // 3. Salary report row + company_report snapshot ----------------------------
 function salaryReportSql() {
   const salCompanyReportId = newUid()
-  // Average employee counts by gender, derived from the 100-employee sheet.
   let male = 0
   let female = 0
   let neutral = 0
@@ -172,19 +185,19 @@ INSERT INTO report (id, type, status, company_national_id, company_admin_name, c
   provider_type, provider_id, identifier, equality_report_id,
   average_employee_male_count, average_employee_female_count, average_employee_neutral_count,
   imported_from_excel, reviewer_user_id)
-VALUES (${escStr(RICH_SAL)}, 'SALARY', 'IN_REVIEW', ${escStr(RICH_NATIONAL_ID)},
-  'Sigrún Sigrúnardóttir', 'sigrun@storaprofunin.is', 'FEMALE',
-  'Sigrún Sigrúnardóttir', 'sigrun@storaprofunin.is', '999-9999',
-  'ISLAND_IS', 'prov-sal-029', 'LS-2026-029',
-  ${escStr(RICH_EQ)},
+VALUES (${escStr(SAL_REPORT_ID)}, 'SALARY', 'IN_REVIEW', ${escStr(NATIONAL_ID)},
+  'Þóra Þórsdóttir', 'thora@thrihopa.is', 'FEMALE',
+  'Þóra Þórsdóttir', 'thora@thrihopa.is', '888-8888',
+  'ISLAND_IS', 'prov-sal-030', 'LS-2026-030',
+  ${escStr(EQ_REPORT_ID)},
   ${num(male)}, ${num(female)}, ${num(neutral)},
   TRUE,
   ${escStr(REVIEWER_ID)});
 
 INSERT INTO company_report (id, company_id, report_id, parent_company_id,
   name, national_id, address, city, postcode, employee_count_category, isat_category)
-VALUES (${escStr(salCompanyReportId)}, ${escStr(RICH_CID)}, ${escStr(RICH_SAL)}, NULL,
-  ${escStr(RICH_COMPANY_NAME)}, ${escStr(RICH_NATIONAL_ID)}, 'Borgartún 29', 'Reykjavík', '105', 'LARGE', 'M');
+VALUES (${escStr(salCompanyReportId)}, ${escStr(COMPANY_ID)}, ${escStr(SAL_REPORT_ID)}, NULL,
+  ${escStr(COMPANY_NAME)}, ${escStr(NATIONAL_ID)}, 'Borgartún 30', 'Reykjavík', '105', 'LARGE', 'M');
 
 COMMIT;
   `
@@ -195,7 +208,7 @@ function criteriaSql() {
   const critValues = excel.criteria
     .map(
       (c, i) =>
-        `  (${escStr(criterionIds[i])}, ${escStr(RICH_SAL)}, ${escStr(c.title)}, ${num(
+        `  (${escStr(criterionIds[i])}, ${escStr(SAL_REPORT_ID)}, ${escStr(c.title)}, ${num(
           c.weight,
         )}, ${escStr(c.description)}, ${escStr(c.type)})`,
     )
@@ -274,7 +287,6 @@ COMMIT;
 
 // 6. Employees + personal step assignments ----------------------------------
 function employeesSql() {
-  // Scores from analysis.dataPoints (ordered by employee ordinal).
   const scoreByOrdinal = new Map()
   analysis.baseSalaryByGenderAndScoreAll.dataPoints.forEach((dp, i) => {
     scoreByOrdinal.set(i + 1, dp.score)
@@ -293,7 +305,7 @@ function employeesSql() {
           ? 'NULL'
           : num(Number(value).toFixed(2))
       return (
-        `  (${escStr(empId)}, ${escStr(RICH_SAL)}, ${num(e.ordinal)}, ` +
+        `  (${escStr(empId)}, ${escStr(SAL_REPORT_ID)}, ${num(e.ordinal)}, ` +
         `${escStr(e.education)}, ${escStr(e.field)}, ${escStr(e.department)}, ` +
         `${escStr(e.startDate)}, ${num(e.workRatio)}, ` +
         `${num(Number(e.baseSalary).toFixed(2))}, ` +
@@ -362,7 +374,6 @@ function resultSql() {
     employees: analysis.outliers,
   }
 
-  // Per-role aggregates derived from the 100-employee sheet.
   const empsByRole = new Map()
   excel.employees.forEach((e) => {
     if (!empsByRole.has(e.roleTitle)) empsByRole.set(e.roleTitle, [])
@@ -419,7 +430,7 @@ BEGIN;
 
 INSERT INTO report_result (id, report_id, salary_difference_threshold_percent,
   calculation_version, base_snapshot, full_snapshot, outlier_analysis_snapshot)
-VALUES (${escStr(resultId)}, ${escStr(RICH_SAL)}, 1.95, 'v1',
+VALUES (${escStr(resultId)}, ${escStr(SAL_REPORT_ID)}, 1.95, 'v1',
   ${escJson(baseSnapshot)}, ${escJson(fullSnapshot)}, ${escJson(outlierSnapshot)});
 
 INSERT INTO report_role_result (id, report_result_id, report_employee_role_id, role_title, base_snapshot, full_snapshot) VALUES
@@ -429,40 +440,54 @@ COMMIT;
   `
 }
 
-// 8. Outliers (~20 rows, |differencePercent| >= 32) ------------------------
-// The explanation (reason / action / signature) now lives on an outlier
-// group; each outlier is a thin join referencing its group_id. We create two
-// groups: one "explained" (all four fields populated) and one "unexplained"
-// (all four NULL) — both satisfy the group CHECK and exercise both UI branches.
+// 8. Outliers split across THREE explained groups ---------------------------
+// Each outlier is a thin join referencing its group_id. We create three
+// explained groups (all four explanation fields populated) and distribute the
+// flagged outliers round-robin so every group gets a spread of deviations.
 function outliersSql() {
   const filtered = analysis.outliers.filter(
     (o) => Math.abs(o.differencePercent) >= 32,
   )
 
-  // Roughly the first third go in the explained group; the rest unexplained.
-  const explainedCutoff = Math.ceil(filtered.length / 3)
-
-  const explainedGroupId = newUid()
-  const unexplainedGroupId = newUid()
-
-  const groupValues = [
-    `  (${escStr(explainedGroupId)}, ${escStr(RICH_SAL)}, ${escStr(
-      'Útskýrður hópur',
-    )}, ${escStr(
-      'Sérfræðiþekking og reynsla starfsmanns réttlætir frávikið.',
-    )}, ${escStr('Endurmat við næstu launaviðræður.')}, ${escStr(
-      'Sigrún Sigrúnardóttir',
-    )}, ${escStr('Framkvæmdastjóri')})`,
-    `  (${escStr(unexplainedGroupId)}, ${escStr(RICH_SAL)}, ${escStr(
-      'Óútskýrður hópur',
-    )}, NULL, NULL, NULL, NULL)`,
+  const groups = [
+    {
+      id: newUid(),
+      name: 'Stjórnendur',
+      reason: 'Stjórnunarábyrgð og umfang starfs réttlætir hærri grunnlaun.',
+      action: 'Yfirfarið við næstu launaviðræður stjórnenda.',
+      signatureName: 'Þóra Þórsdóttir',
+      signatureRole: 'Framkvæmdastjóri',
+    },
+    {
+      id: newUid(),
+      name: 'Sérfræðingar',
+      reason: 'Eftirsótt sérþekking og markaðsaðstæður á sérfræðisviði.',
+      action: 'Markaðsgreining launa gerð á næsta ársfjórðungi.',
+      signatureName: 'Jón Jónsson',
+      signatureRole: 'Mannauðsstjóri',
+    },
+    {
+      id: newUid(),
+      name: 'Reynslumiklir starfsmenn',
+      reason: 'Löng starfsreynsla og tryggð við fyrirtækið.',
+      action: 'Starfsþróunarsamtöl bókuð fyrir árslok.',
+      signatureName: 'Anna Annadóttir',
+      signatureRole: 'Deildarstjóri',
+    },
   ]
+
+  const groupValues = groups.map(
+    (g) =>
+      `  (${escStr(g.id)}, ${escStr(SAL_REPORT_ID)}, ${escStr(g.name)}, ${escStr(
+        g.reason,
+      )}, ${escStr(g.action)}, ${escStr(g.signatureName)}, ${escStr(g.signatureRole)})`,
+  )
 
   const outlierValues = filtered.map((o, i) => {
     const empId = empIdByOrdinal.get(o.employeeOrdinal)
     if (!empId)
       throw new Error(`Outlier references unknown ordinal ${o.employeeOrdinal}`)
-    const groupId = i < explainedCutoff ? explainedGroupId : unexplainedGroupId
+    const groupId = groups[i % groups.length].id
     return `  (${escStr(newUid())}, ${escStr(empId)}, ${escStr(groupId)})`
   })
 
@@ -483,64 +508,58 @@ COMMIT;
 function eventsSql() {
   const evSubmitted = newUid()
   const evInReview = newUid()
-  const commentId = newUid()
   return `
 BEGIN;
 
 INSERT INTO report_event (id, report_id, event_type, actor_user_id, report_status, company_id)
-VALUES (${escStr(evSubmitted)}, ${escStr(RICH_SAL)}, 'SUBMITTED', NULL, 'SUBMITTED', ${escStr(RICH_CID)});
+VALUES (${escStr(evSubmitted)}, ${escStr(SAL_REPORT_ID)}, 'SUBMITTED', NULL, 'SUBMITTED', ${escStr(COMPANY_ID)});
 
 INSERT INTO report_event (id, report_id, event_type, actor_user_id, report_status,
   from_status, to_status, company_id)
-VALUES (${escStr(evInReview)}, ${escStr(RICH_SAL)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'IN_REVIEW',
-  'SUBMITTED', 'IN_REVIEW', ${escStr(RICH_CID)});
-
-INSERT INTO report_comment (id, report_id, author_kind, author_user_id, visibility, body, report_status)
-VALUES (${escStr(commentId)}, ${escStr(RICH_SAL)}, 'REVIEWER', ${escStr(REVIEWER_ID)}, 'EXTERNAL',
-  'Fjöldi útlaga er hár — vinsamlegast yfirfarið skýringar á efstu launakeppendum og tryggið að rökstuðningur sé fullnægjandi.',
-  'IN_REVIEW');
+VALUES (${escStr(evInReview)}, ${escStr(SAL_REPORT_ID)}, 'STATUS_CHANGED', ${escStr(REVIEWER_ID)}, 'IN_REVIEW',
+  'SUBMITTED', 'IN_REVIEW', ${escStr(COMPANY_ID)});
 
 COMMIT;
   `
 }
 
-// 10. Down: scoped to the rich-scenario company only ------------------------
+// 10. Down: scoped to this scenario's company only --------------------------
 function downSql() {
   return `
 BEGIN;
 
-DELETE FROM report_comment      WHERE report_id IN (${escStr(RICH_SAL)}, ${escStr(RICH_EQ)});
-DELETE FROM report_event        WHERE company_id = ${escStr(RICH_CID)};
+DELETE FROM report_comment      WHERE report_id IN (${escStr(SAL_REPORT_ID)}, ${escStr(EQ_REPORT_ID)});
+DELETE FROM report_event        WHERE company_id = ${escStr(COMPANY_ID)};
 DELETE FROM report_employee_personal_criterion_step
-  WHERE report_employee_id IN (SELECT id FROM report_employee WHERE report_id = ${escStr(RICH_SAL)});
+  WHERE report_employee_id IN (SELECT id FROM report_employee WHERE report_id = ${escStr(SAL_REPORT_ID)});
 DELETE FROM report_employee_outlier
-  WHERE report_employee_id IN (SELECT id FROM report_employee WHERE report_id = ${escStr(RICH_SAL)});
-DELETE FROM report_outlier_group WHERE report_id = ${escStr(RICH_SAL)};
+  WHERE report_employee_id IN (SELECT id FROM report_employee WHERE report_id = ${escStr(SAL_REPORT_ID)});
+DELETE FROM report_outlier_group WHERE report_id = ${escStr(SAL_REPORT_ID)};
 DELETE FROM report_employee_role_criterion_step
   WHERE report_sub_criterion_step_id IN (
     SELECT rscs.id FROM report_sub_criterion_step rscs
     JOIN report_sub_criterion rsc ON rsc.id = rscs.report_sub_criterion_id
     JOIN report_criterion rc ON rc.id = rsc.report_criterion_id
-    WHERE rc.report_id = ${escStr(RICH_SAL)}
+    WHERE rc.report_id = ${escStr(SAL_REPORT_ID)}
   );
-DELETE FROM report_employee     WHERE report_id = ${escStr(RICH_SAL)};
+DELETE FROM report_employee     WHERE report_id = ${escStr(SAL_REPORT_ID)};
 DELETE FROM report_role_result
-  WHERE report_result_id IN (SELECT id FROM report_result WHERE report_id = ${escStr(RICH_SAL)});
+  WHERE report_result_id IN (SELECT id FROM report_result WHERE report_id = ${escStr(SAL_REPORT_ID)});
 DELETE FROM report_employee_role
   WHERE id IN (${[...roleIdByTitle.values()].map((id) => escStr(id)).join(', ')});
-DELETE FROM report_result       WHERE report_id = ${escStr(RICH_SAL)};
+DELETE FROM report_result       WHERE report_id = ${escStr(SAL_REPORT_ID)};
 DELETE FROM report_sub_criterion_step
   WHERE report_sub_criterion_id IN (
     SELECT rsc.id FROM report_sub_criterion rsc
     JOIN report_criterion rc ON rc.id = rsc.report_criterion_id
-    WHERE rc.report_id = ${escStr(RICH_SAL)}
+    WHERE rc.report_id = ${escStr(SAL_REPORT_ID)}
   );
 DELETE FROM report_sub_criterion
-  WHERE report_criterion_id IN (SELECT id FROM report_criterion WHERE report_id = ${escStr(RICH_SAL)});
-DELETE FROM report_criterion    WHERE report_id = ${escStr(RICH_SAL)};
-DELETE FROM company_report      WHERE company_id = ${escStr(RICH_CID)};
-DELETE FROM report              WHERE id IN (${escStr(RICH_SAL)}, ${escStr(RICH_EQ)});
-DELETE FROM company             WHERE id = ${escStr(RICH_CID)};
+  WHERE report_criterion_id IN (SELECT id FROM report_criterion WHERE report_id = ${escStr(SAL_REPORT_ID)});
+DELETE FROM report_criterion    WHERE report_id = ${escStr(SAL_REPORT_ID)};
+DELETE FROM company_report      WHERE company_id = ${escStr(COMPANY_ID)};
+DELETE FROM report              WHERE id IN (${escStr(SAL_REPORT_ID)}, ${escStr(EQ_REPORT_ID)});
+DELETE FROM company             WHERE id = ${escStr(COMPANY_ID)};
 
 COMMIT;
   `

--- a/apps/directorate-of-equality-api/src/modules/report/dto/get-report-outlier-groups-response.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/get-report-outlier-groups-response.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+import { ReportOutlierGroupDto } from '../../report-employee/dto/report-outlier-group.dto'
+
+/**
+ * All outlier groups for a single report. A report with detected outliers
+ * always has at least one group (the implicit "default group" when the
+ * applicant did not split them). Drives the per-group tables in the salary
+ * report's Úrbótaáætlun view.
+ */
+export class GetReportOutlierGroupsResponseDto {
+  @ApiProperty({ type: [ReportOutlierGroupDto] })
+  groups!: ReportOutlierGroupDto[]
+}

--- a/apps/directorate-of-equality-api/src/modules/report/dto/get-report-outliers.query.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/get-report-outliers.query.dto.ts
@@ -1,4 +1,4 @@
-import { ApiOptionalEnum } from '@dmr.is/decorators'
+import { ApiOptionalEnum, ApiOptionalUuid } from '@dmr.is/decorators'
 import { PagingQuery } from '@dmr.is/shared-dto'
 
 import { SortDirectionEnum } from './get-reports.query.dto'
@@ -24,6 +24,12 @@ export enum ReportOutlierSortByEnum {
  * ascending order (matching the FE improvement-plan numbering).
  */
 export class GetReportOutliersQueryDto extends PagingQuery {
+  @ApiOptionalUuid({
+    description:
+      'Restrict the list to the outliers belonging to a single group.',
+  })
+  groupId?: string
+
   @ApiOptionalEnum(ReportOutlierSortByEnum, {
     enumName: 'ReportOutlierSortByEnum',
   })

--- a/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.controller.ts
@@ -16,6 +16,7 @@ import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 import { DoeResponse } from '../../core/decorators/doe-response.decorator'
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
+import { GetReportOutlierGroupsResponseDto } from './dto/get-report-outlier-groups-response.dto'
 import { GetReportOutliersQueryDto } from './dto/get-report-outliers.query.dto'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
@@ -83,5 +84,19 @@ export class ReportController {
     @Query() query: GetReportOutliersQueryDto,
   ): Promise<GetReportOutliersResponseDto> {
     return this.reportService.getOutliers(id, query)
+  }
+
+  @Get(':id/outlier-groups')
+  @DoeResponse({
+    operationId: 'getReportOutlierGroups',
+    type: GetReportOutlierGroupsResponseDto,
+    include404: true,
+    description:
+      "A report's outlier groups (id, name, and the shared reason/action/signature explanation). A report with detected outliers always has at least one group; multiple groups drive the per-group Úrbótaáætlun tables.",
+  })
+  async getOutlierGroups(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<GetReportOutlierGroupsResponseDto> {
+    return this.reportService.getOutlierGroups(id)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.interface.ts
@@ -1,5 +1,6 @@
 import { GetReportOutliersResponseDto } from '../report-employee/dto/get-report-outliers-response.dto'
 import { EqualityReportSummaryDto } from './dto/equality-report-summary.dto'
+import { GetReportOutlierGroupsResponseDto } from './dto/get-report-outlier-groups-response.dto'
 import { GetReportOutliersQueryDto } from './dto/get-report-outliers.query.dto'
 import { GetReportsQueryDto } from './dto/get-reports.query.dto'
 import { GetReportsResponseDto } from './dto/get-reports-response.dto'
@@ -14,6 +15,7 @@ export interface IReportService {
     reportId: string,
     query: GetReportOutliersQueryDto,
   ): Promise<GetReportOutliersResponseDto>
+  getOutlierGroups(reportId: string): Promise<GetReportOutlierGroupsResponseDto>
   getActiveEqualityForCompany(
     companyId: string,
   ): Promise<EqualityReportSummaryDto | null>

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -145,6 +145,11 @@ const makeService = () => {
     findAll: jest.fn().mockResolvedValue([]),
   } as unknown as typeof import('../report-comment/models/report-comment.model').ReportCommentModel
 
+  const outlierGroupFindAll = jest.fn().mockResolvedValue([])
+  const reportOutlierGroupModel = {
+    findAll: outlierGroupFindAll,
+  } as unknown as typeof import('../report-employee/models/report-outlier-group.model').ReportOutlierGroupModel
+
   const service = new ReportService(
     logger,
     reportModel,
@@ -153,6 +158,7 @@ const makeService = () => {
     reportEmployeeOutlierModel,
     companyReportModel,
     reportCommentModel,
+    reportOutlierGroupModel,
   )
   return {
     service,
@@ -164,6 +170,7 @@ const makeService = () => {
     outlierFindAndCountAll,
     outlierCount,
     companyReportFindAll,
+    outlierGroupFindAll,
     logger,
   }
 }
@@ -1046,6 +1053,38 @@ describe('ReportService.getOutliers', () => {
     expect(order[0][1]).toBe('gender')
     expect(order[0][2]).toBe('ASC')
   })
+
+  const captureWhere = async (
+    query: Parameters<ReportService['getOutliers']>[1],
+  ) => {
+    const { service, findByPkOrThrow, outlierFindAndCountAll } = makeService()
+    findByPkOrThrow.mockResolvedValueOnce(
+      makeDetailedSalaryReportRow() as unknown as ReportModel,
+    )
+    outlierFindAndCountAll.mockResolvedValueOnce({ rows: [], count: 0 })
+
+    await service.getOutliers(REPORT_ID, query)
+
+    return outlierFindAndCountAll.mock.calls[0][0].where as
+      | Record<string, unknown>
+      | undefined
+  }
+
+  it('scopes the query to a single group when groupId is given', async () => {
+    const where = await captureWhere({
+      page: 1,
+      pageSize: 10,
+      groupId: 'group-1',
+    })
+
+    expect(where).toEqual({ groupId: 'group-1' })
+  })
+
+  it('omits the group filter when no groupId is given', async () => {
+    const where = await captureWhere({ page: 1, pageSize: 10 })
+
+    expect(where).toBeUndefined()
+  })
 })
 
 describe('ReportService.getActiveEqualityForCompany', () => {
@@ -1128,5 +1167,61 @@ describe('ReportService.getActiveEqualityForCompany', () => {
 
     const callArg = findOne.mock.calls[0][0]
     expect(callArg.where.validUntil).toEqual({ [Op.gt]: expect.any(Date) })
+  })
+})
+
+describe('ReportService.getOutlierGroups', () => {
+  const REPORT_ID = '00000000-0000-0000-0000-000000000001'
+
+  const makeGroupRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    id: 'group-1',
+    reportId: REPORT_ID,
+    name: 'Tenure',
+    reason: 'Tenure premium',
+    action: 'Reviewed',
+    signatureName: 'Reviewer',
+    signatureRole: 'HR',
+    fromModel() {
+      const r = this as unknown as Record<string, unknown>
+      return {
+        id: r.id,
+        reportId: r.reportId,
+        name: r.name,
+        reason: r.reason,
+        action: r.action,
+        signatureName: r.signatureName,
+        signatureRole: r.signatureRole,
+      }
+    },
+    ...overrides,
+  })
+
+  it('returns the report groups ordered by name', async () => {
+    const { service, findByPkOrThrow, outlierGroupFindAll } = makeService()
+    findByPkOrThrow.mockResolvedValueOnce({ id: REPORT_ID } as unknown as ReportModel)
+    outlierGroupFindAll.mockResolvedValueOnce([makeGroupRow()])
+
+    const result = await service.getOutlierGroups(REPORT_ID)
+
+    expect(findByPkOrThrow).toHaveBeenCalledWith(REPORT_ID)
+    expect(outlierGroupFindAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { reportId: REPORT_ID },
+        order: [['name', 'ASC']],
+      }),
+    )
+    expect(result.groups).toEqual([
+      expect.objectContaining({ id: 'group-1', name: 'Tenure', reason: 'Tenure premium' }),
+    ])
+  })
+
+  it('returns an empty list when the report has no groups', async () => {
+    const { service, findByPkOrThrow, outlierGroupFindAll } = makeService()
+    findByPkOrThrow.mockResolvedValueOnce({ id: REPORT_ID } as unknown as ReportModel)
+    outlierGroupFindAll.mockResolvedValueOnce([])
+
+    const result = await service.getOutlierGroups(REPORT_ID)
+
+    expect(result.groups).toEqual([])
   })
 })

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -38,6 +38,7 @@ import { ReportRoleResultModel } from '../report-result/models/report-role-resul
 import { UserModel } from '../user/models/user.model'
 import { EqualityReportDto } from './dto/equality-report.dto'
 import { EqualityReportSummaryDto } from './dto/equality-report-summary.dto'
+import { GetReportOutlierGroupsResponseDto } from './dto/get-report-outlier-groups-response.dto'
 import {
   GetReportOutliersQueryDto,
   ReportOutlierSortByEnum,
@@ -95,6 +96,8 @@ export class ReportService implements IReportService {
     private readonly companyReportModel: typeof CompanyReportModel,
     @InjectModel(ReportCommentModel)
     private readonly reportCommentModel: typeof ReportCommentModel,
+    @InjectModel(ReportOutlierGroupModel)
+    private readonly reportOutlierGroupModel: typeof ReportOutlierGroupModel,
   ) {}
 
   async list(query: GetReportsQueryDto): Promise<GetReportsResponseDto> {
@@ -650,6 +653,10 @@ export class ReportService implements IReportService {
     const { limit, offset } = getLimitAndOffset(query)
 
     const { rows, count } = await this.reportEmployeeOutlierModel.findAndCountAll({
+      // `groupId` is a non-null FK on every outlier row, so this scopes the
+      // page (and `count`) to one group without ever excluding rows; omitted
+      // → all of the report's outliers, preserving the pre-grouping behavior.
+      where: query.groupId ? { groupId: query.groupId } : undefined,
       include: [
         {
           model: ReportEmployeeModel,
@@ -705,6 +712,25 @@ export class ReportService implements IReportService {
     const paging = generatePaging(outliers, query.page, query.pageSize, count)
 
     return { outliers, paging }
+  }
+
+  async getOutlierGroups(
+    reportId: string,
+  ): Promise<GetReportOutlierGroupsResponseDto> {
+    this.logger.debug('Listing report outlier groups', {
+      context: LOGGING_CONTEXT,
+      reportId,
+    })
+
+    // Verify the report exists (throws 404 otherwise) before listing groups.
+    const report = await this.reportModel.findByPkOrThrow(reportId)
+
+    const rows = await this.reportOutlierGroupModel.findAll({
+      where: { reportId: report.id },
+      order: [['name', 'ASC']],
+    })
+
+    return { groups: rows.map((row) => row.fromModel()) }
   }
 
   /**

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -2463,6 +2463,13 @@
             "schema": { "default": 10, "example": 10, "type": "number" }
           },
           {
+            "name": "groupId",
+            "required": false,
+            "in": "query",
+            "description": "Restrict the list to the outliers belonging to a single group.",
+            "schema": { "format": "uuid", "type": "string" }
+          },
+          {
             "name": "sortBy",
             "required": false,
             "in": "query",
@@ -2482,6 +2489,75 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/GetReportOutliersResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Reports"]
+      }
+    },
+    "/api/v1/reports/{id}/outlier-groups": {
+      "get": {
+        "description": "A report's outlier groups (id, name, and the shared reason/action/signature explanation). A report with detected outliers always has at least one group; multiple groups drive the per-group Úrbótaáætlun tables.",
+        "operationId": "getReportOutlierGroups",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetReportOutlierGroupsResponseDto"
                 }
               }
             }
@@ -5140,6 +5216,36 @@
           "paging": { "$ref": "#/components/schemas/Paging" }
         },
         "required": ["outliers", "paging"]
+      },
+      "ReportOutlierGroupDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "reportId": { "type": "string", "format": "uuid" },
+          "name": {
+            "type": "string",
+            "description": "Applicant-supplied label for the group. Non-empty. The implicit single group created when no grouping is provided uses a default name."
+          },
+          "reason": {
+            "type": "string",
+            "nullable": true,
+            "description": "Null only while the parent report is postponed (explanation not yet filled). Otherwise non-empty."
+          },
+          "action": { "type": "string", "nullable": true },
+          "signatureName": { "type": "string", "nullable": true },
+          "signatureRole": { "type": "string", "nullable": true }
+        },
+        "required": ["id", "reportId", "name"]
+      },
+      "GetReportOutlierGroupsResponseDto": {
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ReportOutlierGroupDto" }
+          }
+        },
+        "required": ["groups"]
       },
       "CreateReportCommentDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/ReportTabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 import { useQuery } from '@dmr.is/trpc/client/trpc'
 
@@ -9,10 +9,8 @@ import { Tabs } from '@island.is/island-ui/core'
 import { CommentsContainer } from '../../../containers/report/CommentsContainer'
 import {
   ReportDetailDto,
-  ReportOutlierSortByEnum,
   ReportTypeEnum,
   SalaryByGenderAndScoreDto,
-  SortDirectionEnum,
 } from '../../../gen/fetch'
 import { reportText } from '../../../lib/text'
 import { useTRPC } from '../../../lib/trpc/client/trpc'
@@ -20,15 +18,10 @@ import { CompanyInfoTab } from './company-tab/CompanyInfoTab'
 import { EqualityReportTab } from './equality-tab/EqualityReportTab'
 import { SalaryReportTab } from './salary-tab/SalaryReportTab'
 
-import { keepPreviousData } from '@tanstack/react-query'
-import { type SortingState } from '@tanstack/react-table'
-
 type ReportTabsProps = {
   report: ReportDetailDto
   salaryStats?: SalaryByGenderAndScoreDto
 }
-
-const OUTLIERS_PAGE_SIZE = 10
 
 export function ReportTabs({ report, salaryStats }: ReportTabsProps) {
   const trpc = useTRPC()
@@ -36,37 +29,10 @@ export function ReportTabs({ report, salaryStats }: ReportTabsProps) {
   const [selectedTab, setSelectedTab] = useState(
     isSalary ? 'launagreining' : 'jafnrettisaetlun',
   )
-  const [outliersPage, setOutliersPage] = useState(1)
-  const [outliersSorting, setOutliersSorting] = useState<SortingState>([])
 
-  useEffect(() => {
-    setOutliersPage(1)
-  }, [report.id])
-
-  const outlierSortBy = outliersSorting[0]?.id as
-    | ReportOutlierSortByEnum
-    | undefined
-  const outlierDirection = outliersSorting[0]
-    ? outliersSorting[0].desc
-      ? SortDirectionEnum.DESC
-      : SortDirectionEnum.ASC
-    : undefined
-
-  const handleOutliersSortingChange = (next: SortingState) => {
-    setOutliersSorting(next)
-    setOutliersPage(1)
-  }
-
-  const { data: outliersData, isLoading: outliersLoading } = useQuery({
-    ...trpc.reports.getOutliers.queryOptions({
-      id: report.id,
-      page: outliersPage,
-      pageSize: OUTLIERS_PAGE_SIZE,
-      sortBy: outlierSortBy,
-      direction: outlierDirection,
-    }),
+  const { data: groupsData } = useQuery({
+    ...trpc.reports.getOutlierGroups.queryOptions({ id: report.id }),
     enabled: isSalary && report.includesImprovementPlan,
-    placeholderData: keepPreviousData,
   })
 
   const jafnrettisaetlun = {
@@ -118,15 +84,11 @@ export function ReportTabs({ report, salaryStats }: ReportTabsProps) {
             content: (
               <SalaryReportTab
                 data={salaryStats}
-                outliers={outliersData?.outliers ?? []}
+                reportId={report.id}
+                groups={groupsData?.groups ?? []}
                 outliersPostponed={
                   report.status.match(/postponed/i) ? true : false
                 }
-                outliersPaging={outliersData?.paging}
-                outliersLoading={outliersLoading}
-                onOutliersPageChange={setOutliersPage}
-                outliersSorting={outliersSorting}
-                onOutliersSortingChange={handleOutliersSortingChange}
                 outlierDate={
                   report.correctionDeadline
                     ? new Date(report.correctionDeadline)

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierGroupTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierGroupTable.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react'
+
+import { useQuery } from '@dmr.is/trpc/client/trpc'
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
+import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { Table } from '@dmr.is/ui/components/Tables/Table/Table'
+
+import {
+  type ReportEmployeeOutlierDto,
+  ReportOutlierGroupDto,
+  ReportOutlierSortByEnum,
+  SortDirectionEnum,
+} from '../../../../gen/fetch'
+import { reportText as r, sharedText } from '../../../../lib/text'
+import { useTRPC } from '../../../../lib/trpc/client/trpc'
+import { formatSalary } from '../../../../lib/utils'
+
+import { keepPreviousData } from '@tanstack/react-query'
+import { type ColumnDef, type SortingState } from '@tanstack/react-table'
+
+const dash = '–'
+const s = r.salaryTab
+const o = s.outlierTable
+const OUTLIERS_PAGE_SIZE = 10
+
+const genderMap: Record<string, string> = {
+  MALE: sharedText.genders.male,
+  FEMALE: sharedText.genders.female,
+  NEUTRAL: sharedText.genders.neutral,
+}
+
+// Per-group table: the group column is dropped (every row shares this group).
+const columns: ColumnDef<ReportEmployeeOutlierDto>[] = [
+  {
+    accessorKey: 'employeeOrdinal',
+    header: o.numberHeader,
+    cell: ({ getValue }) => getValue<number | null>() ?? dash,
+    enableSorting: true,
+  },
+  {
+    id: 'roleTitle',
+    header: o.roleHeader,
+    cell: ({ row }) => row.original.roleTitle ?? dash,
+    enableSorting: true,
+  },
+  {
+    id: 'gender',
+    header: o.genderHeader,
+    accessorFn: (row) => (row.gender ? (genderMap[row.gender] ?? '') : ''),
+    cell: ({ row }) =>
+      row.original.gender ? (genderMap[row.original.gender] ?? dash) : dash,
+    enableSorting: true,
+  },
+  {
+    id: 'score',
+    header: o.deviationHeader,
+    accessorFn: (row) => row.score ?? 0,
+    cell: ({ row }) =>
+      row.original.differencePercent == null
+        ? dash
+        : `${row.original.differencePercent.toLocaleString('is-IS')}%`,
+    enableSorting: true,
+  },
+]
+
+// Shared label/value rows (was the expanded-row grid). Used for both the
+// per-employee expanded detail and the group metadata below the table.
+const LabelValueRows = ({
+  rows,
+}: {
+  rows: { label: string; value: string | number | null | undefined }[]
+}) => (
+  <>
+    {rows.map(({ label, value }, index) => (
+      <Box
+        background={index % 2 === 0 ? 'white' : 'blue100'}
+        padding={1}
+        key={label}
+      >
+        <GridRow>
+          <GridColumn span="4/12">
+            <Text variant="small" fontWeight="semiBold">
+              {label}
+            </Text>
+          </GridColumn>
+          <GridColumn>
+            <Text variant="small" textAlign="left">
+              {value ?? dash}
+            </Text>
+          </GridColumn>
+        </GridRow>
+      </Box>
+    ))}
+  </>
+)
+
+// Per-employee detail only — group-level fields now live below the table.
+const ExpandedRow = ({ row }: { row: ReportEmployeeOutlierDto }) => (
+  <Box padding={2} background="blue100">
+    <LabelValueRows
+      rows={[
+        { label: o.points, value: row.score },
+        {
+          label: o.salary,
+          value:
+            row.predictedBaseSalary != null
+              ? `${formatSalary(row.predictedBaseSalary)} kr.`
+              : null,
+        },
+      ]}
+    />
+  </Box>
+)
+
+// Group reason/action/signature shown beneath the table (was in ExpandedRow).
+const GroupMetadata = ({ group }: { group: ReportOutlierGroupDto }) => (
+  <Box marginTop={2}>
+    <LabelValueRows
+      rows={[
+        { label: o.reasonLabel, value: group.reason },
+        { label: o.actionLabel, value: group.action },
+        { label: o.signatureNameLabel, value: group.signatureName },
+        { label: o.signatureRoleLabel, value: group.signatureRole },
+      ]}
+    />
+  </Box>
+)
+
+interface OutlierGroupTableProps {
+  reportId: string
+  group: ReportOutlierGroupDto
+}
+
+export const OutlierGroupTable = ({
+  reportId,
+  group,
+}: OutlierGroupTableProps) => {
+  const trpc = useTRPC()
+  const [page, setPage] = useState(1)
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  useEffect(() => {
+    setPage(1)
+  }, [reportId, group.id])
+
+  const sortBy = sorting[0]?.id as ReportOutlierSortByEnum | undefined
+  const direction = sorting[0]
+    ? sorting[0].desc
+      ? SortDirectionEnum.DESC
+      : SortDirectionEnum.ASC
+    : undefined
+
+  const handleSortingChange = (next: SortingState) => {
+    setSorting(next)
+    setPage(1)
+  }
+
+  const { data, isLoading } = useQuery({
+    ...trpc.reports.getOutliers.queryOptions({
+      id: reportId,
+      groupId: group.id,
+      page,
+      pageSize: OUTLIERS_PAGE_SIZE,
+      sortBy,
+      direction,
+    }),
+    placeholderData: keepPreviousData,
+  })
+
+  return (
+    <Box marginBottom={4}>
+      <Text variant="h5" marginBottom={2}>
+        {group.name}
+      </Text>
+      <Table
+        columns={columns}
+        data={data?.outliers ?? []}
+        getRowExpanded={(row) => <ExpandedRow row={row} />}
+        paging={data?.paging}
+        loading={isLoading}
+        onPageChange={setPage}
+        showPageSizeSelect={false}
+        noDataMessage={s.noDataMessage}
+        sorting={sorting}
+        onSortingChange={handleSortingChange}
+      />
+      <GroupMetadata group={group} />
+    </Box>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/OutlierPlanTable.tsx
@@ -1,128 +1,25 @@
 import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
-import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
-import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
-import { Table } from '@dmr.is/ui/components/Tables/Table/Table'
 
-import {
-  type Paging,
-  type ReportEmployeeOutlierDto,
-} from '../../../../gen/fetch'
-import { reportText as r, reportText, sharedText } from '../../../../lib/text'
-import { formatSalary } from '../../../../lib/utils'
+import { type ReportOutlierGroupDto } from '../../../../gen/fetch'
+import { reportText } from '../../../../lib/text'
+import { OutlierGroupTable } from './OutlierGroupTable'
 import { OutlierInputForm } from './OutlierInputForm'
 
-import { type ColumnDef, type SortingState } from '@tanstack/react-table'
-
 interface OutlierPlanTableProps {
-  outliers: ReportEmployeeOutlierDto[]
-  paging?: Paging
-  loading?: boolean
-  onPageChange?: (page: number) => void
-  sorting?: SortingState
-  onSortingChange?: (sorting: SortingState) => void
+  reportId: string
+  groups: ReportOutlierGroupDto[]
   outliersPostponed?: boolean
   outlierDate?: Date
 }
 
-const dash = '–'
-
-const s = r.salaryTab
-const o = s.outlierTable
-
-const genderMap: Record<string, string> = {
-  MALE: sharedText.genders.male,
-  FEMALE: sharedText.genders.female,
-  NEUTRAL: sharedText.genders.neutral,
-}
-const columns: ColumnDef<ReportEmployeeOutlierDto>[] = [
-  {
-    accessorKey: 'employeeOrdinal',
-    header: o.numberHeader,
-    cell: ({ getValue }) => getValue<number | null>() ?? dash,
-    enableSorting: true,
-  },
-  {
-    id: 'roleTitle',
-    header: o.roleHeader,
-    cell: ({ row }) => row.original.roleTitle ?? dash,
-    enableSorting: true,
-  },
-  {
-    id: 'groupName',
-    header: o.groupHeader,
-    cell: ({ row }) => row.original.groupName ?? dash,
-    enableSorting: false,
-  },
-  {
-    id: 'gender',
-    header: o.genderHeader,
-    accessorFn: (row) => (row.gender ? (genderMap[row.gender] ?? '') : ''),
-    cell: ({ row }) =>
-      row.original.gender ? (genderMap[row.original.gender] ?? dash) : dash,
-    enableSorting: true,
-  },
-  {
-    id: 'score',
-    header: o.deviationHeader,
-    accessorFn: (row) => row.score ?? 0,
-    cell: ({ row }) =>
-      row.original.differencePercent == null
-        ? dash
-        : `${row.original.differencePercent.toLocaleString('is-IS')}%`,
-    enableSorting: true,
-  },
-]
-
-const ExpandedRow = ({ row }: { row: ReportEmployeeOutlierDto }) => (
-  <Box padding={2} background="blue100">
-    {[
-      { label: o.points, value: row.score },
-      {
-        label: o.salary,
-        value:
-          row.predictedBaseSalary != null
-            ? `${formatSalary(row.predictedBaseSalary)} kr.`
-            : null,
-      },
-      { label: o.groupLabel, value: row.groupName },
-      { label: o.reasonLabel, value: row.reason },
-      { label: o.actionLabel, value: row.action },
-      { label: o.signatureNameLabel, value: row.signatureName },
-      { label: o.signatureRoleLabel, value: row.signatureRole },
-    ].map(({ label, value }, index) => (
-      <Box
-        background={index % 2 === 0 ? 'white' : 'blue100'}
-        padding={1}
-        key={label}
-      >
-        <GridRow key={label}>
-          <GridColumn span="4/12">
-            <Text variant="small" fontWeight="semiBold">
-              {label}
-            </Text>
-          </GridColumn>
-
-          <GridColumn>
-            <Text variant="small" textAlign="left">
-              {value ?? dash}
-            </Text>
-          </GridColumn>
-        </GridRow>
-      </Box>
-    ))}
-  </Box>
-)
+const o = reportText.salaryTab.outlierTable
 
 export const OutlierPlanTable = ({
-  outliers,
-  paging,
-  loading,
-  onPageChange,
-  sorting,
-  onSortingChange,
+  reportId,
+  groups,
   outliersPostponed,
   outlierDate,
 }: OutlierPlanTableProps) => {
@@ -139,23 +36,13 @@ export const OutlierPlanTable = ({
               title={reportText.salaryTab.outliersPostponedTitle}
               message={reportText.salaryTab.outliersPostponedMessage}
             />
-
             <OutlierInputForm outlierDate={outlierDate} />
           </Stack>
         </Box>
       )}
-      <Table
-        columns={columns}
-        data={outliers}
-        getRowExpanded={(row) => <ExpandedRow row={row} />}
-        paging={paging}
-        loading={loading}
-        onPageChange={onPageChange}
-        showPageSizeSelect={false}
-        noDataMessage={s.noDataMessage}
-        sorting={sorting}
-        onSortingChange={onSortingChange}
-      />
+      {groups.map((group) => (
+        <OutlierGroupTable key={group.id} reportId={reportId} group={group} />
+      ))}
     </>
   )
 }

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryReportTab.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryReportTab.tsx
@@ -3,8 +3,7 @@ import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Stack } from '@island.is/island-ui/core'
 
 import {
-  Paging,
-  ReportEmployeeOutlierDto,
+  ReportOutlierGroupDto,
   SalaryByGenderAndScoreDto,
 } from '../../../../gen/fetch'
 import { reportText } from '../../../../lib/text'
@@ -14,29 +13,19 @@ import { OutlierPlanTable } from './OutlierPlanTable'
 import { SalaryDistributionChart } from './SalaryDistributionChart'
 import { SalaryStatistics } from './SalaryStatistics'
 
-import { type SortingState } from '@tanstack/react-table'
-
 interface SalaryReportTabProps {
   data: SalaryByGenderAndScoreDto
-  outliers: ReportEmployeeOutlierDto[]
-  outliersPaging?: Paging
-  outliersLoading?: boolean
-  onOutliersPageChange: (page: number) => void
-  outliersSorting?: SortingState
-  onOutliersSortingChange?: (sorting: SortingState) => void
+  reportId: string
+  groups: ReportOutlierGroupDto[]
   outlierDate?: Date
   outliersPostponed?: boolean
 }
 
 export const SalaryReportTab = ({
   data,
-  outliers,
+  reportId,
+  groups,
   outliersPostponed,
-  outliersPaging,
-  outliersLoading,
-  onOutliersPageChange,
-  outliersSorting,
-  onOutliersSortingChange,
   outlierDate,
 }: SalaryReportTabProps) => {
   if (!data) {
@@ -56,17 +45,13 @@ export const SalaryReportTab = ({
         femaleAverageSalary={formatSalary(data.totals.femaleAverageSalary)}
         wageGapPercent={data.totals.wageGapPercent?.toString() ?? '0'}
       />
-      {outliers.length > 0 && (
+      {groups.length > 0 && (
         <Box marginBottom={4}>
           <OutlierPlanTable
-            outliers={outliers}
-            paging={outliersPaging}
-            loading={outliersLoading}
+            reportId={reportId}
+            groups={groups}
             outliersPostponed={outliersPostponed}
             outlierDate={outlierDate}
-            onPageChange={onOutliersPageChange}
-            sorting={outliersSorting}
-            onSortingChange={onOutliersSortingChange}
           />
         </Box>
       )}

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportsRouter.ts
@@ -1,5 +1,6 @@
 import {
   zGetReportByIdPath,
+  zGetReportOutlierGroupsPath,
   zGetReportOutliersPath,
   zGetReportOutliersQuery,
   zListReportsQuery,
@@ -26,12 +27,20 @@ export const reportsRouter = router({
   getOutliers: protectedProcedure
     .input(zGetReportOutliersPath.merge(zGetReportOutliersQuery))
     .query(({ ctx, input }) => {
-      const { id, page, pageSize, sortBy, direction } = input
+      const { id, page, pageSize, sortBy, direction, groupId } = input
       return ctx.api.getReportOutliers({
         path: { id },
-        query: { page, pageSize, sortBy, direction },
+        query: { page, pageSize, sortBy, direction, groupId },
       })
     }),
+
+  getOutlierGroups: protectedProcedure
+    .input(zGetReportOutlierGroupsPath)
+    .query(({ ctx, input }) =>
+      ctx.api.getReportOutlierGroups({
+        path: { id: input.id },
+      }),
+    ),
 
   overview: protectedProcedure.query(({ ctx }) => ctx.api.getReportOverview()),
 


### PR DESCRIPTION
## What
The salary report's "Úrbótaáætlun" (improvement plan) section previously rendered all detected outliers in a single table, repeating each group's shared explanation inside every expanded row. Outliers actually belong to outlier groups (a report always has ≥1; an applicant who doesn't split them gets a single "default group"). This PR renders one table per group so reviewers can read each group's plan as a unit.

## How

- One table per group — a report with N groups shows N tables; one group → one table (single unified code path, no special-casing).
- Each table paginates and sorts independently, server-side, scoped to its own group.
- Each group's reason, action, signature name, and signature role render below that group's table (previously crammed into every expanded row).
- The expandable row now keeps only per-employee detail (points/score, predicted salary).
- Postponed reports still show the warning + input form once, above the tables; not-yet-filled fields show –.

## Changes

### Backend (directorate-of-equality-api)

- GET /reports/:id/outliers gains an optional groupId filter (getOutliers scopes rows + count to one group).
- New GET /reports/:id/outlier-groups endpoint + getOutlierGroups service method, returning each group's metadata.
- New GetReportOutlierGroupsResponseDto; reuses existing ReportOutlierGroupDto.
- Unit tests for the groupId filter and the new endpoint (393 passing).

### Frontend (directorate-of-equality-web)

- tRPC: new getOutlierGroups procedure + groupId passthrough on getOutliers.
- Regenerated client (clientConfig.json / gen/fetch).
- New self-fetching OutlierGroupTable (own page/sort state, group metadata below, group column dropped); OutlierPlanTable becomes a thin container; SalaryReportTab/ReportTabs rewired to fetch groups (section gated on groups.length > 0).

### Seeders

- Fixed id helpers + role constants to emit valid v4-shaped UUIDs (-0000-4000-8000-). The previous non-RFC UUIDs passed the backend's lenient validation but are rejected by the regenerated client's strict z.uuid() on the new groupId param. Real DB UUIDs (uuid_generate_v4()) were unaffected — this was seed-data only.
- New seed-doe-three-group-outliers.js: a SALARY/IN_REVIEW report (LS-2026-030) with 22 outliers across 3 explained groups (8/7/7) to exercise the per-group UI.