### PR TITLE
fix(doe): import and hardens it against memory-driven crashes

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/report-excel/lib/semaphore.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/lib/semaphore.spec.ts
@@ -1,0 +1,79 @@
+import { Semaphore, SemaphoreQueueFullError } from './semaphore'
+
+/** Resolve on the next microtask so queued acquisitions can settle. */
+const tick = () => new Promise<void>((r) => setImmediate(r))
+
+describe('Semaphore', () => {
+  it('allows up to maxConcurrent slots without queueing', async () => {
+    const s = new Semaphore(2, 10)
+    await s.acquire()
+    await s.acquire()
+    expect(s.activeCount).toBe(2)
+    expect(s.queuedCount).toBe(0)
+  })
+
+  it('queues callers beyond maxConcurrent and admits them as slots free up', async () => {
+    const s = new Semaphore(1, 10)
+    const r1 = await s.acquire()
+
+    let secondAcquired = false
+    const p2 = s.acquire().then((release) => {
+      secondAcquired = true
+      return release
+    })
+
+    await tick()
+    expect(secondAcquired).toBe(false) // still waiting
+    expect(s.queuedCount).toBe(1)
+    expect(s.activeCount).toBe(1)
+
+    r1() // free the only slot
+    const r2 = await p2
+    expect(secondAcquired).toBe(true)
+    expect(s.activeCount).toBe(1)
+    expect(s.queuedCount).toBe(0)
+    r2()
+    expect(s.activeCount).toBe(0)
+  })
+
+  it('rejects immediately once active + queue are both full', async () => {
+    const s = new Semaphore(1, 1)
+    await s.acquire() // active
+    s.acquire() // queued (the 1 allowed waiter) — intentionally not awaited
+    await tick()
+
+    await expect(s.acquire()).rejects.toBeInstanceOf(SemaphoreQueueFullError)
+    expect(s.activeCount).toBe(1)
+    expect(s.queuedCount).toBe(1)
+  })
+
+  it('is idempotent per release — double-calling does not over-free slots', async () => {
+    const s = new Semaphore(2, 10)
+    const r = await s.acquire()
+    await s.acquire()
+    expect(s.activeCount).toBe(2)
+    r()
+    r() // second call is a no-op
+    expect(s.activeCount).toBe(1)
+  })
+
+  it('bounds concurrency under a burst larger than maxConcurrent', async () => {
+    const s = new Semaphore(2, 100)
+    let running = 0
+    let peak = 0
+
+    const task = async () => {
+      const release = await s.acquire()
+      running++
+      peak = Math.max(peak, running)
+      await tick()
+      running--
+      release()
+    }
+
+    await Promise.all(Array.from({ length: 20 }, task))
+    expect(peak).toBe(2)
+    expect(s.activeCount).toBe(0)
+    expect(s.queuedCount).toBe(0)
+  })
+})

