### PR TITLE
fix(doe): surface in-flight report conflicts and allow denying postponed reports

### DIFF
--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -76,6 +76,7 @@ const COMPANY: CompanyDto = {
   reportStatus: CompanyReportStatusEnum.SATISFACTORY,
   equalityReportOverdue: false,
   salaryReportOverdue: false,
+  email: null,
 }
 
 describe('ApplicationService', () => {

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -283,6 +283,30 @@ describe('ReportWorkflowService', () => {
       )
     })
 
+    it('transitions POSTPONED → DENIED and emits STATUS_CHANGED with POSTPONED as from-status', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+
+      await service.deny(reviewerContext(ReportStatusEnum.POSTPONED), {
+        denialReason: 'Outliers never resolved',
+      })
+
+      expect(reportModel.update).toHaveBeenCalledWith(
+        {
+          status: ReportStatusEnum.DENIED,
+          reviewerUserId: 'reviewer-1',
+        },
+        { where: { id: 'report-1' } },
+      )
+      expect(reportEventService.emitStatusChanged).toHaveBeenCalledWith(
+        'report-1',
+        ReportStatusEnum.POSTPONED,
+        ReportStatusEnum.DENIED,
+        'reviewer-1',
+        'Outliers never resolved',
+      )
+    })
+
     it('notifies the application system when the report is island.is-sourced', async () => {
       reportModel.update.mockResolvedValue([1])
       reportEventService.emitStatusChanged.mockResolvedValue(undefined)
@@ -333,12 +357,19 @@ describe('ReportWorkflowService', () => {
       ).resolves.toBeUndefined()
     })
 
-    it('rejects non-IN_REVIEW reports', async () => {
-      await expect(
-        service.deny(reviewerContext(ReportStatusEnum.SUBMITTED), {
-          denialReason: 'reason',
-        }),
-      ).rejects.toBeInstanceOf(BadRequestException)
+    it('rejects reports outside IN_REVIEW / POSTPONED', async () => {
+      for (const status of [
+        ReportStatusEnum.SUBMITTED,
+        ReportStatusEnum.DRAFT,
+        ReportStatusEnum.APPROVED,
+        ReportStatusEnum.DENIED,
+      ]) {
+        await expect(
+          service.deny(reviewerContext(status), {
+            denialReason: 'reason',
+          }),
+        ).rejects.toBeInstanceOf(BadRequestException)
+      }
 
       expect(reportModel.update).not.toHaveBeenCalled()
     })

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -158,7 +158,14 @@ export class ReportWorkflowService implements IReportWorkflowService {
       throw new ForbiddenException('Only reviewers may deny reports')
     }
 
-    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+    // POSTPONED is deniable alongside IN_REVIEW: a report parked on postponed
+    // outliers blocks the company from submitting a replacement, so reviewers
+    // need a way to close it out when the applicant never resolves them.
+    const deniableStatuses: ReportStatusEnum[] = [
+      ReportStatusEnum.IN_REVIEW,
+      ReportStatusEnum.POSTPONED,
+    ]
+    if (!deniableStatuses.includes(context.reportStatus)) {
       throw new BadRequestException(
         `Cannot deny report with status ${context.reportStatus}`,
       )
@@ -182,7 +189,7 @@ export class ReportWorkflowService implements IReportWorkflowService {
 
     await this.reportEventService.emitStatusChanged(
       context.reportId,
-      ReportStatusEnum.IN_REVIEW,
+      context.reportStatus,
       ReportStatusEnum.DENIED,
       actorUserId,
       denialReason,

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -4118,8 +4118,7 @@
           "contactPhone": { "type": "string" },
           "equalityReportContent": {
             "type": "string",
-            "minLength": 1,
-            "description": "Narrative gender-equality plan. Persisted as `report.equality_report_content`."
+            "description": "Narrative gender-equality plan as base64-encoded HTML. Decoded server-side and persisted as `report.equality_report_content`."
           }
         },
         "required": [

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportStatusSelect.tsx
@@ -71,6 +71,10 @@ export const ReportStatusSelect = ({ reportId, status, disabled }: Props) => {
   const isLoading = assign.isPending || approve.isPending || deny.isPending
   const isInReview = status === ReportStatusEnum.IN_REVIEW
   const isSubmitted = status === ReportStatusEnum.SUBMITTED
+  // A POSTPONED report can be denied (to unblock the company when postponed
+  // outliers are never resolved) but not approved — approval requires the
+  // outlier explanations to be complete, which POSTPONED by definition lacks.
+  const canDeny = isInReview || status === ReportStatusEnum.POSTPONED
 
   return (
     <>
@@ -106,7 +110,7 @@ export const ReportStatusSelect = ({ reportId, status, disabled }: Props) => {
               fluid
               size="small"
               colorScheme="destructive"
-              disabled={disabled || isLoading || !isInReview}
+              disabled={disabled || isLoading || !canDeny}
               loading={deny.isPending}
               onClick={() => setIsModalOpen(true)}
             >

--- a/apps/directorate-of-equality-web/src/components/reports/CreateEqualityReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/CreateEqualityReportDrawer.tsx
@@ -18,7 +18,7 @@ import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 import { GenderEnum } from '../../gen/fetch/types.gen'
 import { overviewText, reportText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
-import { formatNationalId } from '../../lib/utils'
+import { formatNationalId, parseInflightConflictStatus } from '../../lib/utils'
 import { UtilityButton } from '../buttons/UtilityButton'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -71,7 +71,17 @@ export const CreateEqualityReportDrawer = () => {
       handleReset()
       setIsOpen(false)
     },
-    onError: () => toast.error(s.form.errorToast),
+    onError: (error) => {
+      // The API blocks a new submit while a sibling report is IN_REVIEW or
+      // POSTPONED (409). Tell the admin which status is blocking instead of
+      // the generic fallback so they know to resolve the in-flight report.
+      const conflictStatus = parseInflightConflictStatus(error.message)
+      if (conflictStatus) {
+        toast.error(t.inflightConflictToast.replace('{status}', conflictStatus))
+        return
+      }
+      toast.error(s.form.errorToast)
+    },
   })
 
   const handleReset = () => {

--- a/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
+++ b/apps/directorate-of-equality-web/src/components/reports/CreateSalaryReportDrawer.tsx
@@ -28,7 +28,11 @@ import {
 import { putWorkbookToPresignedUrl } from '../../lib/import-upload'
 import { overviewText, sharedText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
-import { formatNationalId, formatSalary } from '../../lib/utils'
+import {
+  formatNationalId,
+  formatSalary,
+  parseInflightConflictStatus,
+} from '../../lib/utils'
 import { UtilityButton } from '../buttons/UtilityButton'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
@@ -319,6 +323,15 @@ export const CreateSalaryReportDrawer = () => {
       // report" error as a clear message instead of the generic fallback.
       if (/equality report/i.test(message)) {
         toast.error(t.missingEqualityToast)
+        return
+      }
+
+      // The API blocks a new submit while a sibling report is IN_REVIEW or
+      // POSTPONED (409). Tell the admin which status is blocking instead of
+      // the generic fallback so they know to resolve the in-flight report.
+      const conflictStatus = parseInflightConflictStatus(message)
+      if (conflictStatus) {
+        toast.error(t.inflightConflictToast.replace('{status}', conflictStatus))
         return
       }
 

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -28,10 +28,12 @@ export function ReportSidebarContainer({
     ...trpc.reports.getById.queryOptions({ id: report.id }),
     initialData: report,
   })
-  const isDisabled =
-    data.status === 'POSTPONED' ||
-    data.status === 'DENIED' ||
-    data.status === 'APPROVED'
+  // Terminal statuses lock the sidebar entirely. POSTPONED only locks reviewer
+  // assignment (the API rejects assigning postponed reports) — the status
+  // actions stay live so a reviewer can deny a report whose postponed outliers
+  // are never resolved.
+  const isTerminal = data.status === 'DENIED' || data.status === 'APPROVED'
+  const isDisabled = isTerminal || data.status === 'POSTPONED'
 
   return (
     <ReportSidebar>
@@ -60,7 +62,7 @@ export function ReportSidebarContainer({
       <ReportStatusSelect
         reportId={data.id}
         status={data.status}
-        disabled={isDisabled}
+        disabled={isTerminal}
       />
       <Box paddingTop={1}>
         <Divider />

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -79,6 +79,8 @@ export const overviewText = {
     buttonLabel: 'Jafnréttisáætlun',
     heading: 'Ný jafnréttisáætlun',
     successToast: 'Skýrsla send inn',
+    inflightConflictToast:
+      'Fyrirtækið er nú þegar með jafnréttisáætlun í stöðunni „{status}“. Ljúktu afgreiðslu hennar áður en ný jafnréttisáætlun er send inn.',
   },
   createSalaryReport: {
     drawerLabel: 'Skrá launagreiningu',
@@ -128,6 +130,8 @@ export const overviewText = {
       'Ekki er hægt að senda inn launagreiningu fyrir þetta fyrirtæki fyrr en það er með samþykkta jafnréttisáætlun í gildi. Skráðu jafnréttisáætlun fyrst.',
     missingEqualityToast:
       'Fyrirtækið er ekki með samþykkta jafnréttisáætlun í gildi. Skráðu jafnréttisáætlun áður en launagreining er send inn.',
+    inflightConflictToast:
+      'Fyrirtækið er nú þegar með launagreiningu í stöðunni „{status}“. Ljúktu afgreiðslu hennar áður en ný launagreining er send inn.',
   },
 }
 

--- a/apps/directorate-of-equality-web/src/lib/utils.ts
+++ b/apps/directorate-of-equality-web/src/lib/utils.ts
@@ -1,4 +1,5 @@
 import { CompanySizeEnum } from '../gen/fetch'
+import { sharedText } from './text'
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 export const getBaseUrlFromServerSide = (includePrefix = false): string => {
@@ -42,6 +43,22 @@ export const EMPLOYEE_RANGES = [
 
 export const formatSalary = (v: number) =>
   new Intl.NumberFormat('is-IS').format(Math.round(v)).replaceAll(',', '.')
+
+/**
+ * Matches the API's 409 message "Company already has a <TYPE> report in
+ * status <STATUS> (providerId: ...). Resolve it before submitting another."
+ * and returns the localized status label, or null for any other message.
+ */
+export const parseInflightConflictStatus = (message: string): string | null => {
+  const match = message.match(/already has a \w+ report in status (\w+)/i)
+  if (!match) return null
+  const status = match[1].toUpperCase()
+  return (
+    sharedText.statusLabels[
+      status as keyof typeof sharedText.statusLabels
+    ] ?? status
+  )
+}
 
 export const COMPANY_SIZE_LABEL: Record<CompanySizeEnum, string> = {
   [CompanySizeEnum.UNKNOWN]: 'Óþekkt',


### PR DESCRIPTION
## feat(doe): surface in-flight report conflicts and allow denying postponed reports

### What

**1. Surface 409 conflict errors in the admin UI**

Submitting a report while the company already has one in `IN_REVIEW`/`POSTPONED` returns a 409 from the API, but the admin drawers only showed the generic "Villa við innsendingu" toast — the actual reason was only visible in Datadog.

- New `parseInflightConflictStatus()` helper matches the API's conflict message and maps the blocking status to its localized label
- Both `CreateSalaryReportDrawer` and `CreateEqualityReportDrawer` now show a specific toast, e.g. _"Fyrirtækið er nú þegar með launagreiningu í stöðunni „Frestað". Ljúktu afgreiðslu hennar áður en ný launagreining er send inn."_

**2. Allow admins to DENY a POSTPONED report**

A report stuck in `POSTPONED` (outliers never resolved) blocked the company from submitting a replacement, with no way for reviewers to close it out.

- API: `deny()` now accepts `POSTPONED` in addition to `IN_REVIEW`; the `STATUS_CHANGED` event records the actual from-status instead of hardcoded `IN_REVIEW`
- Web: the deny button is enabled for `POSTPONED` reports (approve remains `IN_REVIEW`-only — approval requires resolved outlier explanations). Reviewer assignment stays locked for postponed reports.
- Denying an island.is-sourced postponed report notifies the application system, same as a regular denial

### Testing

- New unit test: `POSTPONED → DENIED` transition with correct event from-status
- Extended status-rejection test to sweep `SUBMITTED`, `DRAFT`, `APPROVED`, `DENIED`
- All 28 report-workflow tests pass; typecheck + lint green on both projects
