### PR TITLE
feat(doe): salary report flow errors - template excel

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/admin-report/admin-report.controller.ts
@@ -1,10 +1,12 @@
 import {
   Body,
   Controller,
+  Get,
   Inject,
   Param,
   ParseUUIDPipe,
   Post,
+  StreamableFile,
   UseGuards,
 } from '@nestjs/common'
 import { ApiBearerAuth, ApiParam, ApiTags } from '@nestjs/swagger'
@@ -25,6 +27,9 @@ import { AdminEqualityReportDto } from './dto/admin-equality-report.dto'
 import { AdminSalaryReportDto } from './dto/admin-salary-report.dto'
 import { IAdminReportService } from './admin-report.service.interface'
 
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
 @Controller({
   path: 'admin-report',
   version: '1',
@@ -41,6 +46,21 @@ export class AdminReportController {
     @Inject(IImportUploadService)
     private readonly importUploadService: IImportUploadService,
   ) {}
+
+  @Get('reports/excel/template')
+  @DoeResponse({
+    operationId: 'getAdminBlankExcelTemplate',
+    successDescription: 'Blank salary report template',
+    produces: XLSX_MIME,
+  })
+  async getTemplate(): Promise<StreamableFile> {
+    const buf = await this.reportExcelService.generateBlankTemplate()
+
+    return new StreamableFile(buf, {
+      type: XLSX_MIME,
+      disposition: 'attachment; filename="salary-report-template.xlsx"',
+    })
+  }
 
   @Post('companies/:companyId/reports/excel/import')
   @ApiParam({ name: 'companyId', type: String })

--- a/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.controller.ts
@@ -152,7 +152,7 @@ export class ApplicationController {
   @DoeResponse({
     operationId: 'getApplicationSalaryReportEligibility',
     description:
-      "Pre-flight check of whether the resolved company may submit a salary report right now. Salary reports run on a 3-year cadence and may only be renewed once the current one is due in 6 months or less; this endpoint returns that verdict (with a machine-readable reason when blocked) so the application portal can gate entry into the flow. The same rule is enforced as a 409 on `POST reports/salary`.",
+      "Pre-flight check of whether the resolved company may submit a salary report right now, with a machine-readable `reason` when blocked so the application portal can gate entry into the flow. Two preconditions are checked: (1) the company must have an APPROVED, in-force equality report (`MISSING_EQUALITY_REPORT`, checked first — a salary report must reference one); and (2) the 3-year renewal window must be open, i.e. the current report is due in 6 months or less (`RENEWAL_WINDOW_NOT_OPEN`). The renewal rule is also enforced as a 409 on `POST reports/salary`, and the equality precondition as a 404.",
     type: SalaryReportEligibilityDto,
   })
   async getSalaryReportEligibility(

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.interface.ts
@@ -31,7 +31,9 @@ export interface IApplicationService {
   getActiveEqualityReport(
     company: CompanyDto,
   ): Promise<EqualityReportSummaryDto>
-  getSalaryReportEligibility(company: CompanyDto): SalaryReportEligibilityDto
+  getSalaryReportEligibility(
+    company: CompanyDto,
+  ): Promise<SalaryReportEligibilityDto>
   getReport(
     providerId: string,
     company: CompanyDto,

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -421,24 +421,50 @@ describe('ApplicationService', () => {
   })
 
   describe('getSalaryReportEligibility', () => {
-    it('is eligible when there is no due date', () => {
-      const result = service.getSalaryReportEligibility(COMPANY)
+    const activeEquality = {
+      id: 'eq-1',
+      identifier: 'EQ-2025-001',
+      approvedAt: new Date('2025-01-01T00:00:00Z'),
+      validUntil: new Date('2028-01-01T00:00:00Z'),
+    }
+
+    it('is eligible when there is no due date and an equality report exists', async () => {
+      getActiveEqualityForCompany.mockResolvedValue(activeEquality)
+
+      const result = await service.getSalaryReportEligibility(COMPANY)
 
       expect(result.eligible).toBe(true)
       expect(result.reason).toBeNull()
       expect(result.dueAt).toBeNull()
     })
 
-    it('is ineligible with a reason when the due date is more than 6 months out', () => {
+    it('is ineligible with a reason when the due date is more than 6 months out', async () => {
+      getActiveEqualityForCompany.mockResolvedValue(activeEquality)
       const farFuture = new Date()
       farFuture.setFullYear(farFuture.getFullYear() + 2)
       const company = { ...COMPANY, nextSalaryReportDueAt: farFuture }
 
-      const result = service.getSalaryReportEligibility(company)
+      const result = await service.getSalaryReportEligibility(company)
 
       expect(result.eligible).toBe(false)
       expect(result.reason).toBe('RENEWAL_WINDOW_NOT_OPEN')
       expect(result.dueAt).toEqual(farFuture)
+      expect(result.earliestSubmissionDate).toBeInstanceOf(Date)
+    })
+
+    it('is ineligible with MISSING_EQUALITY_REPORT when no active equality report exists, taking priority over the renewal window', async () => {
+      getActiveEqualityForCompany.mockResolvedValue(null)
+      // Due date within the window would otherwise be eligible; the missing
+      // equality report must still block and win the reason.
+      const soon = new Date()
+      soon.setMonth(soon.getMonth() + 3)
+      const company = { ...COMPANY, nextSalaryReportDueAt: soon }
+
+      const result = await service.getSalaryReportEligibility(company)
+
+      expect(result.eligible).toBe(false)
+      expect(result.reason).toBe('MISSING_EQUALITY_REPORT')
+      expect(result.dueAt).toEqual(soon)
       expect(result.earliestSubmissionDate).toBeInstanceOf(Date)
     })
   })

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -89,7 +89,10 @@ import type {
 import { SubmitSalaryReportDto } from './dto/submit-salary-report.dto'
 import { EQUALITY_REPORT_TEMPLATE_BASE64 } from './equality-template/template-data'
 import { buildEqualityReportTemplateHtml } from './equality-template/template-html'
-import { evaluateSalaryRenewalEligibility } from './lib/salary-renewal-eligibility'
+import {
+  evaluateSalaryRenewalEligibility,
+  SalaryReportEligibilityReasonEnum,
+} from './lib/salary-renewal-eligibility'
 import { IApplicationService } from './application.service.interface'
 
 const LOGGING_CONTEXT = 'ApplicationService'
@@ -201,13 +204,19 @@ export class ApplicationService implements IApplicationService {
     })
 
     // Renewal-window gate: a company may only submit a salary report once its
-    // current one is due in 6 months or less. Same verdict the eligibility
-    // endpoint returns, so the pre-check and this block cannot drift. Only the
-    // company-facing portal path is gated — admin/system creation is not.
-    const eligibility = this.getSalaryReportEligibility(company)
-    if (!eligibility.eligible) {
+    // current one is due in 6 months or less. Shares the pure renewal decision
+    // with the eligibility endpoint, so the pre-check and this block cannot
+    // drift on the window rule. The equality-report precondition is enforced
+    // separately (as a 404) by `createSalary` below, so it is not re-checked
+    // here. Only the company-facing portal path is gated — admin/system
+    // creation is not.
+    const renewal = evaluateSalaryRenewalEligibility(
+      company.nextSalaryReportDueAt ?? null,
+      new Date(),
+    )
+    if (!renewal.eligible) {
       throw new ConflictException(
-        `Salary report renewal window is not open yet for company "${company.id}"; earliest submission ${eligibility.earliestSubmissionDate?.toISOString() ?? 'n/a'}`,
+        `Salary report renewal window is not open yet for company "${company.id}"; earliest submission ${renewal.earliestSubmissionDate?.toISOString() ?? 'n/a'}`,
       )
     }
 
@@ -215,12 +224,30 @@ export class ApplicationService implements IApplicationService {
     return this.reportCreateService.createSalary(createInput)
   }
 
-  getSalaryReportEligibility(company: CompanyDto): SalaryReportEligibilityDto {
+  async getSalaryReportEligibility(
+    company: CompanyDto,
+  ): Promise<SalaryReportEligibilityDto> {
     const { eligible, reason, dueAt, earliestSubmissionDate } =
       evaluateSalaryRenewalEligibility(
         company.nextSalaryReportDueAt ?? null,
         new Date(),
       )
+
+    // A salary report must reference an approved, in-force equality report.
+    // This blocks the flow regardless of the renewal window, so it takes
+    // priority — but we still surface the (informational) due dates from the
+    // renewal decision so the portal can render them either way.
+    const activeEquality = await this.reportService.getActiveEqualityForCompany(
+      company.id,
+    )
+    if (!activeEquality) {
+      return {
+        eligible: false,
+        reason: SalaryReportEligibilityReasonEnum.MISSING_EQUALITY_REPORT,
+        dueAt,
+        earliestSubmissionDate,
+      }
+    }
 
     return { eligible, reason, dueAt, earliestSubmissionDate }
   }

--- a/apps/directorate-of-equality-api/src/modules/application/dto/salary-report-eligibility.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/dto/salary-report-eligibility.dto.ts
@@ -21,7 +21,7 @@ export class SalaryReportEligibilityDto {
   @ApiOptionalEnum(SalaryReportEligibilityReasonEnum, {
     nullable: true,
     description:
-      'Machine-readable reason when `eligible` is false; null when eligible.',
+      'Machine-readable reason when `eligible` is false; null when eligible. `MISSING_EQUALITY_REPORT` (no approved, in-force equality report — takes priority) or `RENEWAL_WINDOW_NOT_OPEN` (current report due more than 6 months out).',
   })
   reason!: SalaryReportEligibilityReasonEnum | null
 

--- a/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/lib/salary-renewal-eligibility.ts
@@ -18,6 +18,13 @@ export const SALARY_RENEWAL_WINDOW_MONTHS = 6
 export enum SalaryReportEligibilityReasonEnum {
   /** Due date is more than `SALARY_RENEWAL_WINDOW_MONTHS` months away. */
   RENEWAL_WINDOW_NOT_OPEN = 'RENEWAL_WINDOW_NOT_OPEN',
+  /**
+   * The company has no APPROVED, in-force equality report. A salary report must
+   * reference one, so the flow is blocked until an equality report exists. This
+   * is decided in the service (it needs a DB lookup), not in the pure
+   * renewal-window function below, and takes priority over the renewal window.
+   */
+  MISSING_EQUALITY_REPORT = 'MISSING_EQUALITY_REPORT',
 }
 
 export interface SalaryRenewalEligibility {

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -1,6 +1,57 @@
 {
   "openapi": "3.0.0",
   "paths": {
+    "/api/v1/admin-report/reports/excel/template": {
+      "get": {
+        "operationId": "getAdminBlankExcelTemplate",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Blank salary report template",
+            "content": {
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Admin Report"]
+      }
+    },
     "/api/v1/admin-report/companies/{companyId}/reports/excel/import": {
       "post": {
         "operationId": "importAdminSalaryReportWorkbook",
@@ -3573,6 +3624,49 @@
       "bearer": { "scheme": "bearer", "bearerFormat": "JWT", "type": "http" }
     },
     "schemas": {
+      "ApiErrorDto": {
+        "type": "object",
+        "properties": {
+          "statusCode": { "type": "number" },
+          "timestamp": { "type": "string" },
+          "name": {
+            "type": "string",
+            "enum": [
+              "NotFound",
+              "ValidationError",
+              "ForeignKeyConstraintError",
+              "UniqueConstraintError",
+              "TimeoutError",
+              "Unauthorized",
+              "Forbidden",
+              "BadRequest",
+              "InternalServerError",
+              "ConnectionAcquireTimeoutError",
+              "UnknownError"
+            ],
+            "example": [
+              "NotFound",
+              "ValidationError",
+              "ForeignKeyConstraintError",
+              "UniqueConstraintError",
+              "TimeoutError",
+              "Unauthorized",
+              "Forbidden",
+              "BadRequest",
+              "InternalServerError",
+              "ConnectionAcquireTimeoutError",
+              "UnknownError"
+            ]
+          },
+          "message": { "type": "string" },
+          "translatedMessage": {
+            "type": "string",
+            "description": "User-facing, localized message safe to display directly in the client. Absent when the error has no curated translation."
+          },
+          "details": { "type": "array", "items": { "type": "string" } }
+        },
+        "required": ["statusCode", "timestamp"]
+      },
       "ImportKeyDto": {
         "type": "object",
         "properties": {
@@ -3717,49 +3811,6 @@
           }
         },
         "required": ["criteria", "roles", "employees"]
-      },
-      "ApiErrorDto": {
-        "type": "object",
-        "properties": {
-          "statusCode": { "type": "number" },
-          "timestamp": { "type": "string" },
-          "name": {
-            "type": "string",
-            "enum": [
-              "NotFound",
-              "ValidationError",
-              "ForeignKeyConstraintError",
-              "UniqueConstraintError",
-              "TimeoutError",
-              "Unauthorized",
-              "Forbidden",
-              "BadRequest",
-              "InternalServerError",
-              "ConnectionAcquireTimeoutError",
-              "UnknownError"
-            ],
-            "example": [
-              "NotFound",
-              "ValidationError",
-              "ForeignKeyConstraintError",
-              "UniqueConstraintError",
-              "TimeoutError",
-              "Unauthorized",
-              "Forbidden",
-              "BadRequest",
-              "InternalServerError",
-              "ConnectionAcquireTimeoutError",
-              "UnknownError"
-            ]
-          },
-          "message": { "type": "string" },
-          "translatedMessage": {
-            "type": "string",
-            "description": "User-facing, localized message safe to display directly in the client. Absent when the error has no curated translation."
-          },
-          "details": { "type": "array", "items": { "type": "string" } }
-        },
-        "required": ["statusCode", "timestamp"]
       },
       "CreateReportOutlierGroupDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/app/api/salary-template/route.ts
+++ b/apps/directorate-of-equality-web/src/app/api/salary-template/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+
+import { getBaseUrl } from '../../../lib/api/createClient'
+import { authOptions } from '../../../lib/auth/authOptions'
+
+const XLSX_MIME =
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+/**
+ * Streams the blank salary-report Excel template to the admin. The API endpoint
+ * is bearer-guarded, so a plain <a href> from the browser can't reach it — this
+ * same-origin route injects the session token server-side and forwards the
+ * file with an attachment disposition so the browser downloads it.
+ */
+export async function GET() {
+  const session = await getServerSession(authOptions)
+  if (session?.invalid || !session?.idToken) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const res = await fetch(
+    `${getBaseUrl()}/api/v1/admin-report/reports/excel/template`,
+    { headers: { Authorization: `Bearer ${session.idToken}` } },
+  )
+
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: 'Failed to fetch salary report template' },
+      { status: res.status },
+    )
+  }
+
+  const buffer = await res.arrayBuffer()
+
+  return new NextResponse(buffer, {
+    status: 200,
+    headers: {
+      'Content-Type': XLSX_MIME,
+      'Content-Disposition':
+        'attachment; filename="salary-report-template.xlsx"',
+    },
+  })
+}

--- a/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react'
 
 import { TextInput } from '@dmr.is/ui/components/Inputs/TextInput'
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Button } from '@dmr.is/ui/components/island-is/Button'
 import { Checkbox } from '@dmr.is/ui/components/island-is/Checkbox'
@@ -15,7 +16,11 @@ import { Select } from '@dmr.is/ui/components/island-is/Select'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 
-import { GenderEnum, type ParsedReportDto } from '../../gen/fetch/types.gen'
+import {
+  CompanyReportStatusEnum,
+  GenderEnum,
+  type ParsedReportDto,
+} from '../../gen/fetch/types.gen'
 import { putWorkbookToPresignedUrl } from '../../lib/import-upload'
 import { overviewText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
@@ -77,6 +82,16 @@ export const CreateSalaryReportDrawer = () => {
     value: c.id,
   }))
 
+  // A salary report must reference an approved, in-force equality report. The
+  // company's server-computed report status already tells us when one is
+  // missing, so we can warn the admin up front rather than let them fill in the
+  // whole form and hit a 404 on submit.
+  const selectedCompany =
+    companiesQuery.data?.companies.find((c) => c.id === companyId) ?? null
+  const missingEqualityReport =
+    selectedCompany?.reportStatus ===
+    CompanyReportStatusEnum.MISSING_EQUALITY_REPORT
+
   const requestUploadMutation = useMutation(
     trpc.adminReport.requestImportUpload.mutationOptions(),
   )
@@ -109,6 +124,19 @@ export const CreateSalaryReportDrawer = () => {
     } catch {
       toast.error(t.excelErrorToast)
     }
+  }
+
+  // Downloads the blank Excel template. The API endpoint is bearer-guarded, so
+  // we hit a same-origin route that injects the token server-side; the response
+  // carries an attachment disposition, so the click triggers a download without
+  // navigating away.
+  const handleDownloadTemplate = () => {
+    const link = document.createElement('a')
+    link.href = '/api/salary-template'
+    link.download = 'salary-report-template.xlsx'
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
   }
 
   const handleReset = () => {
@@ -165,12 +193,22 @@ export const CreateSalaryReportDrawer = () => {
         return
       }
 
+      // Safety net: the proactive gate above normally catches this, but the
+      // company's report status may be stale (e.g. an equality report expired
+      // since the list was loaded). Surface the API's "no approved equality
+      // report" error as a clear message instead of the generic fallback.
+      if (/equality report/i.test(message)) {
+        toast.error(t.missingEqualityToast)
+        return
+      }
+
       toast.error(s.form.errorToast)
     }
   }
 
   const canSubmit =
     !!companyId &&
+    !missingEqualityReport &&
     !!parsedReport &&
     !!form.companyAdminName &&
     !!form.companyAdminEmail &&
@@ -219,12 +257,35 @@ export const CreateSalaryReportDrawer = () => {
               backgroundColor="blue"
             />
           </GridColumn>
+          {missingEqualityReport && (
+            <GridColumn span="12/12">
+              <AlertMessage
+                type="warning"
+                title={t.missingEqualityTitle}
+                message={t.missingEqualityMessage}
+              />
+            </GridColumn>
+          )}
         </GridRow>
         <GridRow rowGap={1} marginBottom={4}>
           <GridColumn span="12/12">
-            <Text variant="h4" marginBottom={1}>
-              {t.excelHeading}
-            </Text>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="spaceBetween"
+              marginBottom={1}
+            >
+              <Text variant="h4">{t.excelHeading}</Text>
+              <Button
+                variant="text"
+                size="small"
+                icon="download"
+                iconType="outline"
+                onClick={handleDownloadTemplate}
+              >
+                {t.downloadTemplate}
+              </Button>
+            </Box>
           </GridColumn>
           <GridColumn span="12/12">
             <Box

--- a/apps/directorate-of-equality-web/src/lib/api/createClient.ts
+++ b/apps/directorate-of-equality-web/src/lib/api/createClient.ts
@@ -1,7 +1,7 @@
 import type { Client } from '../../gen/fetch/client'
 import { createClient, createConfig } from '../../gen/fetch/client'
 
-const getBaseUrl = () => {
+export const getBaseUrl = () => {
   if (process.env.NODE_ENV !== 'production') return 'http://localhost:5100'
   return process.env.DOE_API_BASE_PATH as string
 }

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -88,6 +88,7 @@ export const overviewText = {
     excelPlaceholder: 'Veldu Excel skrá til að flytja inn launagreiningargögn',
     switchFile: 'Skipta um skrá',
     chooseFile: 'Velja skrá',
+    downloadTemplate: 'Sækja sniðmát',
     deviationsHeading: 'Frávik',
     deferLabel: 'Fresta skilum frávika',
     deferReasonLabel: 'Ástæða frestunar',
@@ -95,6 +96,11 @@ export const overviewText = {
     excelSuccessToast: 'Excel skrá flutt inn',
     excelErrorToast: 'Villa við innflutning á Excel skrá',
     successToast: 'Skýrslugjöf send inn',
+    missingEqualityTitle: 'Samþykkta jafnréttisáætlun vantar',
+    missingEqualityMessage:
+      'Ekki er hægt að senda inn launagreiningu fyrir þetta fyrirtæki fyrr en það er með samþykkta jafnréttisáætlun í gildi. Skráðu jafnréttisáætlun fyrst.',
+    missingEqualityToast:
+      'Fyrirtækið er ekki með samþykkta jafnréttisáætlun í gildi. Skráðu jafnréttisáætlun áður en launagreining er send inn.',
   },
 }
 


### PR DESCRIPTION
## Summary

Three improvements to the Directorate of Equality (DOE) salary-report flow, all
centered on the fact that a salary report **must** reference an approved,
in-force equality report — the most common reason a submission fails.

1. **Surface the "missing equality report" error to admins** instead of a
   generic toast.
2. **Expose that precondition as a structured signal** on the application API
   so the application-portal (island.is) can gate the flow the same way.
3. **Add a "download template" button** to the admin salary-report drawer.

## 1. Admin drawer — missing equality report is now visible

Previously, if an admin submitted a salary report for a company without an
approved equality report, the API returned a clear 404 but the drawer swallowed
it and showed a generic `"Villa við innsendingu"`.

- **Proactive gate:** the company list already returns a server-computed
  `reportStatus`. When the admin selects a company with
  `MISSING_EQUALITY_REPORT`, a warning `AlertMessage` appears and submit is
  disabled — so they see it before filling in the form, not after.
- **Reactive fallback:** if the status was stale (e.g. an equality report
  expired since the list loaded), the submit error is caught and surfaced as a
  clear Icelandic message instead of the generic one.

## 2. Application API — equality readiness in the eligibility pre-flight

The salary renewal-window check already had a structured pre-flight
(`GET application/reports/salary/eligibility` → `{ eligible, reason, ... }`).
The equality-report precondition had no equivalent — the portal had to infer it
from a 404 on a different endpoint.

- Added `MISSING_EQUALITY_REPORT` to `SalaryReportEligibilityReasonEnum`.
- `getSalaryReportEligibility` now also checks for an approved, in-force
  equality report. It takes **priority** over the renewal window (it blocks
  regardless), while still returning the informational due dates.
- Submit-time behavior is unchanged: the renewal window is still enforced as a
  409, and the equality precondition as a 404 (decoupled the 409 gate from the
  combined check so nothing drifts).
- Updated OpenAPI descriptions on the endpoint and the `reason` field so the
  contract is self-documenting.

> **Note for the application-portal team:** the new `MISSING_EQUALITY_REPORT`
> reason needs an OpenAPI client regen on that side to pick it up.

## 3. Admin drawer — download blank Excel template

Admins can now download the blank salary-report template directly from the
drawer (small text button next to the Excel-import heading).

- Added admin-guarded `GET admin-report/reports/excel/template`
  (`getAdminBlankExcelTemplate`), mirroring the existing company-facing
  endpoint.
- The endpoint is bearer-guarded, so the web uses a same-origin Next route
  handler (`/api/salary-template`) that injects the session token server-side
  and streams the file back with an attachment disposition. No client codegen
  required.