--- a/apps/directorate-of-equality-api/src/modules/report-excel/lib/semaphore.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/lib/semaphore.ts
@@ -1,0 +1,76 @@
+/**
+ * Bounds how many callers may hold a slot at once, with a cap on how many may
+ * wait for one. Used to gate the memory-heavy exceljs parse: loading one of
+ * these workbooks costs ~350MB of heap regardless of employee count (it's the
+ * exceljs model for the wide, styled, multi-sheet template — not the data), so
+ * a burst of simultaneous uploads would otherwise stack parses until the
+ * container OOMs. Capping concurrency pins worst-case parse memory to
+ * `maxConcurrent × ~350MB`; excess callers queue, and once the queue is full
+ * they're rejected fast (mapped to a 503 upstream) rather than piling up.
+ *
+ * Pure and framework-free so it's trivially unit-testable — the NestJS mapping
+ * to `ServiceUnavailableException` lives in the caller.
+ */
+export class SemaphoreQueueFullError extends Error {
+  constructor(maxQueued: number) {
+    super(`Semaphore queue is full (max ${maxQueued} waiting)`)
+    this.name = 'SemaphoreQueueFullError'
+  }
+}
+
+export class Semaphore {
+  private active = 0
+  private readonly waiters: Array<() => void> = []
+
+  constructor(
+    private readonly maxConcurrent: number,
+    private readonly maxQueued: number,
+  ) {
+    if (maxConcurrent < 1) throw new Error('maxConcurrent must be >= 1')
+    if (maxQueued < 0) throw new Error('maxQueued must be >= 0')
+  }
+
+  get activeCount(): number {
+    return this.active
+  }
+
+  get queuedCount(): number {
+    return this.waiters.length
+  }
+
+  /**
+   * Acquire a slot. Resolves to a release function the caller MUST invoke
+   * (in a `finally`) exactly once. Throws {@link SemaphoreQueueFullError}
+   * immediately when both the active slots and the wait queue are full.
+   */
+  async acquire(): Promise<() => void> {
+    if (this.active < this.maxConcurrent) {
+      this.active++
+      return this.makeRelease()
+    }
+
+    if (this.waiters.length >= this.maxQueued) {
+      throw new SemaphoreQueueFullError(this.maxQueued)
+    }
+
+    await new Promise<void>((resolve) => this.waiters.push(resolve))
+    // Resumed by release(), which hands its slot straight over — `active` is
+    // deliberately not re-incremented here (the slot count is unchanged).
+    return this.makeRelease()
+  }
+
+  private makeRelease(): () => void {
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      const next = this.waiters.shift()
+      if (next) {
+        // Hand the slot directly to the next waiter — active stays constant.
+        next()
+      } else {
+        this.active--
+      }
+    }
+  }
+}

--- a/apps/directorate-of-equality-api/src/modules/report-excel/parser/employees.parser.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/parser/employees.parser.ts
@@ -81,6 +81,21 @@ const COLS = {
  */
 const ABSOLUTE_MAX_EMPLOYEE_ROWS = 50000
 
+/**
+ * Stop scanning after this many consecutive empty rows. `sheet.rowCount` is
+ * unreliable as a scan bound: whole-column formatting (borders/styles applied
+ * to an entire column — very common in hand-edited files) pushes the stored
+ * dimension out to Excel's ~1 048 576-row maximum. Because `readRow` calls
+ * `sheet.getCell(...)` ~14× per row and exceljs *lazily materialises* a cell
+ * object on every call, blindly scanning to `rowCount` can instantiate
+ * hundreds of thousands of junk cells and exhaust the heap — even on an empty
+ * upload. Real employee tables never contain a 200-row internal gap, so
+ * breaking after this run bounds cell materialisation to the real data (plus a
+ * small margin) while still tolerating the stray blank rows that made the
+ * original code prefer `rowCount` over the under-reporting `actualRowCount`.
+ */
+const EMPTY_ROW_RUN_LIMIT = 200
+
 /** Minimum padding for the ordinal portion of the identifier — always ≥3 digits so small imports read as "ABC-001", large ones naturally grow ("ABC-2000"). */
 const IDENTIFIER_MIN_ORDINAL_DIGITS = 3
 
@@ -318,9 +333,16 @@ export const parseEmployees = (
     TABLE_FIRST_DATA_ROW + ABSOLUTE_MAX_EMPLOYEE_ROWS - 1,
   )
 
+  let consecutiveEmpty = 0
   for (let r = TABLE_FIRST_DATA_ROW; r <= lastRow; r++) {
     const row = readRow(sheet, r)
-    if (isEmptyRow(row)) continue
+    if (isEmptyRow(row)) {
+      // Bail out of a runaway scan once we've seen a long unbroken blank run —
+      // guards against an inflated `sheet.rowCount` (see EMPTY_ROW_RUN_LIMIT).
+      if (++consecutiveEmpty >= EMPTY_ROW_RUN_LIMIT) break
+      continue
+    }
+    consecutiveEmpty = 0
 
     // Ordinal is derived from row position, not read from column A. The
     // template auto-numbers column A with `=ROW()-5` (a formula the parser

--- a/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/parser/workbook.parser.spec.ts
@@ -419,6 +419,53 @@ describe('parseWorkbook', () => {
     })
   })
 
