### PR TITLE
fix(doe): Excel parsing ordinal position

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/report-excel/parser/employees.parser.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/parser/employees.parser.ts
@@ -33,18 +33,17 @@ import {
   SHEETS,
   TABLE_FIRST_DATA_ROW,
 } from '../workbook.schema'
-import {
-  readDate,
-  readInteger,
-  readNumber,
-  readString,
-  toIsoDate,
-} from './cell'
+import { readDate, readNumber, readString, toIsoDate } from './cell'
 import { ErrorBag } from './errors'
 
 /**
  * Column letters in the Starfsmenn sheet. These MUST match the hand-authored
  * `template.xlsx` layout — the parser reads cells positionally, not by header.
+ *
+ * Column A ("#" / Raðnúmer) is deliberately absent: the template auto-numbers
+ * it with `=ROW()-5`, and the parser never trusts formula results (see
+ * `readInteger`). The ordinal is therefore derived from row position instead
+ * (see {@link parseEmployees}), which reproduces `=ROW()-5` exactly.
  *
  * The salary breakdown lives in K–P (6 sub-components). The template also has
  * two trailing computed columns — Q "Viðbótarlaun" (`=SUM(K:L)`) and R
@@ -53,7 +52,6 @@ import { ErrorBag } from './errors'
  * formulas are display-only.
  */
 const COLS = {
-  ordinal: 'A',
   name: 'B',
   role: 'C',
   gender: 'D',
@@ -113,7 +111,6 @@ export type EmployeesParseResult = {
 }
 
 type RawRow = {
-  ordinal: number | null
   role: string | null
   genderDisplay: string | null
   workRatioPct: number | null
@@ -131,7 +128,6 @@ type RawRow = {
 }
 
 const readRow = (sheet: ExcelJS.Worksheet, r: number): RawRow => ({
-  ordinal: readInteger(sheet.getCell(`${COLS.ordinal}${r}`)),
   role: readString(sheet.getCell(`${COLS.role}${r}`)),
   genderDisplay: readString(sheet.getCell(`${COLS.gender}${r}`)),
   workRatioPct: readNumber(sheet.getCell(`${COLS.workRatio}${r}`)),
@@ -182,10 +178,10 @@ const isEmptyRow = (row: RawRow): boolean =>
 const buildEmployee = (
   row: RawRow,
   r: number,
+  ordinal: number,
   errors: ErrorBag,
 ): ParsedEmployeeDto | null => {
   const {
-    ordinal,
     role,
     genderDisplay,
     workRatioPct,
@@ -201,14 +197,6 @@ const buildEmployee = (
     department,
     startDate,
   } = row
-
-  if (ordinal == null) {
-    errors.add(SHEETS.EMPLOYEES, 'Raðnúmer vantar (dálkur A) í röð sem er ekki tóm', {
-      row: r,
-      column: COLS.ordinal,
-    })
-    return null
-  }
 
   let ok = true
   const missingField = (col: string, icelandic: string): void => {
@@ -334,7 +322,14 @@ export const parseEmployees = (
     const row = readRow(sheet, r)
     if (isEmptyRow(row)) continue
 
-    const employee = buildEmployee(row, r, errors)
+    // Ordinal is derived from row position, not read from column A. The
+    // template auto-numbers column A with `=ROW()-5` (a formula the parser
+    // never trusts), so `r - (TABLE_FIRST_DATA_ROW - 1)` reproduces exactly
+    // the "#" the user sees on that row — keeping the imported ordinal aligned
+    // with the sheet even across blank rows.
+    const ordinal = r - (TABLE_FIRST_DATA_ROW - 1)
+
+    const employee = buildEmployee(row, r, ordinal, errors)
     if (!employee) continue
 
     if (!rolesByTitle.has(employee.roleTitle)) {

--- a/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
@@ -328,6 +328,69 @@ describe('parseWorkbook', () => {
     })
   })
 
+  describe('ordinal derivation (column A is a formula in the real template)', () => {
+    it('derives ordinal from row position, ignoring the =ROW()-5 formula in column A', async () => {
+      const wb = await loadTemplate()
+      writeEmployeeRow(wb, 1, {
+        name: 'A',
+        role: 'R',
+        gender: 'Kona',
+        workRatioPct: 100,
+        education: 'Háskólapróf (BA/BS)',
+        baseSalary: 1,
+        additionalFixedOvertime: 0,
+        additionalFixedCarAllowance: null,
+        bonusOccasionalCarAllowance: null,
+        bonusOccasionalOvertime: null,
+        bonusPayments: null,
+        bonusOther: null,
+        field: 'X',
+        department: 'X',
+        startDate: new Date('2024-01-01'),
+      })
+      writeEmployeeRow(wb, 2, {
+        name: 'B',
+        role: 'R',
+        gender: 'Karl',
+        workRatioPct: 100,
+        education: 'Háskólapróf (BA/BS)',
+        baseSalary: 1,
+        additionalFixedOvertime: 0,
+        additionalFixedCarAllowance: null,
+        bonusOccasionalCarAllowance: null,
+        bonusOccasionalOvertime: null,
+        bonusPayments: null,
+        bonusOther: null,
+        field: 'X',
+        department: 'X',
+        startDate: new Date('2024-01-01'),
+      })
+
+      // Mirror the shipped template: column A holds the auto-numbering formula,
+      // NOT a literal. Before the row-position fix this made every non-empty
+      // row fail with "Raðnúmer vantar".
+      const s = wb.getWorksheet('Starfsmenn')!
+      s.getCell('A6').value = { formula: 'ROW()-5', result: 1 }
+      s.getCell('A7').value = { formula: 'ROW()-5', result: 2 }
+
+      addPersonalCriterion(wb, 10, 'Sérhæfing', 10)
+      addPersonalSub(wb, 13, 'Sérhæfing', 'Tungumál', 10, [
+        'Engin sérstök',
+        'Grunnkunnátta',
+        'Góð kunnátta',
+        'Mjög góð kunnátta',
+        'Sérfræðikunnátta',
+      ])
+      fillRoleClassification(wb, [[1, 1, 1, 1, 1, 1, 1]])
+      fillEmployeeClassification(wb, [[1], [1]])
+
+      const report = await parseWorkbook(await serialize(wb))
+
+      // Row 6 → ordinal 1, row 7 → ordinal 2 (matches the sheet's "#" column).
+      expect(report.employees.map((e) => e.ordinal)).toEqual([1, 2])
+    })
+  })
+
   describe('parse-layer errors', () => {
     it('rejects unknown gender value', async () => {
       const wb = await loadTemplate()

--- a/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
@@ -12,14 +12,42 @@ import { parseWorkbook } from './workbook.parser'
 
 const templateBuffer = () => Buffer.from(TEMPLATE_BASE64, 'base64')
 
+/**
+ * A Node `Buffer` may be a view into a larger shared pool, so `.buffer` alone
+ * can hand exceljs bytes beyond this buffer's own region. Slice to the exact
+ * range — same guard the parser applies (see `parseWorkbook`). Passing the raw
+ * `.buffer` intermittently corrupts the load under full-suite memory pressure.
+ */
+const toArrayBuffer = (buf: Buffer): ArrayBuffer =>
+  buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer
+
 const loadTemplate = async (): Promise<ExcelJS.Workbook> => {
   const wb = new ExcelJS.Workbook()
-  await wb.xlsx.load(templateBuffer().buffer as ArrayBuffer)
+  await wb.xlsx.load(toArrayBuffer(templateBuffer()))
   return wb
 }
 
-const serialize = async (wb: ExcelJS.Workbook): Promise<Buffer> =>
-  Buffer.from((await wb.xlsx.writeBuffer()) as unknown as ArrayBuffer)
+/** xlsx is a zip; every valid file starts with the local-file-header magic `PK\x03\x04`. */
+const isValidXlsx = (buf: Buffer): boolean =>
+  buf.length > 4 &&
+  buf[0] === 0x50 &&
+  buf[1] === 0x4b &&
+  buf[2] === 0x03 &&
+  buf[3] === 0x04
+
+/**
+ * exceljs's `writeBuffer()` occasionally emits a truncated/empty zip under the
+ * parallelised full-suite run (surfaces as "Corrupted zip: expected N records,
+ * got 0" on the subsequent load). It's non-deterministic and re-serialising
+ * fixes it, so validate the output and retry a couple of times before giving up.
+ */
+const serialize = async (wb: ExcelJS.Workbook): Promise<Buffer> => {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const buf = Buffer.from((await wb.xlsx.writeBuffer()) as unknown as ArrayBuffer)
+    if (isValidXlsx(buf)) return buf
+  }
+  throw new Error('exceljs writeBuffer produced an invalid xlsx after 3 attempts')
+}
 
 const writeEmployeeRow = (
   wb: ExcelJS.Workbook,


### PR DESCRIPTION
## What

Fix Excel import failing with "Raðnúmer vantar" on every employee row. The parser now derives each employee's ordinal (`#`) from its row position instead of reading column A.

## Why

Column A in the template is auto-numbered with the formula `=ROW()-5`, and the parser deliberately never trusts formula results — so `readInteger` returned `null` for every row, and each non-empty row failed the "ordinal required" guard. This broke every real upload, since the shipped template ships with that formula.

Deriving the ordinal from row position (`r - 5`) reproduces `=ROW()-5` exactly, so the imported ordinal matches the `#` the user sees on each row (blank rows included). No change to the template needed. Added a regression test that mirrors the real template's formula in column A.
