### PR TITLE
feat(doe): Report communication status

### DIFF
--- a/apps/directorate-of-equality-api/db/migrations/m-20260710-report-communication-status.js
+++ b/apps/directorate-of-equality-api/db/migrations/m-20260710-report-communication-status.js
@@ -1,0 +1,68 @@
+'use strict'
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface) {
+    // ALTER TYPE ... ADD VALUE cannot run inside a transaction block.
+    //
+    // COMMUNICATION_OPENED / COMMUNICATION_CLOSED audit the reviewer opening
+    // and closing the communication thread with the applicant. The directional
+    // sub-states (AWAITING_RESPONSE <-> RESPONSE_RECEIVED) flip on comments and
+    // are not events; only the explicit open/close transitions are recorded.
+    await queryInterface.sequelize.query(`
+      ALTER TYPE report_event_type_enum ADD VALUE IF NOT EXISTS 'COMMUNICATION_OPENED';
+    `)
+    await queryInterface.sequelize.query(`
+      ALTER TYPE report_event_type_enum ADD VALUE IF NOT EXISTS 'COMMUNICATION_CLOSED';
+    `)
+
+    // report.communication_status — the persisted state of the applicant
+    // conversation. Replaces the previously derived waitingForAction boolean.
+    //   NOT_STARTED       never opened; the applicant cannot comment
+    //   OPEN              open, no message exchanged yet; the applicant may comment
+    //   AWAITING_RESPONSE open, reviewer messaged; ball in the applicant's court
+    //   RESPONSE_RECEIVED open, applicant has replied (overview "Beðið svara" icon)
+    //   CLOSED            reviewer closed the thread; the applicant cannot comment
+    // Existing rows backfill to NOT_STARTED via the column default.
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+      DO $$
+      BEGIN
+        IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'communication_status_enum') THEN
+          CREATE TYPE communication_status_enum AS ENUM (
+            'NOT_STARTED',
+            'OPEN',
+            'AWAITING_RESPONSE',
+            'RESPONSE_RECEIVED',
+            'CLOSED'
+          );
+        END IF;
+      END $$;
+
+      ALTER TABLE report
+        ADD COLUMN IF NOT EXISTS communication_status communication_status_enum
+        NOT NULL DEFAULT 'NOT_STARTED';
+
+      COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    // Postgres cannot drop an enum value, so the COMMUNICATION_OPENED /
+    // COMMUNICATION_CLOSED event-type values are left in place. Drop the column,
+    // its enum type, and any audit-only rows that depend on the new events.
+    await queryInterface.sequelize.query(`
+      BEGIN;
+
+      DELETE FROM report_event
+        WHERE event_type IN ('COMMUNICATION_OPENED', 'COMMUNICATION_CLOSED');
+
+      ALTER TABLE report DROP COLUMN IF EXISTS communication_status;
+
+      DROP TYPE IF EXISTS communication_status_enum;
+
+      COMMIT;
+    `)
+  },
+}

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.spec.ts
@@ -20,6 +20,7 @@ import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
 import { SalaryOutlierAnalysisMethodEnum } from '../report/lib/compensation-aggregates'
 import {
+  CommunicationStatusEnum,
   GenderEnum,
   ReportProviderEnum,
   ReportStatusEnum,
@@ -102,6 +103,7 @@ describe('ApplicationService', () => {
   let getResultByReportId: jest.Mock
   let emitEdited: jest.Mock
   let emitStatusChanged: jest.Mock
+  let emitCommunicationClosed: jest.Mock
 
   beforeEach(async () => {
     configGetByKey = jest.fn().mockResolvedValue({
@@ -134,6 +136,7 @@ describe('ApplicationService', () => {
     getResultByReportId = jest.fn()
     emitEdited = jest.fn().mockResolvedValue(undefined)
     emitStatusChanged = jest.fn().mockResolvedValue(undefined)
+    emitCommunicationClosed = jest.fn().mockResolvedValue(undefined)
 
     const module = await Test.createTestingModule({
       providers: [
@@ -170,6 +173,7 @@ describe('ApplicationService', () => {
           useValue: {
             emitEdited,
             emitStatusChanged,
+            emitCommunicationClosed,
           },
         },
         {
@@ -1051,6 +1055,33 @@ describe('ApplicationService', () => {
       )
     })
 
+    it('force-closes an open communication thread on withdraw', async () => {
+      reportFindOne.mockResolvedValueOnce(
+        makeReportRow({
+          id: REPORT_ID,
+          providerId: PROVIDER_ID,
+          type: ReportTypeEnum.SALARY,
+          status: ReportStatusEnum.IN_REVIEW,
+          communicationStatus: CommunicationStatusEnum.RESPONSE_RECEIVED,
+        }),
+      )
+      companyReportFindAll.mockResolvedValueOnce([
+        makeCompanyReportRow({ reportId: REPORT_ID }),
+      ])
+
+      await service.withdraw(PROVIDER_ID, COMPANY)
+
+      expect(reportUpdate).toHaveBeenCalledWith(
+        { communicationStatus: CommunicationStatusEnum.CLOSED },
+        { where: { id: REPORT_ID } },
+      )
+      expect(emitCommunicationClosed).toHaveBeenCalledWith(
+        REPORT_ID,
+        ReportStatusEnum.WITHDRAWN,
+        null,
+      )
+    })
+
     it('is an idempotent no-op when the report is already WITHDRAWN', async () => {
       reportFindOne.mockResolvedValueOnce(
         makeReportRow({
@@ -1567,6 +1598,7 @@ function makeReportRow(
     providerId: null,
     type: ReportTypeEnum.EQUALITY,
     status: ReportStatusEnum.SUBMITTED,
+    communicationStatus: CommunicationStatusEnum.NOT_STARTED,
     identifier: 'REPORT-001',
     equalityReportId: null,
     equalityReportContent: null,

--- a/apps/directorate-of-equality-api/src/modules/application/application.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/application/application.service.ts
@@ -24,6 +24,7 @@ import { CompanyReportModel } from '../company/models/company-report.model'
 import { IConfigService } from '../config/config.service.interface'
 import { EqualityReportSummaryDto } from '../report/dto/equality-report-summary.dto'
 import {
+  CommunicationStatusEnum,
   ReportProviderEnum,
   ReportStatusEnum,
   ReportTypeEnum,
@@ -437,6 +438,31 @@ export class ApplicationService implements IApplicationService {
       report.status,
       ReportStatusEnum.WITHDRAWN,
     )
+
+    // A withdrawn report accepts no further messages — force the conversation
+    // closed from any state. The audit event only fires when it was open (a
+    // never-opened thread flips NOT_STARTED -> CLOSED silently).
+    if (report.communicationStatus !== CommunicationStatusEnum.CLOSED) {
+      const wasOpen =
+        report.communicationStatus === CommunicationStatusEnum.OPEN ||
+        report.communicationStatus ===
+          CommunicationStatusEnum.AWAITING_RESPONSE ||
+        report.communicationStatus ===
+          CommunicationStatusEnum.RESPONSE_RECEIVED
+
+      await this.reportModel.update(
+        { communicationStatus: CommunicationStatusEnum.CLOSED },
+        { where: { id: report.id } },
+      )
+
+      if (wasOpen) {
+        await this.reportEventService.emitCommunicationClosed(
+          report.id,
+          ReportStatusEnum.WITHDRAWN,
+          null,
+        )
+      }
+    }
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.spec.ts
@@ -1,5 +1,10 @@
-import { BadRequestException } from '@nestjs/common'
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common'
 
+import { CommunicationStatusEnum } from '../report/models/report.model'
 import {
   type ReportResourceContext,
   ReportRoleEnum,
@@ -30,6 +35,22 @@ describe('ReportCommentService', () => {
   const mailService = {
     sendExternalCommentNotification: jest.fn(),
   }
+
+  // A loaded report record the service can read `communicationStatus` off and
+  // call `.update()` on to move the directional sub-state.
+  const makeReport = (
+    communicationStatus: CommunicationStatusEnum = CommunicationStatusEnum.NOT_STARTED,
+  ) => ({
+    id: 'report-1',
+    communicationStatus,
+    update: jest.fn(),
+  })
+
+  const makeComment = (id: string) => ({
+    id,
+    fromModel: () => ({ id }),
+    reload: jest.fn(),
+  })
 
   let service: ReportCommentService
   let reviewerContext: ReportResourceContext
@@ -62,14 +83,8 @@ describe('ReportCommentService', () => {
   })
 
   it('creates a reviewer comment with the current report status snapshot', async () => {
-    const commentDto = { id: 'comment-1' }
-    const commentRecord = {
-      id: 'comment-1',
-      fromModel: () => commentDto,
-      reload: jest.fn(),
-    }
-
-    reportCommentModel.create.mockResolvedValue(commentRecord)
+    reportModel.findByPk.mockResolvedValue(makeReport())
+    reportCommentModel.create.mockResolvedValue(makeComment('comment-1'))
 
     const dto: CreateReportCommentDto = {
       visibility: CommentVisibilityEnum.INTERNAL,
@@ -86,7 +101,7 @@ describe('ReportCommentService', () => {
       body: 'Needs follow-up',
       reportStatus: 'IN_REVIEW',
     })
-    expect(result).toEqual(commentDto)
+    expect(result).toEqual({ id: 'comment-1' })
   })
 
   it('filters company users to external comments only', async () => {
@@ -111,14 +126,10 @@ describe('ReportCommentService', () => {
     expect(result).toEqual([commentDto])
   })
 
-  it('creates a company comment when the guard has already limited visibility', async () => {
-    const commentDto = { id: 'comment-2' }
-
-    reportCommentModel.create.mockResolvedValue({
-      id: 'comment-2',
-      fromModel: () => commentDto,
-      reload: jest.fn(),
-    })
+  it('creates a company comment and flips the thread to RESPONSE_RECEIVED', async () => {
+    const report = makeReport(CommunicationStatusEnum.AWAITING_RESPONSE)
+    reportModel.findByPk.mockResolvedValue(report)
+    reportCommentModel.create.mockResolvedValue(makeComment('comment-2'))
 
     const result = await service.create(companyContext, {
       visibility: CommentVisibilityEnum.EXTERNAL,
@@ -133,7 +144,25 @@ describe('ReportCommentService', () => {
       body: 'Reply from company',
       reportStatus: 'SUBMITTED',
     })
-    expect(result).toEqual(commentDto)
+    expect(report.update).toHaveBeenCalledWith({
+      communicationStatus: CommunicationStatusEnum.RESPONSE_RECEIVED,
+    })
+    expect(result).toEqual({ id: 'comment-2' })
+  })
+
+  it('rejects a company comment when communication is not open', async () => {
+    reportModel.findByPk.mockResolvedValue(
+      makeReport(CommunicationStatusEnum.NOT_STARTED),
+    )
+
+    await expect(
+      service.create(companyContext, {
+        visibility: CommentVisibilityEnum.EXTERNAL,
+        body: 'Reply from company',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException)
+
+    expect(reportCommentModel.create).not.toHaveBeenCalled()
   })
 
   it('rejects internal comments from company users', async () => {
@@ -143,6 +172,25 @@ describe('ReportCommentService', () => {
         body: 'Internal note',
       }),
     ).rejects.toThrow('Company admins may only create external comments')
+
+    expect(reportCommentModel.create).not.toHaveBeenCalled()
+  })
+
+  it('rejects reviewer internal comments on a draft report', async () => {
+    reportModel.findByPk.mockResolvedValue(makeReport())
+
+    await expect(
+      service.create(
+        {
+          ...reviewerContext,
+          reportStatus: 'DRAFT' as never,
+        },
+        {
+          visibility: CommentVisibilityEnum.INTERNAL,
+          body: 'Internal note',
+        },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException)
 
     expect(reportCommentModel.create).not.toHaveBeenCalled()
   })
@@ -158,72 +206,89 @@ describe('ReportCommentService', () => {
     expect(reportCommentModel.create).not.toHaveBeenCalled()
   })
 
-  it('sends an external comment notification when a reviewer posts an external comment', async () => {
-    const commentRecord = {
-      id: 'comment-3',
-      fromModel: () => ({ id: 'comment-3' }),
-      reload: jest.fn(),
-    }
-    const reportRecord = { id: 'report-1' }
+  it('throws NotFound when the report cannot be loaded', async () => {
+    reportModel.findByPk.mockResolvedValue(null)
 
+    await expect(
+      service.create(reviewerContext, {
+        visibility: CommentVisibilityEnum.EXTERNAL,
+        body: 'External reviewer comment',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException)
+
+    expect(reportCommentModel.create).not.toHaveBeenCalled()
+  })
+
+  it('sends an external comment notification when a reviewer posts an external comment', async () => {
+    const report = makeReport(CommunicationStatusEnum.OPEN)
+    const commentRecord = makeComment('comment-3')
+
+    reportModel.findByPk.mockResolvedValue(report)
     reportCommentModel.create.mockResolvedValue(commentRecord)
-    reportModel.findByPk.mockResolvedValue(reportRecord)
 
     await service.create(reviewerContext, {
       visibility: CommentVisibilityEnum.EXTERNAL,
       body: 'Please update the report',
     })
 
-    expect(reportModel.findByPk).toHaveBeenCalledWith('report-1')
     expect(mailService.sendExternalCommentNotification).toHaveBeenCalledWith(
-      reportRecord,
+      report,
       commentRecord,
     )
   })
 
-  it('does not send mail for reviewer internal comments', async () => {
-    reportCommentModel.create.mockResolvedValue({
-      id: 'comment-4',
-      fromModel: () => ({ id: 'comment-4' }),
-      reload: jest.fn(),
+  it('rejects a reviewer external comment when communication is not open', async () => {
+    reportModel.findByPk.mockResolvedValue(
+      makeReport(CommunicationStatusEnum.NOT_STARTED),
+    )
+
+    await expect(
+      service.create(reviewerContext, {
+        visibility: CommentVisibilityEnum.EXTERNAL,
+        body: 'This should be blocked',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException)
+
+    expect(reportCommentModel.create).not.toHaveBeenCalled()
+  })
+
+  it('flips an open thread back to AWAITING_RESPONSE on a reviewer external reply', async () => {
+    const report = makeReport(CommunicationStatusEnum.RESPONSE_RECEIVED)
+    reportModel.findByPk.mockResolvedValue(report)
+    reportCommentModel.create.mockResolvedValue(makeComment('comment-3b'))
+
+    await service.create(reviewerContext, {
+      visibility: CommentVisibilityEnum.EXTERNAL,
+      body: 'Thanks, one more thing',
     })
+
+    expect(report.update).toHaveBeenCalledWith({
+      communicationStatus: CommunicationStatusEnum.AWAITING_RESPONSE,
+    })
+  })
+
+  it('flips OPEN to AWAITING_RESPONSE on a reviewer external comment', async () => {
+    const report = makeReport(CommunicationStatusEnum.OPEN)
+    reportModel.findByPk.mockResolvedValue(report)
+    reportCommentModel.create.mockResolvedValue(makeComment('comment-3c'))
+
+    await service.create(reviewerContext, {
+      visibility: CommentVisibilityEnum.EXTERNAL,
+      body: 'First message to the applicant',
+    })
+
+    expect(report.update).toHaveBeenCalledWith({
+      communicationStatus: CommunicationStatusEnum.AWAITING_RESPONSE,
+    })
+  })
+
+  it('does not send mail for reviewer internal comments', async () => {
+    reportModel.findByPk.mockResolvedValue(makeReport())
+    reportCommentModel.create.mockResolvedValue(makeComment('comment-4'))
 
     await service.create(reviewerContext, {
       visibility: CommentVisibilityEnum.INTERNAL,
       body: 'Internal reviewer note',
-    })
-
-    expect(reportModel.findByPk).not.toHaveBeenCalled()
-    expect(mailService.sendExternalCommentNotification).not.toHaveBeenCalled()
-  })
-
-  it('does not send mail for company-authored comments', async () => {
-    reportCommentModel.create.mockResolvedValue({
-      id: 'comment-5',
-      fromModel: () => ({ id: 'comment-5' }),
-      reload: jest.fn(),
-    })
-
-    await service.create(companyContext, {
-      visibility: CommentVisibilityEnum.EXTERNAL,
-      body: 'Reply from company',
-    })
-
-    expect(reportModel.findByPk).not.toHaveBeenCalled()
-    expect(mailService.sendExternalCommentNotification).not.toHaveBeenCalled()
-  })
-
-  it('skips mail when the report cannot be loaded', async () => {
-    reportCommentModel.create.mockResolvedValue({
-      id: 'comment-6',
-      fromModel: () => ({ id: 'comment-6' }),
-      reload: jest.fn(),
-    })
-    reportModel.findByPk.mockResolvedValue(null)
-
-    await service.create(reviewerContext, {
-      visibility: CommentVisibilityEnum.EXTERNAL,
-      body: 'External reviewer comment',
     })
 
     expect(mailService.sendExternalCommentNotification).not.toHaveBeenCalled()

--- a/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-comment/report-comment.service.ts
@@ -3,13 +3,18 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  NotFoundException,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
 import { Logger, LOGGER_PROVIDER } from '@dmr.is/logging'
 
 import { IDoeMailService } from '../mail/doe-mail.service.interface'
-import { ReportModel } from '../report/models/report.model'
+import {
+  CommunicationStatusEnum,
+  ReportModel,
+  ReportStatusEnum,
+} from '../report/models/report.model'
 import {
   type ReportResourceContext,
   ReportRoleEnum,
@@ -82,17 +87,46 @@ export class ReportCommentService implements IReportCommentService {
       )
     }
 
-    const visibility =
-      context.actor.kind !== ReportRoleEnum.REVIEWER
-        ? CommentVisibilityEnum.EXTERNAL
-        : dto.visibility
+    const isReviewer = context.actor.kind === ReportRoleEnum.REVIEWER
+
+    const visibility = isReviewer
+      ? dto.visibility
+      : CommentVisibilityEnum.EXTERNAL
+
+    const report = await this.reportModel.findByPk(context.reportId)
+    if (!report) {
+      throw new NotFoundException(`Report "${context.reportId}" not found`)
+    }
+
+    // Reviewers may leave internal notes on any report they can see, but never
+    // on a DRAFT — a draft has not been submitted, so there is nothing to
+    // review yet. (Drafts are not surfaced to reviewers today; this is a guard.)
+    if (
+      isReviewer &&
+      visibility === CommentVisibilityEnum.INTERNAL &&
+      context.reportStatus === ReportStatusEnum.DRAFT
+    ) {
+      throw new ForbiddenException(
+        'Internal comments are not allowed on a draft report',
+      )
+    }
+
+    const isOpen =
+      report.communicationStatus === CommunicationStatusEnum.OPEN ||
+      report.communicationStatus ===
+        CommunicationStatusEnum.AWAITING_RESPONSE ||
+      report.communicationStatus === CommunicationStatusEnum.RESPONSE_RECEIVED
+
+    // External comments (from either side) require an open thread. Opening is an
+    // explicit reviewer action — an external comment never opens a NOT_STARTED /
+    // CLOSED thread. Reviewer INTERNAL notes are exempt (see DRAFT guard above).
+    if (visibility === CommentVisibilityEnum.EXTERNAL && !isOpen) {
+      throw new ForbiddenException('Communication is not open on this report')
+    }
 
     const comment = await this.reportCommentModel.create({
       reportId: context.reportId,
-      authorKind:
-        context.actor.kind === ReportRoleEnum.REVIEWER
-          ? ReportRoleEnum.REVIEWER
-          : ReportRoleEnum.COMPANY,
+      authorKind: isReviewer ? ReportRoleEnum.REVIEWER : ReportRoleEnum.COMPANY,
       authorUserId:
         context.actor.kind === ReportRoleEnum.REVIEWER
           ? context.actor.userId
@@ -102,14 +136,29 @@ export class ReportCommentService implements IReportCommentService {
       reportStatus: context.reportStatus,
     })
 
-    if (
-      context.actor.kind === ReportRoleEnum.REVIEWER &&
-      visibility === CommentVisibilityEnum.EXTERNAL
-    ) {
-      const report = await this.reportModel.findByPk(context.reportId)
-      if (report) {
-        await this.mailService.sendExternalCommentNotification(report, comment)
+    // Move the directional sub-state. The applicant answering flips the thread
+    // to RESPONSE_RECEIVED (surfaces the overview "Beðið svara" icon); a reviewer
+    // reply on an already-open thread flips it back to AWAITING_RESPONSE. A
+    // reviewer comment does NOT open a NOT_STARTED / CLOSED thread — opening is
+    // an explicit action (see ReportWorkflowService.openCommunication).
+    if (!isReviewer) {
+      if (report.communicationStatus !== CommunicationStatusEnum.RESPONSE_RECEIVED) {
+        await report.update({
+          communicationStatus: CommunicationStatusEnum.RESPONSE_RECEIVED,
+        })
       }
+    } else if (
+      visibility === CommentVisibilityEnum.EXTERNAL &&
+      isOpen &&
+      report.communicationStatus !== CommunicationStatusEnum.AWAITING_RESPONSE
+    ) {
+      await report.update({
+        communicationStatus: CommunicationStatusEnum.AWAITING_RESPONSE,
+      })
+    }
+
+    if (isReviewer && visibility === CommentVisibilityEnum.EXTERNAL) {
+      await this.mailService.sendExternalCommentNotification(report, comment)
     }
 
     // Reload with the author so the response carries authorName (the freshly

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.interface.ts
@@ -26,6 +26,16 @@ export interface IReportEventService {
     companyId: string,
   ): Promise<void>
   emitWithdrawn(reportId: string, relatedReportId: string): Promise<void>
+  emitCommunicationOpened(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void>
+  emitCommunicationClosed(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void>
 }
 
 export const IReportEventService = Symbol('IReportEventService')

--- a/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-event/report-event.service.ts
@@ -152,4 +152,40 @@ export class ReportEventService implements IReportEventService {
       relatedReportId,
     })
   }
+
+  async emitCommunicationOpened(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void> {
+    this.logger.info(
+      `Emitting COMMUNICATION_OPENED event for report ${reportId}`,
+      { context: LOGGING_CONTEXT, reportId: reportId },
+    )
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.COMMUNICATION_OPENED,
+      actorUserId: actorUserId ?? null,
+      reportStatus,
+    })
+  }
+
+  async emitCommunicationClosed(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    actorUserId?: string | null,
+  ): Promise<void> {
+    this.logger.info(
+      `Emitting COMMUNICATION_CLOSED event for report ${reportId}`,
+      { context: LOGGING_CONTEXT, reportId: reportId },
+    )
+
+    await this.reportEventModel.create({
+      reportId,
+      eventType: ReportEventTypeEnum.COMMUNICATION_CLOSED,
+      actorUserId: actorUserId ?? null,
+      reportStatus,
+    })
+  }
 }

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/dto/send-to-edit.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/dto/send-to-edit.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString } from 'class-validator'
+
+import { ApiString } from '@dmr.is/decorators'
+
+/**
+ * Reviewer request to send a report back to the applicant for changes. The
+ * reason is posted as an external comment (visible to the applicant) in the
+ * same action, so the applicant always sees why they were asked to edit.
+ */
+export class SendToEditDto {
+  @ApiString()
+  @IsString()
+  @IsNotEmpty()
+  reason!: string
+}

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.controller.ts
@@ -17,6 +17,7 @@ import { ReportResourceGuard } from '../../core/guards/report-resource/report-re
 import { type ReportResourceContext } from '../report/types/report-resource-context'
 import { AssignReportDto } from './dto/assign-report.dto'
 import { DenyReportDto } from './dto/deny-report.dto'
+import { SendToEditDto } from './dto/send-to-edit.dto'
 import { IReportWorkflowService } from './report-workflow.service.interface'
 
 @Controller({
@@ -60,5 +61,33 @@ export class ReportWorkflowController {
     @CurrentReportResourceContext() context: ReportResourceContext,
   ): Promise<void> {
     return this.reportWorkflowService.approve(context)
+  }
+
+  @Post('send-to-edit')
+  @HttpCode(204)
+  @DoeResponse({ operationId: 'sendReportToEdit', include404: true })
+  async sendToEdit(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+    @Body() dto: SendToEditDto,
+  ): Promise<void> {
+    return this.reportWorkflowService.sendToEdit(context, dto)
+  }
+
+  @Post('communication/open')
+  @HttpCode(204)
+  @DoeResponse({ operationId: 'openReportCommunication', include404: true })
+  async openCommunication(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+  ): Promise<void> {
+    return this.reportWorkflowService.openCommunication(context)
+  }
+
+  @Post('communication/close')
+  @HttpCode(204)
+  @DoeResponse({ operationId: 'closeReportCommunication', include404: true })
+  async closeCommunication(
+    @CurrentReportResourceContext() context: ReportResourceContext,
+  ): Promise<void> {
+    return this.reportWorkflowService.closeCommunication(context)
   }
 }

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.core.module.ts
@@ -5,6 +5,7 @@ import { ApplicationSystemCoreModule } from '../application-system/application-s
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import { ReportModel } from '../report/models/report.model'
+import { ReportCommentCoreModule } from '../report-comment/report-comment.core.module'
 import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { ReportEventCoreModule } from '../report-event/report-event.core.module'
 import { UserModel } from '../user/models/user.model'
@@ -22,6 +23,7 @@ import { IReportWorkflowService } from './report-workflow.service.interface'
     ]),
     ReportEventCoreModule,
     ApplicationSystemCoreModule,
+    ReportCommentCoreModule,
   ],
   providers: [
     {

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.interface.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.interface.ts
@@ -1,11 +1,18 @@
 import { type ReportResourceContext } from '../report/types/report-resource-context'
 import { AssignReportDto } from './dto/assign-report.dto'
 import { DenyReportDto } from './dto/deny-report.dto'
+import { SendToEditDto } from './dto/send-to-edit.dto'
 
 export interface IReportWorkflowService {
   assign(context: ReportResourceContext, dto: AssignReportDto): Promise<void>
   deny(context: ReportResourceContext, dto: DenyReportDto): Promise<void>
   approve(context: ReportResourceContext): Promise<void>
+  sendToEdit(
+    context: ReportResourceContext,
+    dto: SendToEditDto,
+  ): Promise<void>
+  openCommunication(context: ReportResourceContext): Promise<void>
+  closeCommunication(context: ReportResourceContext): Promise<void>
 }
 
 export const IReportWorkflowService = Symbol('IReportWorkflowService')

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, ForbiddenException } from '@nestjs/common'
 
 import {
+  CommunicationStatusEnum,
   ReportProviderEnum,
   ReportStatusEnum,
   ReportTypeEnum,
@@ -26,6 +27,9 @@ describe('ReportWorkflowService', () => {
     emitUnassigned: jest.fn(),
     emitStatusChanged: jest.fn(),
     emitSuperseded: jest.fn(),
+    emitEdited: jest.fn(),
+    emitCommunicationOpened: jest.fn(),
+    emitCommunicationClosed: jest.fn(),
   }
 
   const applicationSystemService = {
@@ -34,10 +38,17 @@ describe('ReportWorkflowService', () => {
     notifyEdited: jest.fn(),
   }
 
+  const reportCommentService = {
+    getByReportId: jest.fn(),
+    create: jest.fn(),
+    delete: jest.fn(),
+  }
+
   const reportModel = {
     update: jest.fn(),
     findOne: jest.fn(),
     findAll: jest.fn(),
+    findByPk: jest.fn(),
   }
 
   const companyReportModel = {
@@ -79,6 +90,7 @@ describe('ReportWorkflowService', () => {
       logger as never,
       reportEventService as never,
       applicationSystemService as never,
+      reportCommentService as never,
       reportModel as never,
       companyReportModel as never,
       companyModel as never,
@@ -322,6 +334,70 @@ describe('ReportWorkflowService', () => {
       expect(applicationSystemService.notifyDenied).toHaveBeenCalledWith(
         'app-uuid-1',
       )
+    })
+
+    it('closes an open communication thread and emits COMMUNICATION_CLOSED', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.RESPONSE_RECEIVED,
+        update,
+      })
+
+      await service.deny(reviewerContext(ReportStatusEnum.IN_REVIEW), {
+        denialReason: 'reason',
+      })
+
+      expect(update).toHaveBeenCalledWith({
+        communicationStatus: CommunicationStatusEnum.CLOSED,
+      })
+      expect(
+        reportEventService.emitCommunicationClosed,
+      ).toHaveBeenCalledWith('report-1', ReportStatusEnum.DENIED, 'reviewer-1')
+    })
+
+    it('forces a never-opened thread to CLOSED without an audit event', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.NOT_STARTED,
+        update,
+      })
+
+      await service.deny(reviewerContext(ReportStatusEnum.IN_REVIEW), {
+        denialReason: 'reason',
+      })
+
+      expect(update).toHaveBeenCalledWith({
+        communicationStatus: CommunicationStatusEnum.CLOSED,
+      })
+      expect(
+        reportEventService.emitCommunicationClosed,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('leaves an already-CLOSED thread untouched', async () => {
+      reportModel.update.mockResolvedValue([1])
+      reportEventService.emitStatusChanged.mockResolvedValue(undefined)
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.CLOSED,
+        update,
+      })
+
+      await service.deny(reviewerContext(ReportStatusEnum.IN_REVIEW), {
+        denialReason: 'reason',
+      })
+
+      expect(update).not.toHaveBeenCalled()
+      expect(
+        reportEventService.emitCommunicationClosed,
+      ).not.toHaveBeenCalled()
     })
 
     it('does not notify the application system for non-island.is reports', async () => {
@@ -585,6 +661,82 @@ describe('ReportWorkflowService', () => {
         expect.objectContaining({ status: ReportStatusEnum.APPROVED }),
         { where: { id: 'report-1' } },
       )
+    })
+  })
+
+  describe('openCommunication', () => {
+    it('opens a NOT_STARTED thread to OPEN and emits COMMUNICATION_OPENED', async () => {
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.NOT_STARTED,
+        update,
+      })
+
+      await service.openCommunication(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(update).toHaveBeenCalledWith({
+        communicationStatus: CommunicationStatusEnum.OPEN,
+      })
+      expect(reportEventService.emitCommunicationOpened).toHaveBeenCalledWith(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        'reviewer-1',
+      )
+    })
+
+    it('is a no-op when already open', async () => {
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.RESPONSE_RECEIVED,
+        update,
+      })
+
+      await service.openCommunication(reviewerContext(ReportStatusEnum.IN_REVIEW))
+
+      expect(update).not.toHaveBeenCalled()
+      expect(reportEventService.emitCommunicationOpened).not.toHaveBeenCalled()
+    })
+
+    it('rejects when the report is not IN_REVIEW', async () => {
+      await expect(
+        service.openCommunication(reviewerContext(ReportStatusEnum.SUBMITTED)),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.findByPk).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('closeCommunication', () => {
+    it('closes an open thread and emits COMMUNICATION_CLOSED', async () => {
+      const update = jest.fn()
+      reportModel.findByPk.mockResolvedValue({
+        id: 'report-1',
+        communicationStatus: CommunicationStatusEnum.OPEN,
+        update,
+      })
+
+      await service.closeCommunication(
+        reviewerContext(ReportStatusEnum.IN_REVIEW),
+      )
+
+      expect(update).toHaveBeenCalledWith({
+        communicationStatus: CommunicationStatusEnum.CLOSED,
+      })
+      expect(reportEventService.emitCommunicationClosed).toHaveBeenCalledWith(
+        'report-1',
+        ReportStatusEnum.IN_REVIEW,
+        'reviewer-1',
+      )
+    })
+
+    it('rejects when the report is not IN_REVIEW', async () => {
+      await expect(
+        service.closeCommunication(reviewerContext(ReportStatusEnum.APPROVED)),
+      ).rejects.toBeInstanceOf(BadRequestException)
+
+      expect(reportModel.findByPk).not.toHaveBeenCalled()
     })
   })
 })

--- a/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report-workflow/report-workflow.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   Inject,
   Injectable,
+  NotFoundException,
 } from '@nestjs/common'
 import { InjectModel } from '@nestjs/sequelize'
 
@@ -12,6 +13,7 @@ import { IApplicationSystemService } from '../application-system/application-sys
 import { CompanyModel } from '../company/models/company.model'
 import { CompanyReportModel } from '../company/models/company-report.model'
 import {
+  CommunicationStatusEnum,
   ReportModel,
   ReportProviderEnum,
   ReportStatusEnum,
@@ -21,11 +23,14 @@ import {
   type ReportResourceContext,
   ReportRoleEnum,
 } from '../report/types/report-resource-context'
+import { CommentVisibilityEnum } from '../report-comment/models/report-comment.model'
+import { IReportCommentService } from '../report-comment/report-comment.service.interface'
 import { ReportOutlierGroupModel } from '../report-employee/models/report-outlier-group.model'
 import { IReportEventService } from '../report-event/report-event.service.interface'
 import { UserModel } from '../user/models/user.model'
 import { AssignReportDto } from './dto/assign-report.dto'
 import { DenyReportDto } from './dto/deny-report.dto'
+import { SendToEditDto } from './dto/send-to-edit.dto'
 import { IReportWorkflowService } from './report-workflow.service.interface'
 
 const LOGGING_CONTEXT = 'ReportWorkflowService'
@@ -38,6 +43,8 @@ export class ReportWorkflowService implements IReportWorkflowService {
     private readonly reportEventService: IReportEventService,
     @Inject(IApplicationSystemService)
     private readonly applicationSystemService: IApplicationSystemService,
+    @Inject(IReportCommentService)
+    private readonly reportCommentService: IReportCommentService,
     @InjectModel(ReportModel)
     private readonly reportModel: typeof ReportModel,
     @InjectModel(CompanyReportModel)
@@ -195,6 +202,12 @@ export class ReportWorkflowService implements IReportWorkflowService {
       denialReason,
     )
 
+    await this.forceCloseCommunication(
+      context.reportId,
+      ReportStatusEnum.DENIED,
+      actorUserId,
+    )
+
     await this.notifyApplicationSystem(context.reportId, ReportStatusEnum.DENIED)
   }
 
@@ -245,12 +258,256 @@ export class ReportWorkflowService implements IReportWorkflowService {
       actorUserId,
     )
 
+    await this.forceCloseCommunication(
+      context.reportId,
+      ReportStatusEnum.APPROVED,
+      actorUserId,
+    )
+
     await this.notifyApplicationSystem(
       context.reportId,
       ReportStatusEnum.APPROVED,
     )
 
     // TODO: insert public_report row as part of approval pipeline
+  }
+
+  /**
+   * Concluding a review (approve/deny) closes the applicant conversation: a
+   * finalized report accepts no further replies, so communication moves to
+   * CLOSED from ANY state. The audit event is only emitted when a thread was
+   * actually open — a report that was never in conversation flips
+   * NOT_STARTED -> CLOSED silently.
+   */
+  private async forceCloseCommunication(
+    reportId: string,
+    reportStatus: ReportStatusEnum,
+    actorUserId: string,
+  ): Promise<void> {
+    const report = await this.reportModel.findByPk(reportId, {
+      attributes: ['id', 'communicationStatus'],
+    })
+
+    if (
+      !report ||
+      report.communicationStatus === CommunicationStatusEnum.CLOSED
+    ) {
+      return
+    }
+
+    const wasOpen = this.isCommunicationOpen(report.communicationStatus)
+
+    await report.update({
+      communicationStatus: CommunicationStatusEnum.CLOSED,
+    })
+
+    if (wasOpen) {
+      await this.reportEventService.emitCommunicationClosed(
+        reportId,
+        reportStatus,
+        actorUserId,
+      )
+    }
+  }
+
+  /**
+   * Reviewer sends a report back to the applicant for changes. One atomic
+   * action:
+   *   1. the reason is posted as an EXTERNAL comment (so the applicant sees why),
+   *   2. the communication thread is opened (AWAITING_RESPONSE) so they can reply,
+   *   3. an EDITED event is logged, and
+   *   4. the island.is application is driven into edit state.
+   *
+   * The DoE report status is deliberately unchanged — "edited" is an island.is
+   * application-state + audit signal, not a report status. Requiring the reason
+   * up front is what makes this distinct from a bare external comment (which no
+   * longer moves the application on its own).
+   */
+  async sendToEdit(
+    context: ReportResourceContext,
+    dto: SendToEditDto,
+  ): Promise<void> {
+    this.logger.info(`Sending report ${context.reportId} to edit`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may send a report to edit')
+    }
+
+    const reason = dto.reason.trim()
+    if (!reason) {
+      throw new BadRequestException('Reason cannot be empty')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+      throw new BadRequestException(
+        `Cannot send report with status ${context.reportStatus} to edit`,
+      )
+    }
+
+    const report = await this.reportModel.findByPk(context.reportId)
+    if (!report) {
+      throw new NotFoundException(`Report "${context.reportId}" not found`)
+    }
+
+    const actorUserId = context.actor.userId
+    const wasOpen = this.isCommunicationOpen(report.communicationStatus)
+
+    // 1. Open the thread (and mark the reviewer's ball-in-applicant's-court
+    //    state) BEFORE posting — an external comment requires an open thread.
+    //    Only a genuine (closed/never-started -> open) transition is audited.
+    await report.update({
+      communicationStatus: CommunicationStatusEnum.AWAITING_RESPONSE,
+    })
+    if (!wasOpen) {
+      await this.reportEventService.emitCommunicationOpened(
+        context.reportId,
+        context.reportStatus,
+        actorUserId,
+      )
+    }
+
+    // 2. Post the reason as an external comment the applicant can read.
+    await this.reportCommentService.create(context, {
+      body: reason,
+      visibility: CommentVisibilityEnum.EXTERNAL,
+    })
+
+    // 3. Audit the edit request.
+    const companyId = await this.getParentCompanyId(context.reportId)
+    if (companyId) {
+      await this.reportEventService.emitEdited(
+        context.reportId,
+        context.reportStatus,
+        companyId,
+      )
+    }
+
+    // 4. Drive the island.is application into edit state (island.is reports only).
+    await this.notifyApplicationSystemEdited(context.reportId)
+  }
+
+  async openCommunication(context: ReportResourceContext): Promise<void> {
+    this.logger.info(`Opening communication for report ${context.reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may open communication')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+      throw new BadRequestException(
+        `Cannot change communication on a report with status ${context.reportStatus}`,
+      )
+    }
+
+    const report = await this.reportModel.findByPk(context.reportId)
+    if (!report) {
+      throw new NotFoundException(`Report "${context.reportId}" not found`)
+    }
+
+    // Already open — no-op (keep the existing OPEN / AWAITING_RESPONSE /
+    // RESPONSE_RECEIVED sub-state rather than resetting the direction).
+    if (this.isCommunicationOpen(report.communicationStatus)) {
+      return
+    }
+
+    // Opening exchanges no message yet — lands on OPEN. A reviewer message moves
+    // it to AWAITING_RESPONSE; an applicant reply to RESPONSE_RECEIVED.
+    await report.update({
+      communicationStatus: CommunicationStatusEnum.OPEN,
+    })
+    await this.reportEventService.emitCommunicationOpened(
+      context.reportId,
+      context.reportStatus,
+      context.actor.userId,
+    )
+  }
+
+  async closeCommunication(context: ReportResourceContext): Promise<void> {
+    this.logger.info(`Closing communication for report ${context.reportId}`, {
+      context: LOGGING_CONTEXT,
+    })
+
+    if (context.actor.kind !== ReportRoleEnum.REVIEWER) {
+      throw new ForbiddenException('Only reviewers may close communication')
+    }
+
+    if (context.reportStatus !== ReportStatusEnum.IN_REVIEW) {
+      throw new BadRequestException(
+        `Cannot change communication on a report with status ${context.reportStatus}`,
+      )
+    }
+
+    const report = await this.reportModel.findByPk(context.reportId)
+    if (!report) {
+      throw new NotFoundException(`Report "${context.reportId}" not found`)
+    }
+
+    // Nothing open to close (NOT_STARTED or already CLOSED) — no-op.
+    if (!this.isCommunicationOpen(report.communicationStatus)) {
+      return
+    }
+
+    await report.update({
+      communicationStatus: CommunicationStatusEnum.CLOSED,
+    })
+    await this.reportEventService.emitCommunicationClosed(
+      context.reportId,
+      context.reportStatus,
+      context.actor.userId,
+    )
+  }
+
+  private isCommunicationOpen(status: CommunicationStatusEnum): boolean {
+    return (
+      status === CommunicationStatusEnum.OPEN ||
+      status === CommunicationStatusEnum.AWAITING_RESPONSE ||
+      status === CommunicationStatusEnum.RESPONSE_RECEIVED
+    )
+  }
+
+  private async getParentCompanyId(reportId: string): Promise<string | null> {
+    const snapshot = await this.companyReportModel.findOne({
+      where: { reportId, parentCompanyId: null },
+      attributes: ['companyId'],
+    })
+    return snapshot?.companyId ?? null
+  }
+
+  /**
+   * Best-effort outbound notification that the applicant should edit and
+   * resubmit. Mirrors `notifyApplicationSystem` (approve/deny): only
+   * island.is-sourced reports have an application to update, and a failed
+   * outbound call must not fail the reviewer's action.
+   */
+  private async notifyApplicationSystemEdited(reportId: string): Promise<void> {
+    const report = await this.reportModel.findOne({
+      where: { id: reportId },
+      attributes: ['providerType', 'providerId'],
+    })
+
+    if (
+      report?.providerType !== ReportProviderEnum.ISLAND_IS ||
+      !report.providerId
+    ) {
+      return
+    }
+
+    try {
+      await this.applicationSystemService.notifyEdited(report.providerId)
+    } catch (error) {
+      this.logger.error(
+        `Failed to notify application system (edit) for report ${reportId}`,
+        {
+          context: LOGGING_CONTEXT,
+          applicationId: report.providerId,
+          message: error instanceof Error ? error.message : String(error),
+        },
+      )
+    }
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report-list-item.dto.ts
@@ -11,6 +11,7 @@ import {
 import { CompanySizeEnum } from '../../company/models/company.enums'
 import { UserDto } from '../../user/dto/user.dto'
 import {
+  CommunicationStatusEnum,
   GenderEnum,
   ReportStatusEnum,
   ReportTypeEnum,
@@ -34,6 +35,9 @@ export class ReportListItemDto {
 
   @ApiEnum(ReportStatusEnum, { enumName: 'ReportStatusEnum' })
   status!: ReportStatusEnum
+
+  @ApiEnum(CommunicationStatusEnum, { enumName: 'CommunicationStatusEnum' })
+  communicationStatus!: CommunicationStatusEnum
 
   @ApiOptionalString({ nullable: true })
   companyName!: string | null
@@ -73,12 +77,6 @@ export class ReportListItemDto {
       'Quarantine flag. `true` means the company is currently quarantined.',
   })
   companyQuarantined!: boolean
-
-  @ApiBoolean({
-    description:
-      'True when the most recent activity on this report is a comment authored by the company (application side). Resets to false whenever a reviewer action/event or reviewer comment supersedes it.',
-  })
-  waitingForAction!: boolean
 
   @ApiBoolean({
     description:

--- a/apps/directorate-of-equality-api/src/modules/report/dto/report.dto.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/dto/report.dto.ts
@@ -14,6 +14,7 @@ import {
 
 import { UserDto } from '../../user/dto/user.dto'
 import {
+  CommunicationStatusEnum,
   GenderEnum,
   ReportProviderEnum,
   ReportStatusEnum,
@@ -29,6 +30,9 @@ export class ReportDto {
 
   @ApiEnum(ReportStatusEnum, { enumName: 'ReportStatusEnum' })
   status!: ReportStatusEnum
+
+  @ApiEnum(CommunicationStatusEnum, { enumName: 'CommunicationStatusEnum' })
+  communicationStatus!: CommunicationStatusEnum
 
   @ApiOptionalString({ nullable: true })
   companyAdminName!: string | null

--- a/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report-event.model.ts
@@ -17,6 +17,11 @@ export enum ReportEventTypeEnum {
   EDITED = 'EDITED',
   WITHDRAWN = 'WITHDRAWN',
   SYSTEM_AUTO_REVIEW = 'SYSTEM_AUTO_REVIEW',
+  // Reviewer opened / closed the communication thread with the applicant. The
+  // AWAITING_RESPONSE <-> RESPONSE_RECEIVED sub-states flip on comments and are
+  // not events; only the explicit open/close transitions are recorded.
+  COMMUNICATION_OPENED = 'COMMUNICATION_OPENED',
+  COMMUNICATION_CLOSED = 'COMMUNICATION_CLOSED',
 }
 
 /**

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.enums.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.enums.ts
@@ -21,6 +21,30 @@ export enum ReportStatusEnum {
   WITHDRAWN = 'WITHDRAWN',
 }
 
+/**
+ * Persisted state of the reviewer <-> applicant communication thread on a
+ * report. Replaces the previously derived `waitingForAction` boolean.
+ *
+ *   NOT_STARTED       never opened; the applicant cannot comment.
+ *   OPEN              opened, no message exchanged yet; the applicant may comment.
+ *   AWAITING_RESPONSE open, reviewer messaged; ball in the applicant's court.
+ *   RESPONSE_RECEIVED open, the applicant has replied (surfaces the overview
+ *                     "Beðið svara" icon; ball in the reviewer's court).
+ *   CLOSED            reviewer closed the thread; the applicant cannot comment.
+ *
+ * OPEN / AWAITING_RESPONSE / RESPONSE_RECEIVED are the "open" set — the
+ * applicant may comment and reviewer/applicant comments flip the direction.
+ * NOT_STARTED / CLOSED gate the applicant out. Opening requires the report to
+ * be IN_REVIEW; withdraw/approve/deny force CLOSED.
+ */
+export enum CommunicationStatusEnum {
+  NOT_STARTED = 'NOT_STARTED',
+  OPEN = 'OPEN',
+  AWAITING_RESPONSE = 'AWAITING_RESPONSE',
+  RESPONSE_RECEIVED = 'RESPONSE_RECEIVED',
+  CLOSED = 'CLOSED',
+}
+
 export enum GenderEnum {
   MALE = 'MALE',
   FEMALE = 'FEMALE',

--- a/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/models/report.model.ts
@@ -20,6 +20,7 @@ import type { EqualityReportDto } from '../dto/equality-report.dto'
 import type { ReportDto } from '../dto/report.dto'
 import { ReportListItemDto } from '../dto/report-list-item.dto'
 import {
+  CommunicationStatusEnum,
   GenderEnum,
   ReportProviderEnum,
   ReportStatusEnum,
@@ -29,6 +30,7 @@ import {
 // Re-export for backwards compatibility — many callers import these enums
 // from `report.model.ts` directly. New code should prefer `report.enums.ts`.
 export {
+  CommunicationStatusEnum,
   GenderEnum,
   ReportProviderEnum,
   ReportStatusEnum,
@@ -38,6 +40,7 @@ export {
 type ReportAttributes = {
   type: ReportTypeEnum
   status: ReportStatusEnum
+  communicationStatus: CommunicationStatusEnum
 
   companyAdminName: string | null
   companyAdminEmail: string | null
@@ -69,6 +72,7 @@ type ReportAttributes = {
 type ReportCreateAttributes = {
   type: ReportTypeEnum
   status?: ReportStatusEnum
+  communicationStatus?: CommunicationStatusEnum
 
   companyAdminName?: string | null
   companyAdminEmail?: string | null
@@ -195,6 +199,14 @@ export class ReportModel extends MutableModel<
     defaultValue: ReportStatusEnum.DRAFT,
   })
   status!: ReportStatusEnum
+
+  @Column({
+    type: DataType.ENUM(...Object.values(CommunicationStatusEnum)),
+    allowNull: false,
+    defaultValue: CommunicationStatusEnum.NOT_STARTED,
+    field: 'communication_status',
+  })
+  communicationStatus!: CommunicationStatusEnum
 
   @Column({ type: DataType.TEXT, allowNull: true, field: 'company_admin_name' })
   companyAdminName!: string | null
@@ -345,6 +357,7 @@ export class ReportModel extends MutableModel<
       id: model.id,
       type: model.type,
       status: model.status,
+      communicationStatus: model.communicationStatus,
       companyAdminName: model.companyAdminName,
       companyAdminEmail: model.companyAdminEmail,
       companyAdminGender: model.companyAdminGender,
@@ -405,7 +418,6 @@ export class ReportModel extends MutableModel<
 
   static fromModelToListItem(
     model: ReportModel,
-    waitingForAction = false,
     includesImprovementPlan = false,
   ): ReportListItemDto {
     return {
@@ -413,6 +425,7 @@ export class ReportModel extends MutableModel<
       identifier: model.identifier,
       type: model.type,
       status: model.status,
+      communicationStatus: model.communicationStatus,
       companyName: model.companyReport?.name ?? null,
       companyNationalId: model.companyReport?.nationalId ?? null,
       companyIsatCategory: model.companyReport?.isatCategory ?? null,
@@ -424,7 +437,6 @@ export class ReportModel extends MutableModel<
       reviewer: model.reviewer ? UserModel.fromModel(model.reviewer) : null,
       companyFinesStarted: model.companyReport?.company?.finesStarted ?? false,
       companyQuarantined: model.companyReport?.company?.quarantined ?? false,
-      waitingForAction,
       includesImprovementPlan,
       createdAt: model.createdAt,
       correctionDeadline: model.correctionDeadline,
@@ -436,15 +448,8 @@ export class ReportModel extends MutableModel<
     return ReportModel.fromModelToEqualityReport(this)
   }
 
-  fromModelToListItem(
-    waitingForAction = false,
-    includesImprovementPlan = false,
-  ): ReportListItemDto {
-    return ReportModel.fromModelToListItem(
-      this,
-      waitingForAction,
-      includesImprovementPlan,
-    )
+  fromModelToListItem(includesImprovementPlan = false): ReportListItemDto {
+    return ReportModel.fromModelToListItem(this, includesImprovementPlan)
   }
 
   fromModel(): ReportDto {

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.spec.ts
@@ -10,7 +10,11 @@ import {
   type GetReportsQueryDto,
   SortDirectionEnum,
 } from './dto/get-reports.query.dto'
-import { ReportStatusEnum, ReportTypeEnum } from './models/report.enums'
+import {
+  CommunicationStatusEnum,
+  ReportStatusEnum,
+  ReportTypeEnum,
+} from './models/report.enums'
 import type { ReportModel } from './models/report.model'
 import { ReportService } from './report.service'
 
@@ -33,6 +37,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
     identifier: 'ABC-001',
     type: ReportTypeEnum.SALARY,
     status: ReportStatusEnum.SUBMITTED,
+    communicationStatus: CommunicationStatusEnum.NOT_STARTED,
     createdAt: new Date('2026-01-01T00:00:00.000Z'),
     correctionDeadline: null,
     validUntil: null,
@@ -52,10 +57,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
   // Instance methods the service calls — projections the real model
   // provides via BaseModel. Tests only need something that returns a
   // plain object shape-compatible with the DTO.
-  row.fromModelToListItem = (
-    waitingForAction = false,
-    includesImprovementPlan = false,
-  ) => {
+  row.fromModelToListItem = (includesImprovementPlan = false) => {
     const companyReport = row.companyReport as
       | {
           name?: string
@@ -69,6 +71,7 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
       identifier: row.identifier,
       type: row.type,
       status: row.status,
+      communicationStatus: row.communicationStatus,
       companyName: companyReport?.name ?? null,
       companyNationalId: companyReport?.nationalId ?? null,
       companyIsatCategory: companyReport?.isatCategory ?? null,
@@ -78,7 +81,6 @@ const makeReportRow = (overrides: Partial<Record<string, unknown>> = {}) => {
       companyAdminEmail: row.companyAdminEmail,
       companyAdminGender: row.companyAdminGender,
       reviewer: row.reviewer,
-      waitingForAction,
       includesImprovementPlan,
       createdAt: row.createdAt,
       correctionDeadline: row.correctionDeadline,
@@ -141,9 +143,6 @@ const makeService = () => {
   const companyReportModel = {
     findAll: companyReportFindAll,
   } as unknown as typeof import('../company/models/company-report.model').CompanyReportModel
-  const reportCommentModel = {
-    findAll: jest.fn().mockResolvedValue([]),
-  } as unknown as typeof import('../report-comment/models/report-comment.model').ReportCommentModel
 
   const outlierGroupFindAll = jest.fn().mockResolvedValue([])
   const reportOutlierGroupModel = {
@@ -157,7 +156,6 @@ const makeService = () => {
     reportRoleResultModel,
     reportEmployeeOutlierModel,
     companyReportModel,
-    reportCommentModel,
     reportOutlierGroupModel,
   )
   return {

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -67,7 +67,6 @@ import {
 import { ReportStatusEnum, ReportTypeEnum } from './models/report.enums'
 import { ReportModel } from './models/report.model'
 import { ReportEventModel } from './models/report-event.model'
-import { ReportRoleEnum } from './types/report-resource-context'
 import {
   buildFreeTextWhere,
   buildImprovementPlanWhere,
@@ -96,8 +95,6 @@ export class ReportService implements IReportService {
     private readonly reportEmployeeOutlierModel: typeof ReportEmployeeOutlierModel,
     @InjectModel(CompanyReportModel)
     private readonly companyReportModel: typeof CompanyReportModel,
-    @InjectModel(ReportCommentModel)
-    private readonly reportCommentModel: typeof ReportCommentModel,
     @InjectModel(ReportOutlierGroupModel)
     private readonly reportOutlierGroupModel: typeof ReportOutlierGroupModel,
   ) {}
@@ -171,15 +168,10 @@ export class ReportService implements IReportService {
     ])
 
     const pageIds = rows.map((r) => r.id)
-    const [waitingMap, improvementPlanMap] = await Promise.all([
-      this.computeWaitingForAction(pageIds),
-      this.computeIncludesImprovementPlan(pageIds),
-    ])
+    const improvementPlanMap =
+      await this.computeIncludesImprovementPlan(pageIds)
     const reports = rows.map((r) =>
-      r.fromModelToListItem(
-        waitingMap.get(r.id) ?? false,
-        improvementPlanMap.get(r.id) ?? false,
-      ),
+      r.fromModelToListItem(improvementPlanMap.get(r.id) ?? false),
     )
     const paging = generatePaging(reports, query.page, query.pageSize, count)
 
@@ -297,62 +289,6 @@ export class ReportService implements IReportService {
       companyQuarantined: report.companyReport.company?.quarantined ?? false,
       includesImprovementPlan,
     }
-  }
-
-  /**
-   * Per-page boolean: true when the most recent timeline item (event OR
-   * comment, whichever is newer) is a COMPANY-authored comment — i.e. the
-   * applicant has said something and no reviewer action/comment has come
-   * after it. Computed via two MAX(createdAt) GROUP BY queries scoped to the
-   * page's report IDs, then compared in JS — bounded by pageSize, no N+1.
-   */
-  private async computeWaitingForAction(
-    reportIds: string[],
-  ): Promise<Map<string, boolean>> {
-    const result = new Map<string, boolean>()
-    if (reportIds.length === 0) return result
-
-    const [latestEvents, latestCompanyComments] = await Promise.all([
-      this.reportEventModel.findAll({
-        where: { reportId: { [Op.in]: reportIds } },
-        attributes: ['reportId', [fn('MAX', col('created_at')), 'latestAt']],
-        group: ['reportId'],
-        raw: true,
-      }) as unknown as Promise<{ reportId: string; latestAt: Date }[]>,
-      this.reportCommentModel.findAll({
-        where: {
-          reportId: { [Op.in]: reportIds },
-          authorKind: ReportRoleEnum.COMPANY,
-        },
-        attributes: ['reportId', [fn('MAX', col('created_at')), 'latestAt']],
-        group: ['reportId'],
-        raw: true,
-      }) as unknown as Promise<{ reportId: string; latestAt: Date }[]>,
-    ])
-
-    const eventMap = new Map(
-      latestEvents.map((e) => [e.reportId, new Date(e.latestAt).getTime()]),
-    )
-    const commentMap = new Map(
-      latestCompanyComments.map((c) => [
-        c.reportId,
-        new Date(c.latestAt).getTime(),
-      ]),
-    )
-
-    for (const reportId of reportIds) {
-      const eventAt = eventMap.get(reportId)
-      const commentAt = commentMap.get(reportId)
-      if (commentAt === undefined) {
-        result.set(reportId, false)
-      } else if (eventAt === undefined) {
-        result.set(reportId, true)
-      } else {
-        result.set(reportId, commentAt > eventAt)
-      }
-    }
-
-    return result
   }
 
   /**

--- a/apps/directorate-of-equality-api/src/modules/report/report.service.ts
+++ b/apps/directorate-of-equality-api/src/modules/report/report.service.ts
@@ -213,15 +213,10 @@ export class ReportService implements IReportService {
       })
 
     const pageIds = rows.map((r) => r.id)
-    const [waitingMap, improvementPlanMap] = await Promise.all([
-      this.computeWaitingForAction(pageIds),
-      this.computeIncludesImprovementPlan(pageIds),
-    ])
+    const improvementPlanMap =
+      await this.computeIncludesImprovementPlan(pageIds)
     const reports = rows.map((r) =>
-      r.fromModelToListItem(
-        waitingMap.get(r.id) ?? false,
-        improvementPlanMap.get(r.id) ?? false,
-      ),
+      r.fromModelToListItem(improvementPlanMap.get(r.id) ?? false),
     )
     const paging = generatePaging(reports, query.page, query.pageSize, count)
 

--- a/apps/directorate-of-equality-web/clientConfig.json
+++ b/apps/directorate-of-equality-web/clientConfig.json
@@ -3277,6 +3277,191 @@
         "tags": ["Report Workflow"]
       }
     },
+    "/api/v1/reports/{reportId}/send-to-edit": {
+      "post": {
+        "operationId": "sendReportToEdit",
+        "parameters": [
+          {
+            "name": "reportId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SendToEditDto" }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Report Workflow"]
+      }
+    },
+    "/api/v1/reports/{reportId}/communication/open": {
+      "post": {
+        "operationId": "openReportCommunication",
+        "parameters": [
+          {
+            "name": "reportId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Report Workflow"]
+      }
+    },
+    "/api/v1/reports/{reportId}/communication/close": {
+      "post": {
+        "operationId": "closeReportCommunication",
+        "parameters": [
+          {
+            "name": "reportId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Report Workflow"]
+      }
+    },
     "/api/v1/reports/{reportId}/statistics/base-salary-by-gender-and-score-all": {
       "get": {
         "description": "Adjusted base salary (baseSalary / workRatio) by gender and total score (all criteria). Returns scatter data points, a linear regression line, score-bucket averages with wage gap, and overall totals.",
@@ -4935,6 +5120,16 @@
         ]
       },
       "SortDirectionEnum": { "type": "string", "enum": ["asc", "desc"] },
+      "CommunicationStatusEnum": {
+        "type": "string",
+        "enum": [
+          "NOT_STARTED",
+          "OPEN",
+          "AWAITING_RESPONSE",
+          "RESPONSE_RECEIVED",
+          "CLOSED"
+        ]
+      },
       "GenderEnum": { "type": "string", "enum": ["MALE", "FEMALE", "NEUTRAL"] },
       "ReportListItemDto": {
         "type": "object",
@@ -4946,6 +5141,11 @@
           },
           "status": {
             "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
+          },
+          "communicationStatus": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CommunicationStatusEnum" }
+            ]
           },
           "companyName": { "type": "string", "nullable": true },
           "companyNationalId": { "type": "string", "nullable": true },
@@ -4971,10 +5171,6 @@
           "companyQuarantined": {
             "type": "boolean",
             "description": "Quarantine flag. `true` means the company is currently quarantined."
-          },
-          "waitingForAction": {
-            "type": "boolean",
-            "description": "True when the most recent activity on this report is a comment authored by the company (application side). Resets to false whenever a reviewer action/event or reviewer comment supersedes it."
           },
           "includesImprovementPlan": {
             "type": "boolean",
@@ -5003,9 +5199,9 @@
           "id",
           "type",
           "status",
+          "communicationStatus",
           "companyFinesStarted",
           "companyQuarantined",
-          "waitingForAction",
           "includesImprovementPlan"
         ]
       },
@@ -5126,7 +5322,9 @@
           "SUPERSEDED",
           "EDITED",
           "WITHDRAWN",
-          "SYSTEM_AUTO_REVIEW"
+          "SYSTEM_AUTO_REVIEW",
+          "COMMUNICATION_OPENED",
+          "COMMUNICATION_CLOSED"
         ]
       },
       "AutoReviewDecisionEnum": {
@@ -5475,6 +5673,11 @@
           "status": {
             "allOf": [{ "$ref": "#/components/schemas/ReportStatusEnum" }]
           },
+          "communicationStatus": {
+            "allOf": [
+              { "$ref": "#/components/schemas/CommunicationStatusEnum" }
+            ]
+          },
           "companyAdminName": { "type": "string", "nullable": true },
           "companyAdminEmail": { "type": "string", "nullable": true },
           "companyAdminGender": {
@@ -5575,6 +5778,7 @@
           "id",
           "type",
           "status",
+          "communicationStatus",
           "importedFromExcel",
           "createdAt",
           "company",
@@ -5721,6 +5925,11 @@
         "type": "object",
         "properties": { "denialReason": { "type": "string" } },
         "required": ["denialReason"]
+      },
+      "SendToEditDto": {
+        "type": "object",
+        "properties": { "reason": { "type": "string" } },
+        "required": ["reason"]
       },
       "GenderWageGapDto": {
         "type": "object",

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportCommunicationControl.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportCommunicationControl.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import React from 'react'
+
+import { Box } from '@dmr.is/ui/components/island-is/Box'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Input } from '@dmr.is/ui/components/island-is/Input'
+import { Stack } from '@dmr.is/ui/components/island-is/Stack'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
+
+import { CommunicationStatusEnum } from '../../../gen/fetch'
+import { CommunicationStatusTranslatedEnum } from '../../../lib/constants'
+import { reportText } from '../../../lib/text'
+import { useTRPC } from '../../../lib/trpc/client/trpc'
+import { ReportSendToEditModal } from './ReportSendToEditModal'
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+const t = reportText.communicationControl
+
+type Props = {
+  reportId: string
+  communicationStatus: CommunicationStatusEnum
+  // Communication is only mutable while the report is IN_REVIEW.
+  disabled?: boolean
+}
+
+export const ReportCommunicationControl = ({
+  reportId,
+  communicationStatus,
+  disabled,
+}: Props) => {
+  const trpc = useTRPC()
+  const queryClient = useQueryClient()
+  const [isModalOpen, setIsModalOpen] = React.useState(false)
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({
+      queryKey: trpc.reports.getById.queryKey({ id: reportId }),
+    })
+    queryClient.invalidateQueries({
+      queryKey: trpc.reports.list.queryKey(),
+    })
+  }
+
+  const onSuccess = () => toast.success(t.successToast)
+  const onError = () => toast.error(t.errorToast)
+
+  const openCommunication = useMutation({
+    ...trpc.reportWorkflow.openCommunication.mutationOptions(),
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+    },
+    onError,
+  })
+
+  const closeCommunication = useMutation({
+    ...trpc.reportWorkflow.closeCommunication.mutationOptions(),
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+    },
+    onError,
+  })
+
+  const sendToEdit = useMutation({
+    ...trpc.reportWorkflow.sendToEdit.mutationOptions(),
+    onSuccess: () => {
+      invalidate()
+      onSuccess()
+      setIsModalOpen(false)
+    },
+    onError,
+  })
+
+  const isLoading =
+    openCommunication.isPending ||
+    closeCommunication.isPending ||
+    sendToEdit.isPending
+
+  const isOpen =
+    communicationStatus === CommunicationStatusEnum.OPEN ||
+    communicationStatus === CommunicationStatusEnum.AWAITING_RESPONSE ||
+    communicationStatus === CommunicationStatusEnum.RESPONSE_RECEIVED
+
+  return (
+    <>
+      <Stack space={2}>
+        <Box background="white" borderRadius="large">
+          <Input
+            name="report-communication-status"
+            readOnly
+            value={CommunicationStatusTranslatedEnum[communicationStatus]}
+            size="sm"
+            label={t.label}
+          />
+        </Box>
+
+        <Box display="flex" columnGap={2}>
+          <Box style={{ flex: 1 }}>
+            <Button
+              fluid
+              size="small"
+              variant="ghost"
+              disabled={disabled || isLoading}
+              loading={
+                openCommunication.isPending || closeCommunication.isPending
+              }
+              onClick={() =>
+                isOpen
+                  ? closeCommunication.mutate({ reportId })
+                  : openCommunication.mutate({ reportId })
+              }
+            >
+              <Text variant="small" fontWeight="semiBold">
+                {isOpen ? t.closeButton : t.openButton}
+              </Text>
+            </Button>
+          </Box>
+          <Box style={{ flex: 1 }}>
+            <Button
+              fluid
+              size="small"
+              disabled={disabled || isLoading}
+              loading={sendToEdit.isPending}
+              onClick={() => setIsModalOpen(true)}
+            >
+              <Text color="white" variant="small" fontWeight="semiBold">
+                {t.sendToEditButton}
+              </Text>
+            </Button>
+          </Box>
+        </Box>
+      </Stack>
+
+      <ReportSendToEditModal
+        visible={isModalOpen}
+        isLoading={sendToEdit.isPending}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={(reason) => sendToEdit.mutate({ reportId, reason })}
+      />
+    </>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportSendToEditModal.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-sidebar/ReportSendToEditModal.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import React from 'react'
+
+import { AlertMessage } from '@dmr.is/ui/components/island-is/AlertMessage'
+import { Button } from '@dmr.is/ui/components/island-is/Button'
+import { Input } from '@dmr.is/ui/components/island-is/Input'
+import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { Modal } from '@dmr.is/ui/components/Modal/Modal'
+
+import { reportText } from '../../../lib/text'
+import * as styles from './ReportDenialModal.css'
+
+const t = reportText.sendToEditModal
+
+interface ReportSendToEditModalProps {
+  visible: boolean
+  isLoading?: boolean
+  onClose: () => void
+  onSubmit: (reason: string) => void
+}
+
+export const ReportSendToEditModal = ({
+  visible,
+  isLoading = false,
+  onClose,
+  onSubmit,
+}: ReportSendToEditModalProps) => {
+  const [reason, setReason] = React.useState('')
+
+  return (
+    <Modal
+      baseId="report-send-to-edit-modal"
+      onVisibilityChange={(v) => {
+        if (!v) onClose()
+      }}
+      isVisible={visible}
+    >
+      <form onSubmit={(e) => e.preventDefault()}>
+        <div className={styles.modalContent}>
+          <Text variant="h3">{t.heading}</Text>
+          <Text>{t.description}</Text>
+          <AlertMessage
+            type="warning"
+            title={t.warningTitle}
+            message={t.warningMessage}
+          />
+          <Input
+            name="send-to-edit-reason-input"
+            label={t.reasonLabel}
+            size="sm"
+            textarea
+            rows={4}
+            backgroundColor="blue"
+            value={reason}
+            disabled={isLoading}
+            onChange={(val) => setReason(val.target.value)}
+          />
+          <Button
+            fluid
+            size="default"
+            type="submit"
+            onClick={() => onSubmit(reason.trim())}
+            disabled={reason.trim().length === 0 || isLoading}
+            loading={isLoading}
+          >
+            {t.submitButton}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/CommentInputForm.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/CommentInputForm.tsx
@@ -10,6 +10,7 @@ import { reportText } from '../../../../lib/text'
 type Props = {
   body: string
   isExternal: boolean
+  canSendExternal?: boolean
   isPending: boolean
   onBodyChange: (value: string) => void
   onExternalChange: (value: boolean) => void
@@ -19,6 +20,7 @@ type Props = {
 export function CommentInputForm({
   body,
   isExternal,
+  canSendExternal = false,
   isPending,
   onBodyChange,
   onExternalChange,
@@ -38,6 +40,10 @@ export function CommentInputForm({
       <Checkbox
         label={reportText.comments.sendToApplicant}
         checked={isExternal}
+        disabled={!canSendExternal}
+        tooltip={
+          canSendExternal ? undefined : reportText.comments.externalDisabledHint
+        }
         onChange={(e) => onExternalChange(e.target.checked)}
       />
       <Box alignSelf="flexEnd">

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/CommentsForm.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/CommentsForm.tsx
@@ -13,6 +13,7 @@ type Props = {
   companyName?: string | null
   currentUserId?: string | null
   readonly?: boolean
+  canSendExternal?: boolean
   body: string
   isExternal: boolean
   isPending: boolean
@@ -27,6 +28,7 @@ export const CommentsForm = ({
   companyName,
   currentUserId,
   readonly = false,
+  canSendExternal = false,
   body,
   isExternal,
   isPending,
@@ -59,6 +61,7 @@ export const CommentsForm = ({
             <CommentInputForm
               body={body}
               isExternal={isExternal}
+              canSendExternal={canSendExternal}
               isPending={isPending}
               onBodyChange={onBodyChange}
               onExternalChange={onExternalChange}

--- a/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/timeline/timelineHelpers.tsx
+++ b/apps/directorate-of-equality-web/src/components/report/report-tabs/comments/timeline/timelineHelpers.tsx
@@ -174,6 +174,33 @@ export function timelineEntryText(
     )
   }
 
+  if (eventType === ReportEventTypeEnum.EDITED) {
+    return (
+      <>
+        {actorName && <Bold>{actorName} </Bold>}
+        {reportText.timeline.edited}
+      </>
+    )
+  }
+
+  if (eventType === ReportEventTypeEnum.COMMUNICATION_OPENED) {
+    return (
+      <>
+        {actorName && <Bold>{actorName} </Bold>}
+        {reportText.timeline.communicationOpened}
+      </>
+    )
+  }
+
+  if (eventType === ReportEventTypeEnum.COMMUNICATION_CLOSED) {
+    return (
+      <>
+        {actorName && <Bold>{actorName} </Bold>}
+        {reportText.timeline.communicationClosed}
+      </>
+    )
+  }
+
   // Company-specific event types are cast as `never` in the adapter but
   // arrive as plain strings at runtime.
   const eventTypeStr = eventType as unknown as string

--- a/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/CommentsContainer.tsx
@@ -8,6 +8,7 @@ import { toast } from '@dmr.is/ui/components/island-is/ToastContainer'
 import { CommentsForm } from '../../components/report/report-tabs/comments/CommentsForm'
 import {
   CommentVisibilityEnum,
+  CommunicationStatusEnum,
   ReportStatusEnum,
 } from '../../gen/fetch/types.gen'
 import { reportText } from '../../lib/text'
@@ -54,14 +55,26 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
     onError: () => toast.error(reportText.comments.deleteError),
   })
 
+  // Internal notes are allowed on any report a reviewer can open (everything
+  // but a draft). Messaging the applicant (external) is only possible while the
+  // communication thread is open — opening/closing is an explicit action in the
+  // sidebar, no longer a side effect of commenting.
+  const isDraft = report?.status === ReportStatusEnum.DRAFT
+  const canSendExternal =
+    report?.communicationStatus === CommunicationStatusEnum.OPEN ||
+    report?.communicationStatus ===
+      CommunicationStatusEnum.AWAITING_RESPONSE ||
+    report?.communicationStatus === CommunicationStatusEnum.RESPONSE_RECEIVED
+
   const handleSubmit = () => {
     if (!body.trim()) return
     createComment({
       reportId,
       body,
-      visibility: isExternal
-        ? CommentVisibilityEnum.EXTERNAL
-        : CommentVisibilityEnum.INTERNAL,
+      visibility:
+        isExternal && canSendExternal
+          ? CommentVisibilityEnum.EXTERNAL
+          : CommentVisibilityEnum.INTERNAL,
     })
   }
 
@@ -74,12 +87,10 @@ export function CommentsContainer({ reportId }: CommentsContainerProps) {
       timeline={report?.timeline ?? []}
       companyName={report?.company?.name}
       currentUserId={me?.id}
-      readonly={
-        report?.status === ReportStatusEnum.APPROVED ||
-        report?.status === ReportStatusEnum.DENIED
-      }
+      readonly={isDraft}
+      canSendExternal={canSendExternal}
       body={body}
-      isExternal={isExternal}
+      isExternal={isExternal && canSendExternal}
       isPending={isPending}
       onBodyChange={setBody}
       onExternalChange={setIsExternal}

--- a/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/report/ReportSidebarContainer.tsx
@@ -7,10 +7,11 @@ import { Text } from '@dmr.is/ui/components/island-is/Text'
 import { AlertMessage } from '@island.is/island-ui/core'
 
 import { EmployeeSelect } from '../../components/report/report-sidebar/EmployeeSelect'
+import { ReportCommunicationControl } from '../../components/report/report-sidebar/ReportCommunicationControl'
 import { ReportFormStepper } from '../../components/report/report-sidebar/ReportFormStepper'
 import { ReportSidebar } from '../../components/report/report-sidebar/ReportSidebar'
 import { ReportStatusSelect } from '../../components/report/report-sidebar/ReportStatusSelect'
-import { ReportDetailDto } from '../../gen/fetch'
+import { ReportDetailDto, ReportStatusEnum } from '../../gen/fetch'
 import { companiesText, reportText } from '../../lib/text'
 import { useTRPC } from '../../lib/trpc/client/trpc'
 
@@ -63,6 +64,14 @@ export function ReportSidebarContainer({
         reportId={data.id}
         status={data.status}
         disabled={isTerminal}
+      />
+      <Box paddingTop={1}>
+        <Divider />
+      </Box>
+      <ReportCommunicationControl
+        reportId={data.id}
+        communicationStatus={data.communicationStatus}
+        disabled={data.status !== ReportStatusEnum.IN_REVIEW}
       />
       <Box paddingTop={1}>
         <Divider />

--- a/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
+++ b/apps/directorate-of-equality-web/src/containers/reports/ReportsContainer.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../components/reports/filter/ReportFilter'
 import { TabContent } from '../../components/reports/tabs/TabContent'
 import {
+  CommunicationStatusEnum,
   type ReportListItemDto,
   ReportStatusEnum,
 } from '../../gen/fetch/types.gen'
@@ -121,7 +122,7 @@ function mapReportToCase(report: ReportListItemDto): Case {
     email: report.companyAdminEmail ?? unknown,
     isatCode: report.companyIsatCategory ?? unknown,
     employeeCount: report.companyEmployeeCountCategory ?? unknown,
-    waitingForAction: report.waitingForAction ?? false,
+    communicationStatus: report.communicationStatus,
     companyFinesStarted: report.companyFinesStarted ?? false,
     companyQuarantined: report.companyQuarantined ?? false,
   }
@@ -133,7 +134,11 @@ const commentsColumn: ColumnDef<Case> = {
   size: 56,
   enableSorting: false,
   cell: ({ row }) => {
-    if (!row.original.waitingForAction) return null
+    if (
+      row.original.communicationStatus !==
+      CommunicationStatusEnum.RESPONSE_RECEIVED
+    )
+      return null
     return (
       <Box display="flex" justifyContent="center" alignItems="center">
         <Tooltip

--- a/apps/directorate-of-equality-web/src/lib/constants.ts
+++ b/apps/directorate-of-equality-web/src/lib/constants.ts
@@ -36,6 +36,14 @@ export enum ReportStatusTranslatedEnum {
   SUPERSEDED = 'Úrelt',
   WITHDRAWN = 'Dregin til baka',
 }
+
+export enum CommunicationStatusTranslatedEnum {
+  NOT_STARTED = 'Ekki hafin',
+  OPEN = 'Opin',
+  AWAITING_RESPONSE = 'Beðið eftir svörum',
+  RESPONSE_RECEIVED = 'Svör hafa borist',
+  CLOSED = 'Lokað',
+}
 import { overviewText, reportText, sharedText } from './text'
 
 import { type ColumnDef } from '@tanstack/react-table'
@@ -53,7 +61,7 @@ export type Case = {
   isatCode: string
   reviewer: string
   employeeCount: string
-  waitingForAction: boolean
+  communicationStatus: string
   companyFinesStarted: boolean
   companyQuarantined: boolean
 }

--- a/apps/directorate-of-equality-web/src/lib/text.ts
+++ b/apps/directorate-of-equality-web/src/lib/text.ts
@@ -151,6 +151,8 @@ export const reportText = {
     label: 'Athugasemd',
     placeholder: 'Bættu við athugasemd',
     sendToApplicant: 'Senda á innsendanda',
+    externalDisabledHint:
+      'Opnaðu samskipti til að senda innsendanda skilaboð.',
     submit: 'Vista athugasemd',
     visibleToApplicant: 'Sýnileg innsendanda',
     seeAllComments: 'Sjá allar athugasemdir',
@@ -164,6 +166,25 @@ export const reportText = {
     assignButton: 'Færa í vinnslu',
     approveButton: 'Samþykkja',
     denyButton: 'Hafna',
+  },
+  communicationControl: {
+    label: 'Staða samskipta',
+    successToast: 'Uppfærsla á samskiptum tókst.',
+    errorToast:
+      'Villa við að uppfæra samskipti. Vinsamlegast reyndu aftur síðar.',
+    openButton: 'Opna',
+    closeButton: 'Loka',
+    sendToEditButton: 'Breytingar',
+  },
+  sendToEditModal: {
+    heading: 'Senda skýrslu í breytingar',
+    description:
+      'Vinsamlegast gerðu grein fyrir hvað þarf að laga. Athugasemdin er sýnileg innsendanda og samskipti verða opnuð svo hægt sé að svara.',
+    warningTitle: 'Athugið',
+    warningMessage:
+      'Innsendandi fær skýrsluna opna til breytinga á Ísland.is.',
+    reasonLabel: 'Ástæða',
+    submitButton: 'Senda í breytingar',
   },
   employeeSelect: {
     label: 'Starfsmaður',
@@ -260,6 +281,9 @@ export const reportText = {
     unassignedOther: 'tók',
     unassignedOtherSuffix: 'af málinu',
     movesToStatus: 'færir mál í stöðuna:',
+    edited: 'gerði breytingar á skýrslu',
+    communicationOpened: 'opnaði á samskipti við innsendanda',
+    communicationClosed: 'lokaði á samskipti við innsendanda',
     companyCreated: 'Fyrirtæki skráð',
     finesStarted: 'hefur hafið dagsektarferli',
     finesStopped: 'hefur stöðvað dagsektarferli',

--- a/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportWorkflowRouter.ts
+++ b/apps/directorate-of-equality-web/src/lib/trpc/server/routers/reportWorkflowRouter.ts
@@ -2,8 +2,12 @@ import {
   zApproveReportPath,
   zAssignReportBody,
   zAssignReportPath,
+  zCloseReportCommunicationPath,
   zDenyReportBody,
   zDenyReportPath,
+  zOpenReportCommunicationPath,
+  zSendReportToEditBody,
+  zSendReportToEditPath,
 } from '../../../../gen/fetch/zod.gen'
 import { protectedProcedure, router } from '../trpc'
 
@@ -30,6 +34,31 @@ export const reportWorkflowRouter = router({
     .input(zApproveReportPath)
     .mutation(async ({ ctx, input }) => {
       await ctx.api.approveReport({
+        path: { reportId: input.reportId },
+      })
+    }),
+
+  sendToEdit: protectedProcedure
+    .input(zSendReportToEditPath.extend(zSendReportToEditBody.shape))
+    .mutation(async ({ ctx, input }) => {
+      await ctx.api.sendReportToEdit({
+        path: { reportId: input.reportId },
+        body: { reason: input.reason },
+      })
+    }),
+
+  openCommunication: protectedProcedure
+    .input(zOpenReportCommunicationPath)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.api.openReportCommunication({
+        path: { reportId: input.reportId },
+      })
+    }),
+
+  closeCommunication: protectedProcedure
+    .input(zCloseReportCommunicationPath)
+    .mutation(async ({ ctx, input }) => {
+      await ctx.api.closeReportCommunication({
         path: { reportId: input.reportId },
       })
     }),


### PR DESCRIPTION
# What

  Adds a persisted **communication status** for the reviewer ↔ applicant thread on Directorate of Equality reports, replacing the previously derived `waitingForAction`
  boolean.

  - New `CommunicationStatusEnum` on the report model: `NOT_STARTED`, `OPEN`, `AWAITING_RESPONSE`, `RESPONSE_RECEIVED`, `CLOSED`.
  - `ReportWorkflowService` with reviewer-only actions — `openCommunication`, `closeCommunication`, `sendToEdit` — all gated to `IN_REVIEW` reports.
  - Comment authorship auto-flips direction: reviewer → `AWAITING_RESPONSE`, applicant → `RESPONSE_RECEIVED`.
  - Terminal actions (`withdraw` / `approve` / `deny`) force-close the thread, emitting an audit event only if a thread was open.
  - `send-to-edit` endpoint + tRPC `reportWorkflowRouter`; notifies the application system on edit.
  - UI: `ReportCommunicationControl` and `ReportSendToEditModal` in the report sidebar; "Beðið svara" icon surfaces `RESPONSE_RECEIVED` in the overview.
  - Reworked comment services/tests to enforce the open-set gating (applicant can only comment while the thread is open).

  # Why

  The old `waitingForAction` boolean was derived on the fly and couldn't represent *whose turn it is* or whether a thread was intentionally opened/closed. A persisted,
  explicit state:

  - makes reviewer/applicant turn-taking unambiguous and auditable,
  - lets us gate applicant commenting to only open threads,
  - ties communication lifecycle to the report status (open requires `IN_REVIEW`; terminal actions close it),
  - and drives the overview "awaiting response" indicator from real state instead of a computed guess.