### PR TITLE
feat(doe): gender building + salary chart tolerance

### DIFF
--- a/apps/directorate-of-equality-api/db/README.md
+++ b/apps/directorate-of-equality-api/db/README.md
@@ -313,13 +313,25 @@ The final `score` on `report_employee` is derived from the steps that apply to t
 
 `report_result` holds immutable report-level salary snapshots for both **adjusted base salary** (`baseSalary / workRatio`) and **adjusted full salary** (`(baseSalary + additionalSalary + bonusSalary) / workRatio`, where `additionalSalary` / `bonusSalary` are the derived sums of their sub-component columns — see `report_employee`). The snapshots are stored as JSONB because the service reads results by `report_id` rather than querying individual metrics in SQL. Each salary family stores report-level totals and score-bucket breakdowns. The same row also snapshots the salary-outlier regression analysis: the fitted base-salary regression lines (gender-blind `regressions.overall`, plus per-cohort `regressions.male/female/neutral` for visualisation), the configured threshold, and each employee's adjusted base salary vs predicted base salary at their exact score. `report_role_result` is kept as the reserved home for a future role-level breakdown and snapshots the role title used at calculation time. Both tables are write-once at submission — computed in the same transaction that persists the report, so reviewers can read the aggregates as soon as they pick the report up. They are not edited by humans, and the approval transition does not recompute them. (Contrast with `public_report`, which is published only on the `APPROVED` transition.)
 
+### Gender bundling: NEUTRAL counts as FEMALE (M vs F+N)
+
+The current product goal is to measure the pay gap between men and women, expressed as **MALE vs FEMALE+NEUTRAL**. So for every aggregation, count, gender-split regression and chart series, `NEUTRAL` employees are **bundled into the `FEMALE` group**. Concretely:
+
+- `totals.female` / bucket `female` averages, medians and counts **include** neutral employees; `maleFemale` is therefore the gap of male vs (female + neutral).
+- The standalone `neutral` cohort (metrics, counts, `regressions.neutral`) is consequently **always empty** in computed output — `null` metrics, `0` counts.
+- The gender-blind `regressions.overall` and the outlier flag are unaffected: they already include every employee regardless of gender, and neutral employees are still flagged like anyone else.
+- On the chart (admin web + PDF) neutral scatter points render in the purple "Kona" (female) series.
+
+This is a **reclassification at computation/display time only** — raw `report_employee.gender` keeps the real `NEUTRAL` value, so the data is preserved for a future standalone neutral category. The rule is centralised in `bundleNeutralIntoFemale()` (`report/lib/compensation-aggregates.ts`) so it is easy to reverse. Decision date: 2026-06.
+
 ### Reconstructing the gender-vs-score chart from a stored result
 
 The same chart shape that `buildChartFromEmployeePoints` produces for the application-side preview can be rebuilt from a persisted `report_result` row:
 
 - **Scatter points** — `outlier_analysis_snapshot.employees[*]` carries `score`, `gender`, and `adjustedBaseSalary` per employee.
-- **Regression line(s)** — `outlier_analysis_snapshot.regressions.overall` is the gender-blind line that drives the outlier flag. `regressions.male/female/neutral` are per-cohort lines available for visualisation only.
+- **Regression line(s)** — `outlier_analysis_snapshot.regressions.overall` is the gender-blind line that drives the outlier flag. `regressions.male/female` are per-cohort lines available for visualisation only; `female` includes neutral and `regressions.neutral` is empty (see "Gender bundling" above).
 - **Score-bucket overlay** — the per-employee `scoreBucketRangeFrom/To` is preserved on each row, but the bucket-level aggregates (median, average, gender breakdowns, counts) live in `base_snapshot.scoreBuckets`. Render the chart by joining on the bucket range when an overlay is needed.
+- **Tolerance band** — the chart shades a wedge of `predicted × (1 ± allowedDifferencePercent / 100)` around the regression line; a point outside it is an outlier. The live base-salary chart endpoint returns `allowedDifferencePercent` directly on `SalaryByGenderAndScoreDto`; from a stored result it is `outlier_analysis_snapshot.allowedDifferencePercent` (half the threshold). Outlier dots are highlighted on the chart (computed from the same rule), so the scatter matches the outlier table.
 
 Bucket placement is informational only: the outlier flag is decided against the regression prediction at the employee's exact score, not the bucket median.
 