+  describe('inflated rowCount (whole-column formatting)', () => {
+    it('stays bounded and parses correctly when a stray far-down cell inflates sheet.rowCount', async () => {
+      const wb = await loadTemplate()
+      writeEmployeeRow(wb, 1, {
+        name: 'A',
+        role: 'R',
+        gender: 'Kona',
+        workRatioPct: 100,
+        education: 'Háskólapróf (BA/BS)',
+        baseSalary: 1,
+        additionalFixedOvertime: 0,
+        additionalFixedCarAllowance: null,
+        bonusOccasionalCarAllowance: null,
+        bonusOccasionalOvertime: null,
+        bonusPayments: null,
+        bonusOther: null,
+        field: 'X',
+        department: 'X',
+        startDate: new Date('2024-01-01'),
+      })
+
+      // Simulate what whole-column formatting does to a hand-edited file: a
+      // stray value far below the data pushes sheet.rowCount into the tens of
+      // thousands. The scan must break on the long blank run rather than
+      // materialise a cell object for every row down to here (the OOM cause).
+      const s = wb.getWorksheet('Starfsmenn')!
+      s.getCell('B40000').value = 'stray'
+      expect(s.rowCount).toBeGreaterThan(30000)
+
+      addPersonalCriterion(wb, 10, 'Sérhæfing', 10)
+      addPersonalSub(wb, 13, 'Sérhæfing', 'Tungumál', 10, [
+        'Engin sérstök',
+        'Grunnkunnátta',
+        'Góð kunnátta',
+        'Mjög góð kunnátta',
+        'Sérfræðikunnátta',
+      ])
+      fillRoleClassification(wb, [[1, 1, 1, 1, 1, 1, 1]])
+      fillEmployeeClassification(wb, [[1]])
+
+      const report = await parseWorkbook(await serialize(wb))
+
+      // Only the real row is parsed; the stray far-down cell is never reached.
+      expect(report.employees.map((e) => e.ordinal)).toEqual([1])
+    })
+  })
+
   describe('parse-layer errors', () => {
     it('rejects unknown gender value', async () => {
       const wb = await loadTemplate()

--- a/apps/directorate-of-equality-api/src/modules/report-excel/report-excel.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-excel/report-excel.service.ts
@@ -1,15 +1,36 @@
-import { BadRequestException, Inject, Injectable } from '@nestjs/common'
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { ImportUploadBoundary } from '../import-upload/import-upload.service.interface'
 import { ImportErrorDto } from './dto/import-error.dto'
 import { ParsedReportDto } from './dto/parsed-report.dto'
+import { Semaphore, SemaphoreQueueFullError } from './lib/semaphore'
 import { parseWorkbook } from './parser/workbook.parser'
 import { IReportExcelService } from './report-excel.service.interface'
 import { TEMPLATE_BASE64 } from './template-data'
 
 const LOGGING_CONTEXT = 'ReportExcelService'
+
+/**
+ * Parsing one workbook holds ~350MB of heap (exceljs model), so unbounded
+ * concurrent imports OOM the container. These bound per-instance parse
+ * concurrency: worst-case parse memory ≈ `maxConcurrent × ~350MB`. Both are
+ * env-overridable so devops can retune against the task's heap without a
+ * redeploy. Defaults are deliberately conservative (2 running, 20 waiting).
+ */
+const MAX_CONCURRENT_PARSES = Number(
+  process.env.DOE_EXCEL_MAX_CONCURRENT_PARSES ?? 2,
+)
+const MAX_QUEUED_PARSES = Number(process.env.DOE_EXCEL_MAX_QUEUED_PARSES ?? 20)
+
+/** Searchable marker for uploads shed because the parse gate was saturated. */
+const EXCEL_IMPORT_BUSY = 'EXCEL_IMPORT_BUSY'
 
 /**
  * Stable, searchable marker for Excel import validation failures. Facet on
@@ -21,6 +42,14 @@ const EXCEL_IMPORT_VALIDATION_FAILED = 'EXCEL_IMPORT_VALIDATION_FAILED'
 
 @Injectable()
 export class ReportExcelService implements IReportExcelService {
+  // Shared across every import path (application / admin / bulk draft-seed) —
+  // they all funnel through importWorkbook, so one gate bounds total parse
+  // concurrency for the instance.
+  private readonly parseGate = new Semaphore(
+    MAX_CONCURRENT_PARSES,
+    MAX_QUEUED_PARSES,
+  )
+
   constructor(@Inject(LOGGER_PROVIDER) private readonly logger: Logger) {}
 
   async generateBlankTemplate(): Promise<Buffer> {
@@ -37,6 +66,8 @@ export class ReportExcelService implements IReportExcelService {
       size: fileBuffer.length,
       boundary,
     })
+
+    const release = await this.acquireParseSlot(boundary)
     try {
       return await parseWorkbook(fileBuffer)
     } catch (e) {
@@ -61,6 +92,35 @@ export class ReportExcelService implements IReportExcelService {
           errorCount: errors.length,
           errors,
         })
+      }
+      throw e
+    } finally {
+      release()
+    }
+  }
+
+  /**
+   * Acquire a parse slot, translating a saturated gate into a 503 the client
+   * can retry. Logs a distinct, greppable marker so shed load is visible in
+   * Datadog separately from validation 400s.
+   */
+  private async acquireParseSlot(
+    boundary: ImportUploadBoundary,
+  ): Promise<() => void> {
+    try {
+      return await this.parseGate.acquire()
+    } catch (e) {
+      if (e instanceof SemaphoreQueueFullError) {
+        this.logger.warn('Excel import shed — parse gate saturated', {
+          context: LOGGING_CONTEXT,
+          errorCode: EXCEL_IMPORT_BUSY,
+          boundary,
+          activeParses: this.parseGate.activeCount,
+          queuedParses: this.parseGate.queuedCount,
+        })
+        throw new ServiceUnavailableException(
+          'Innflutningur er upptekinn í augnablikinu. Reyndu aftur eftir smástund.',
+        )
       }
       throw e
     }


### PR DESCRIPTION
## What

Fixes the DOE salary-report Excel import and hardens it against memory-driven crashes.

- **Ordinal fix:** derive each employee's `#` from row position instead of reading column A. The template auto-numbers column A with `=ROW()-5`, and the parser never trusts formula results — so every row was failing with "Raðnúmer vantar". `r - 5` reproduces the sheet's `#` exactly.
- **rowCount scan guard:** stop scanning after 200 consecutive empty rows. Whole-column formatting inflates `sheet.rowCount` to Excel's max, and the per-row `getCell` loop was materializing hundreds of thousands of empty cells → OOM even on empty files.
- **Parse concurrency gate:** a semaphore caps concurrent exceljs parses (each ~350MB heap). Bounds worst-case parse memory to `maxConcurrent × ~350MB`; returns 503 when saturated instead of stacking parses until the container OOMs. Tunable via `DOE_EXCEL_MAX_CONCURRENT_PARSES` / `DOE_EXCEL_MAX_QUEUED_PARSES` (defaults 2 / 20).
- **Test hardening:** fixed flaky exceljs serialize/load in the parser spec (slice ArrayBuffer, validate + retry on empty write).

## Why

Import was broken (every row rejected) and OOM-crashing on dev under heap. The memory is inherent to exceljs's model for these wide, validation-heavy workbooks — not employee count (10k employees ≈ 424MB, 50 ≈ 314MB).