@@ -622,12 +634,12 @@ Aggregated per-report salary stats. Stored as an immutable calculation snapshot.
 `base_snapshot` and `full_snapshot` share the same shape:
 
 - `totals`
-  - `overall`, `male`, `female`, `neutral` — each contains `average`, `median`, `minimum`, `maximum`.
-  - `salaryDifferences` — contains `maleFemale`, `maleNeutral`, `femaleMale`, `femaleNeutral`, `neutralMale`, `neutralFemale`.
+  - `overall`, `male`, `female`, `neutral` — each contains `average`, `median`, `minimum`, `maximum`. Note: `neutral` is bundled into `female` and is therefore always empty — see "Gender bundling" under Results aggregation.
+  - `salaryDifferences` — contains `maleFemale`, `maleNeutral`, `femaleMale`, `femaleNeutral`, `neutralMale`, `neutralFemale`. Only the male/female pairs are populated; the neutral pairs are always `null`.
 - `scoreBuckets[]`
   - `rangeFrom`, `rangeTo`
   - `totals` with the same aggregate shape as above
-  - `counts` for `overall`, `male`, `female`, `neutral`
+  - `counts` for `overall`, `male`, `female`, `neutral` (`neutral` always `0`)
 
 `outlier_analysis_snapshot` stores:
 

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -27,6 +27,7 @@ import {
   type DetectedOutlier,
   detectOutliers,
   type OutlierDetectionEmployee,
+  resolveAllowedDifferencePercent,
 } from '../report/lib/compensation-aggregates'
 import {
   assertParsedPayloadIntegrity,
@@ -178,8 +179,10 @@ export class ApplicationService implements IApplicationService {
         gender: employee.gender,
       }),
     )
-    const baseSalaryByGenderAndScoreAll =
-      buildChartFromEmployeePoints(chartPoints)
+    const baseSalaryByGenderAndScoreAll = buildChartFromEmployeePoints(
+      chartPoints,
+      resolveAllowedDifferencePercent(thresholdPercent),
+    )
 
     return {
       outliers: detected.map(toOutlierDto),

--- a/apps/directorate-of-equality-api/src/modules/report-pdf/lib/salary-chart-svg.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-pdf/lib/salary-chart-svg.ts
@@ -6,13 +6,12 @@ import {
 
 /**
  * Colors mirror the admin `SalaryDistributionChart` (island-ui theme):
- * blue400 male points, purple400 female points, yellow400 neutral points and
- * the roseTinted400 regression ("Meðallaun") line.
+ * blue400 male points, purple400 female points (NEUTRAL is bundled into the
+ * female series, M vs F+N) and the roseTinted400 regression line.
  */
 const COLORS = {
   male: '#0061ff',
   female: '#6a2ea0',
-  neutral: '#fff066',
   regression: '#9a0074',
   grid: '#ccdfff',
   axis: '#00003c',
@@ -33,9 +32,8 @@ function formatSalary(value: number): string {
 }
 
 function pointColor(gender: GenderEnum): string {
-  if (gender === GenderEnum.MALE) return COLORS.male
-  if (gender === GenderEnum.FEMALE) return COLORS.female
-  return COLORS.neutral
+  // NEUTRAL is bundled into the female series (M vs F+N).
+  return gender === GenderEnum.MALE ? COLORS.male : COLORS.female
 }
 
 /**
@@ -108,7 +106,7 @@ export function buildSalaryChartSvg(
       <circle cx="${MARGIN.left + 90}" cy="${legendY - 4}" r="5" fill="${COLORS.female}" />
       <text x="${MARGIN.left + 102}" y="${legendY}">Kona</text>
       <line x1="${MARGIN.left + 180}" y1="${legendY - 4}" x2="${MARGIN.left + 210}" y2="${legendY - 4}" stroke="${COLORS.regression}" stroke-width="2.5" />
-      <text x="${MARGIN.left + 218}" y="${legendY}">Meðallaun</text>
+      <text x="${MARGIN.left + 218}" y="${legendY}">Áætluð laun eftir stigum</text>
     </g>`
 
   return `

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/dto/salary-by-gender-and-score.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/dto/salary-by-gender-and-score.dto.ts
@@ -103,4 +103,13 @@ export class SalaryByGenderAndScoreDto {
 
   @ApiDto(SalaryTotalsDto)
   totals!: SalaryTotalsDto
+
+  /**
+   * Half the configured salary-difference threshold (e.g. 1.95 for a 3.9%
+   * threshold) — the allowed +/- band around the regression prediction that
+   * defines an outlier. Only populated for the base-salary-by-total-score
+   * chart, where the outlier rule applies; `null` for the other charts.
+   */
+  @ApiOptionalNumber({ nullable: true })
+  allowedDifferencePercent!: number | null
 }

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/lib/build-chart.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/lib/build-chart.ts
@@ -1,4 +1,5 @@
 import {
+  bundleNeutralIntoFemale,
   computeSalaryAggregateSnapshot,
   computeSalaryRegression,
   computeSalaryScoreBucketSnapshots,
@@ -30,6 +31,7 @@ export interface EmployeeDataPoint {
  */
 export function buildChartFromEmployeePoints(
   points: EmployeeDataPoint[],
+  allowedDifferencePercent: number | null = null,
 ): SalaryByGenderAndScoreDto {
   const dataPoints: ScatterDataPointDto[] = points.map((p) => ({
     score: p.score,
@@ -42,6 +44,7 @@ export function buildChartFromEmployeePoints(
     regressionLine: computeLinearRegression(points),
     scoreBuckets: computeScoreBuckets(points),
     totals: computeTotals(points),
+    allowedDifferencePercent,
   }
 }
 
@@ -102,8 +105,13 @@ function computeScoreBuckets(points: EmployeeDataPoint[]): ScoreBucketDto[] {
 }
 
 function computeTotals(points: EmployeeDataPoint[]): SalaryTotalsDto {
-  const males = points.filter((point) => point.gender === GenderEnum.MALE)
-  const females = points.filter((point) => point.gender === GenderEnum.FEMALE)
+  const males = points.filter(
+    (point) => bundleNeutralIntoFemale(point.gender) === GenderEnum.MALE,
+  )
+  // NEUTRAL is bundled with FEMALE (M vs F+N).
+  const females = points.filter(
+    (point) => bundleNeutralIntoFemale(point.gender) === GenderEnum.FEMALE,
+  )
   const snapshot = computeSalaryAggregateSnapshot(
     points.map((point) => ({
       gender: point.gender,

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.core.module.ts
@@ -3,6 +3,7 @@ import { SequelizeModule } from '@nestjs/sequelize'
 
 import { AdminGuard } from '../../core/guards/admin/admin.guard'
 import { AuthorizationCoreModule } from '../authorization/authorization.core.module'
+import { ConfigModel } from '../config/models/config.model'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
 import { ReportSubCriterionStepModel } from '../report-criterion/models/report-sub-criterion-step.model'
@@ -22,6 +23,7 @@ import { IReportStatisticsService } from './report-statistics.service.interface'
       ReportSubCriterionStepModel,
       ReportEmployeeRoleCriterionStepModel,
       ReportEmployeePersonalCriterionStepModel,
+      ConfigModel,
     ]),
   ],
   providers: [

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.spec.ts
@@ -4,6 +4,7 @@ import { Test } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { ConfigModel } from '../config/models/config.model'
 import { GenderEnum } from '../report/models/report.model'
 import { ReportCriterionModel } from '../report-criterion/models/report-criterion.model'
 import { ReportSubCriterionModel } from '../report-criterion/models/report-sub-criterion.model'
@@ -87,6 +88,7 @@ describe('ReportStatisticsService', () => {
   let stepFindAll: jest.Mock
   let roleStepFindAll: jest.Mock
   let personalStepFindAll: jest.Mock
+  let configFindOne: jest.Mock
 
   beforeEach(async () => {
     employeeFindAll = jest.fn()
@@ -95,6 +97,7 @@ describe('ReportStatisticsService', () => {
     stepFindAll = jest.fn().mockResolvedValue([])
     roleStepFindAll = jest.fn().mockResolvedValue([])
     personalStepFindAll = jest.fn().mockResolvedValue([])
+    configFindOne = jest.fn().mockResolvedValue({ value: '3.9' })
 
     const module = await Test.createTestingModule({
       providers: [
@@ -124,6 +127,10 @@ describe('ReportStatisticsService', () => {
           provide: getModelToken(ReportEmployeePersonalCriterionStepModel),
           useValue: { findAll: personalStepFindAll },
         },
+        {
+          provide: getModelToken(ConfigModel),
+          useValue: { findOne: configFindOne },
+        },
       ],
     }).compile()
 
@@ -139,6 +146,17 @@ describe('ReportStatisticsService', () => {
       await expect(
         service.getBaseSalaryByGenderAndScoreAll(REPORT_ID),
       ).rejects.toThrow(NotFoundException)
+    })
+
+    it('carries the allowed +/- band as half the configured threshold', async () => {
+      // config threshold 3.9% → allowed band 1.95%
+      employeeFindAll.mockResolvedValue([
+        makeEmployee(300, 1000000, 1, GenderEnum.MALE),
+      ])
+
+      const result = await service.getBaseSalaryByGenderAndScoreAll(REPORT_ID)
+
+      expect(result.allowedDifferencePercent).toBe(1.95)
     })
 
     it('computes adjusted base salary as baseSalary / workRatio', async () => {
@@ -476,6 +494,8 @@ describe('ReportStatisticsService', () => {
 
       expect(result.dataPoints).toHaveLength(1)
       expect(result.dataPoints[0].adjustedSalary).toBe(1250000)
+      // The outlier band only applies to the base-salary-by-total-score chart.
+      expect(result.allowedDifferencePercent).toBeNull()
     })
 
     it('treats null bonusSalary as zero', async () => {

--- a/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-statistics/report-statistics.service.ts
@@ -1,15 +1,23 @@
 import { Op } from 'sequelize'
 
-import { Inject, Injectable, NotFoundException } from '@nestjs/common'
+import {
+  Inject,
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { ConfigModel } from '../config/models/config.model'
 import {
+  bundleNeutralIntoFemale,
   computeSalaryAggregateSnapshot,
   computeWageGapPercent,
   getAdjustedBaseSalary,
   getAdjustedFullSalary,
+  resolveAllowedDifferencePercent,
   roundNullable,
 } from '../report/lib/compensation-aggregates'
 import { GenderEnum } from '../report/models/report.model'
@@ -52,6 +60,8 @@ export class ReportStatisticsService implements IReportStatisticsService {
     private readonly roleStepModel: typeof ReportEmployeeRoleCriterionStepModel,
     @InjectModel(ReportEmployeePersonalCriterionStepModel)
     private readonly personalStepModel: typeof ReportEmployeePersonalCriterionStepModel,
+    @InjectModel(ConfigModel)
+    private readonly configModel: typeof ConfigModel,
   ) {}
 
   async getBaseSalaryByGenderAndScoreAll(
@@ -70,7 +80,14 @@ export class ReportStatisticsService implements IReportStatisticsService {
       gender: e.gender,
     }))
 
-    return buildChartFromEmployeePoints(points)
+    // Base salary by total score is the chart the outlier rule applies to, so
+    // it carries the allowed +/- band (half the configured threshold) for the
+    // tolerance overlay on the chart.
+    const allowedDifferencePercent = resolveAllowedDifferencePercent(
+      await this.getSalaryDifferenceThresholdPercent(),
+    )
+
+    return buildChartFromEmployeePoints(points, allowedDifferencePercent)
   }
 
   async getBaseSalaryByGenderAndScoreWork(
@@ -180,8 +197,13 @@ export class ReportStatisticsService implements IReportStatisticsService {
       gender: e.gender,
     }))
 
-    const males = rows.filter((r) => r.gender === GenderEnum.MALE)
-    const females = rows.filter((r) => r.gender === GenderEnum.FEMALE)
+    const males = rows.filter(
+      (r) => bundleNeutralIntoFemale(r.gender) === GenderEnum.MALE,
+    )
+    // NEUTRAL is bundled with FEMALE (M vs F+N).
+    const females = rows.filter(
+      (r) => bundleNeutralIntoFemale(r.gender) === GenderEnum.FEMALE,
+    )
 
     const build = (group: typeof rows): GenderBenefitsDto => {
       const bonuses = group.map((r) => r.bonus)
@@ -224,13 +246,31 @@ export class ReportStatisticsService implements IReportStatisticsService {
 
   // ── Private helpers ─────────────────────────────────────────────
 
+  private async getSalaryDifferenceThresholdPercent(): Promise<number> {
+    const config = await this.configModel.findOne({
+      where: { key: 'salary_difference_threshold_percent', supersededAt: null },
+    })
+
+    const parsed = config ? parseFloat(config.value) : NaN
+
+    if (!Number.isFinite(parsed)) {
+      throw new InternalServerErrorException(
+        'Config entry "salary_difference_threshold_percent" must be numeric',
+      )
+    }
+
+    return parsed
+  }
+
   private async fetchEmployees(
     reportId: string,
   ): Promise<ReportEmployeeModel[]> {
     const employees = await this.reportEmployeeModel.findAll({
       where: {
         reportId,
-        gender: { [Op.in]: [GenderEnum.MALE, GenderEnum.FEMALE] },
+        gender: {
+          [Op.in]: [GenderEnum.MALE, GenderEnum.FEMALE, GenderEnum.NEUTRAL],
+        },
       },
     })
 
@@ -344,8 +384,13 @@ export class ReportStatisticsService implements IReportStatisticsService {
 // ── Pure computation helpers ────────────────────────────────────────
 
 function buildWageGapResponse(points: EmployeeDataPoint[]): GenderWageGapDto {
-  const males = points.filter((point) => point.gender === GenderEnum.MALE)
-  const females = points.filter((point) => point.gender === GenderEnum.FEMALE)
+  const males = points.filter(
+    (point) => bundleNeutralIntoFemale(point.gender) === GenderEnum.MALE,
+  )
+  // NEUTRAL is bundled with FEMALE (M vs F+N).
+  const females = points.filter(
+    (point) => bundleNeutralIntoFemale(point.gender) === GenderEnum.FEMALE,
+  )
   const snapshot = computeSalaryAggregateSnapshot(
     points.map((point) => ({
       gender: point.gender,

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.spec.ts
@@ -11,7 +11,7 @@ import {
 } from './compensation-aggregates'
 
 describe('compensation-aggregates', () => {
-  it('computes aggregate metrics and directional wage gaps across genders', () => {
+  it('bundles NEUTRAL into FEMALE for cohort metrics and wage gaps', () => {
     const snapshot = computeSalaryAggregateSnapshot([
       { gender: GenderEnum.MALE, salary: 100 },
       { gender: GenderEnum.MALE, salary: 300 },
@@ -32,27 +32,27 @@ describe('compensation-aggregates', () => {
       minimum: 100,
       maximum: 300,
     })
+    // FEMALE absorbs the NEUTRAL salary (50): avg of 150/250/50 = 150.
     expect(snapshot.female).toEqual({
-      average: 200,
-      median: 200,
-      minimum: 150,
+      average: 150,
+      median: 150,
+      minimum: 50,
       maximum: 250,
     })
+    // Standalone NEUTRAL cohort is empty once bundled.
     expect(snapshot.neutral).toEqual({
-      average: 50,
-      median: 50,
-      minimum: 50,
-      maximum: 50,
+      average: null,
+      median: null,
+      minimum: null,
+      maximum: null,
     })
 
-    expect(snapshot.salaryDifferences).toEqual({
-      maleFemale: 0,
-      maleNeutral: 75,
-      femaleMale: 0,
-      femaleNeutral: 75,
-      neutralMale: -300,
-      neutralFemale: -300,
-    })
+    expect(snapshot.salaryDifferences.maleFemale).toBe(25)
+    expect(snapshot.salaryDifferences.femaleMale).toBeCloseTo(-33.3333, 3)
+    expect(snapshot.salaryDifferences.maleNeutral).toBeNull()
+    expect(snapshot.salaryDifferences.femaleNeutral).toBeNull()
+    expect(snapshot.salaryDifferences.neutralMale).toBeNull()
+    expect(snapshot.salaryDifferences.neutralFemale).toBeNull()
   })
 
   it('returns null for missing cohort metrics and wage gaps', () => {

--- a/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/lib/compensation-aggregates.ts
@@ -157,6 +157,18 @@ export function getAdjustedFullSalary(
   )
 }
 
+/**
+ * Current product rule: the gender salary gap is measured as MALE vs
+ * FEMALE+NEUTRAL, so NEUTRAL is bundled into the FEMALE group for every
+ * grouping, count and gender-split regression. Raw NEUTRAL data is preserved
+ * untouched in `report_employee` — this only reclassifies at computation time.
+ * Centralised here so the rule is reversible when NEUTRAL gets its own
+ * category later.
+ */
+export function bundleNeutralIntoFemale(gender: GenderEnum): GenderEnum {
+  return gender === GenderEnum.NEUTRAL ? GenderEnum.FEMALE : gender
+}
+
 export function computeCompensationAggregates(input: {
   employees: CompensationEmployeeInput[]
   bucketWidth?: number
@@ -523,13 +535,22 @@ function computeRegressionsByGender(
   return {
     overall: computeSalaryRegression(samples),
     male: computeSalaryRegression(
-      samples.filter((sample) => sample.gender === GenderEnum.MALE),
+      samples.filter(
+        (sample) => bundleNeutralIntoFemale(sample.gender) === GenderEnum.MALE,
+      ),
     ),
+    // FEMALE line is fit on FEMALE+NEUTRAL; the standalone neutral line is
+    // therefore empty (the outlier rule uses `overall`, not these).
     female: computeSalaryRegression(
-      samples.filter((sample) => sample.gender === GenderEnum.FEMALE),
+      samples.filter(
+        (sample) => bundleNeutralIntoFemale(sample.gender) === GenderEnum.FEMALE,
+      ),
     ),
     neutral: computeSalaryRegression(
-      samples.filter((sample) => sample.gender === GenderEnum.NEUTRAL),
+      samples.filter(
+        (sample) =>
+          bundleNeutralIntoFemale(sample.gender) === GenderEnum.NEUTRAL,
+      ),
     ),
   }
 }
@@ -710,18 +731,12 @@ function groupSalaries(samples: GenderSalarySample[]): AggregateGroup {
   for (const sample of samples) {
     grouped.overall.push(sample.salary)
 
-    if (sample.gender === GenderEnum.MALE) {
+    // NEUTRAL is bundled into the FEMALE group (see bundleNeutralIntoFemale);
+    // the standalone `neutral` group is therefore always empty here.
+    if (bundleNeutralIntoFemale(sample.gender) === GenderEnum.MALE) {
       grouped.male.push(sample.salary)
-      continue
-    }
-
-    if (sample.gender === GenderEnum.FEMALE) {
+    } else {
       grouped.female.push(sample.salary)
-      continue
-    }
-
-    if (sample.gender === GenderEnum.NEUTRAL) {
-      grouped.neutral.push(sample.salary)
     }
   }
 
@@ -733,11 +748,15 @@ function countSamplesByCohort(
 ): SalaryCohortCounts {
   return {
     overall: samples.length,
-    male: samples.filter((sample) => sample.gender === GenderEnum.MALE).length,
-    female: samples.filter((sample) => sample.gender === GenderEnum.FEMALE)
-      .length,
-    neutral: samples.filter((sample) => sample.gender === GenderEnum.NEUTRAL)
-      .length,
+    male: samples.filter(
+      (sample) => bundleNeutralIntoFemale(sample.gender) === GenderEnum.MALE,
+    ).length,
+    // FEMALE count includes NEUTRAL; the standalone neutral count is therefore
+    // 0 (raw neutral data remains in report_employee).
+    female: samples.filter(
+      (sample) => bundleNeutralIntoFemale(sample.gender) === GenderEnum.FEMALE,
+    ).length,
+    neutral: 0,
   }
 }
 

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -5246,7 +5246,8 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/ScoreBucketDto" }
           },
-          "totals": { "$ref": "#/components/schemas/SalaryTotalsDto" }
+          "totals": { "$ref": "#/components/schemas/SalaryTotalsDto" },
+          "allowedDifferencePercent": { "type": "number", "nullable": true }
         },
         "required": ["dataPoints", "regressionLine", "scoreBuckets", "totals"]
       },

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryDistributionChart.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/salary-tab/SalaryDistributionChart.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  Area,
   CartesianGrid,
   ComposedChart,
   Legend,
@@ -46,9 +47,15 @@ export function SalaryDistributionChart({ data }: Props) {
     )
   }
 
+  const { slope, intercept } = data.regressionLine
+  const allowed = data.allowedDifferencePercent
+  const predict = (score: number) => slope * score + intercept
+
+  // NEUTRAL is bundled into the female series (M vs F+N). Outliers are not
+  // marked on the chart — the tolerance band shows the pattern and the outlier
+  // table carries the exact list.
   const malePoints = data.dataPoints.filter((p) => p.gender === 'MALE')
-  const femalePoints = data.dataPoints.filter((p) => p.gender === 'FEMALE')
-  const neutralPoints = data.dataPoints.filter((p) => p.gender === 'NEUTRAL')
+  const femalePoints = data.dataPoints.filter((p) => p.gender !== 'MALE')
 
   const allY = data.dataPoints.map((p) => p.adjustedSalary)
   const yMax = Math.ceil(Math.max(...allY, 1) / 100000) * 100000
@@ -59,12 +66,27 @@ export function SalaryDistributionChart({ data }: Props) {
       (Math.max(...data.scoreBuckets.map((b) => b.rangeTo)) + 100) / 250,
     ) * 250
 
-  const { slope, intercept } = data.regressionLine
   const xStart = slope !== 0 ? Math.max(0, -intercept / slope) : 0
   const regressionData = [
-    { score: xStart, salary: slope * xStart + intercept },
-    { score: xAxisMax, salary: slope * xAxisMax + intercept },
+    { score: xStart, salary: predict(xStart) },
+    { score: xAxisMax, salary: predict(xAxisMax) },
   ]
+
+  // Tolerance wedge: predicted +/- allowed%, drawn as a shaded band between
+  // the lower and upper bound lines. Only the base-salary chart carries a band.
+  const bandData =
+    allowed != null
+      ? [xStart, xAxisMax].map((score) => {
+          const predicted = predict(score)
+          return {
+            score,
+            band: [
+              predicted * (1 - allowed / 100),
+              predicted * (1 + allowed / 100),
+            ] as [number, number],
+          }
+        })
+      : []
 
   return (
     <Box display="flex" flexDirection="column" rowGap={2} marginY={4}>
@@ -74,7 +96,10 @@ export function SalaryDistributionChart({ data }: Props) {
       </Text>
 
       <ResponsiveContainer width="100%" height={420}>
-        <ComposedChart margin={{ top: 24, right: 0, left: 0, bottom: 24 }}>
+        <ComposedChart
+          margin={{ top: 24, right: 0, left: 0, bottom: 24 }}
+          style={{ outline: 'none' }}
+        >
           <CartesianGrid vertical={false} stroke={theme.color.blue200} />
           <XAxis
             type="number"
@@ -142,6 +167,22 @@ export function SalaryDistributionChart({ data }: Props) {
             }}
           />
 
+          {bandData.length > 0 && (
+            <Area
+              data={bandData}
+              dataKey="band"
+              type="linear"
+              name={`Vikmörk (±${allowed}%)`}
+              stroke="none"
+              fill={theme.color.blue300}
+              fillOpacity={0.32}
+              legendType="rect"
+              tooltipType="none"
+              isAnimationActive={false}
+              activeDot={false}
+            />
+          )}
+
           {malePoints.length > 0 && (
             <Scatter
               name="Karl"
@@ -162,21 +203,11 @@ export function SalaryDistributionChart({ data }: Props) {
             />
           )}
 
-          {neutralPoints.length > 0 && (
-            <Scatter
-              name="Hlutlaust"
-              data={neutralPoints}
-              fill={theme.color.yellow400}
-              legendType="circle"
-              opacity={0.8}
-            />
-          )}
-
           <Line
             data={regressionData}
             type="linear"
             dataKey="salary"
-            name="Meðallaun"
+            name="Áætluð laun eftir stigum"
             stroke={theme.color.roseTinted400}
             strokeWidth={2.5}
             dot={false}


### PR DESCRIPTION
DOE: Gender bundling fix + salary chart tolerance band
Summary
Two related changes to the salary report ("yfirlit") statistics:

1. NEUTRAL is now bundled with FEMALE in all calculations (M vs F+N)
The gender pay gap is measured as MALE vs FEMALE+NEUTRAL. NEUTRAL employees were previously their own cohort (and excluded from the chart entirely). They are now reclassified into the female group for every average, count, wage gap, gender-split regression, and chart series — while the raw report_employee.gender keeps the real NEUTRAL value (data preserved for a future standalone category). The rule is centralized in bundleNeutralIntoFemale() so it's easy to reverse. NEUTRAL dots render in the purple "Kona" series on both the web and PDF charts.

2. Salary chart now shows the outlier tolerance band
Reviewers couldn't tell from the chart why a point was/wasn't an outlier. The chart now draws a shaded ±band (half the configured salary_difference_threshold_percent, e.g. ±1.95%) around the regression line — a point outside the band is an outlier. A new allowedDifferencePercent field on SalaryByGenderAndScoreDto carries the band width. The exact outlier list still lives in the outlier table; the chart shows the pattern.

Minor chart cleanups: removed the chart focus outline on click, line relabeled to "Áætluð laun eftir stigum", band excluded from the tooltip.