### PR TITLE
fix(lg): Category and types CRUD operations for admins

### DIFF
--- a/apps/legal-gazette-api/db/migrations/m-20260722-category-type-change-log.js
+++ b/apps/legal-gazette-api/db/migrations/m-20260722-category-type-change-log.js
@@ -1,0 +1,65 @@
+'use strict'
+
+/**
+ * Schema for admin-managed advert taxonomy.
+ *
+ *  - Adds `active` to advert_category + advert_type. Inactive rows are excluded
+ *    from the create-flow dropdowns but stay valid for existing adverts and
+ *    search facets. (Replaces the hardcoded UNASSIGNABLE_*_IDS constants.)
+ *  - Adds `category_type_change_log`: an append-only log of every admin change to the
+ *    taxonomy (create/update/delete/attach/detach/set-active/move/revert), with
+ *    before/after JSONB snapshots, the blast radius (affected advert count), the
+ *    exact affected advert ids (for precise undo of bulk moves), and a link from
+ *    a revert back to the entry it undid.
+ *
+ * Data corrections (renames, join rebuild, Fyrirkall remap) are intentionally
+ * NOT done here — admins perform those through the new management page.
+ */
+
+module.exports = {
+  async up(queryInterface) {
+    return queryInterface.sequelize.query(`
+      BEGIN;
+
+      ALTER TABLE ADVERT_CATEGORY
+        ADD COLUMN IF NOT EXISTS ACTIVE BOOLEAN NOT NULL DEFAULT TRUE;
+      ALTER TABLE ADVERT_TYPE
+        ADD COLUMN IF NOT EXISTS ACTIVE BOOLEAN NOT NULL DEFAULT TRUE;
+
+      CREATE TABLE IF NOT EXISTS CATEGORY_TYPE_CHANGE_LOG (
+        ID                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+        ACTOR_ID              VARCHAR(255) NOT NULL,
+        ACTOR_NAME            VARCHAR(255),
+        ACTION                VARCHAR(64)  NOT NULL,
+        ENTITY_TYPE           VARCHAR(32)  NOT NULL,
+        ENTITY_ID             UUID,
+        BEFORE                JSONB,
+        AFTER                 JSONB,
+        AFFECTED_ADVERT_COUNT INTEGER      NOT NULL DEFAULT 0,
+        AFFECTED_ADVERT_IDS   JSONB,
+        REVERTS_AUDIT_ID      UUID         REFERENCES CATEGORY_TYPE_CHANGE_LOG (ID),
+        CREATED_AT            TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+      );
+
+      CREATE INDEX IF NOT EXISTS CATEGORY_TYPE_CHANGE_LOG_ENTITY_IDX
+        ON CATEGORY_TYPE_CHANGE_LOG (ENTITY_TYPE, ENTITY_ID);
+      CREATE INDEX IF NOT EXISTS CATEGORY_TYPE_CHANGE_LOG_CREATED_AT_IDX
+        ON CATEGORY_TYPE_CHANGE_LOG (CREATED_AT DESC);
+
+      COMMIT;
+    `)
+  },
+
+  async down(queryInterface) {
+    return queryInterface.sequelize.query(`
+      BEGIN;
+
+      DROP TABLE IF EXISTS CATEGORY_TYPE_CHANGE_LOG;
+
+      ALTER TABLE ADVERT_CATEGORY DROP COLUMN IF EXISTS ACTIVE;
+      ALTER TABLE ADVERT_TYPE DROP COLUMN IF EXISTS ACTIVE;
+
+      COMMIT;
+    `)
+  },
+}

--- a/apps/legal-gazette-api/src/core/constants.ts
+++ b/apps/legal-gazette-api/src/core/constants.ts
@@ -39,6 +39,7 @@ export enum LegalGazetteModels {
   SUBSCRIBER_PAYMENT = 'subscriber_payments',
   PUBLICATION_SEARCH_EVENT = 'publication_search_event',
   BACKFILLED_PUBLICATION = 'backfilled_publication',
+  CATEGORY_TYPE_CHANGE_LOG = 'category_type_change_log',
 }
 
 export const RECALL_BANKRUPTCY_ADVERT_TYPE_ID =
@@ -73,19 +74,6 @@ export const COMMON_ADVERT_TYPES_IDS = [
   'cc18a165-b359-45b2-b587-aae21a09b565',
   '06f349ce-bda5-43d5-afae-4d658ed17b51',
   'b4b31515-b759-44c9-88d2-f33da574ea72',
-]
-
-export const UNASSIGNABLE_CATEGORY_IDS = [
-  '52112993-EDCE-46A1-B7E6-8E3E5CD296F6', // Allar auglýsingar
-  'b2b798e2-e8a3-4928-94eb-0021a5f13409', // Greiðsluaðlögun
-]
-
-export const UNASSIGNABLE_TYPE_IDS = [
-  '82425CC8-B32E-4ADE-9EE4-BC6F8261B735', // Almennar auglýsingar
-  '0A066E81-31AD-4F80-94D2-CE81F68F5368', // Handbækur
-  'aa408eae-a76a-4ed8-9aa3-388dc0c8ff05', // Tölublöð
-  'EC153CBB-BB48-4984-9F96-5E26CC522DD3', // Umferðarauglýsingar
-  'CE0490FA-9CC0-48B4-AD47-5964D081DCDF', // Greiðsluáskorun
 ]
 
 export const TASK_JOB_IDS = {

--- a/apps/legal-gazette-api/src/models/category-type-change-log.model.ts
+++ b/apps/legal-gazette-api/src/models/category-type-change-log.model.ts
@@ -1,0 +1,184 @@
+import { Column, DataType, Model } from 'sequelize-typescript'
+
+import { ApiPropertyOptional } from '@nestjs/swagger'
+
+import {
+  ApiDateTime,
+  ApiEnum,
+  ApiNumber,
+  ApiOptionalArray,
+  ApiOptionalString,
+  ApiOptionalUuid,
+  ApiString,
+  ApiUUId,
+} from '@dmr.is/decorators'
+import { ParanoidTable } from '@dmr.is/shared-models-base'
+
+import { LegalGazetteModels } from '../core/constants'
+
+export enum ChangeLogAction {
+  CREATE = 'CREATE',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE',
+  ATTACH = 'ATTACH',
+  DETACH = 'DETACH',
+  SET_ACTIVE = 'SET_ACTIVE',
+  MOVE = 'MOVE',
+  REVERT = 'REVERT',
+}
+
+export enum ChangeLogEntity {
+  CATEGORY = 'CATEGORY',
+  TYPE = 'TYPE',
+  CONNECTION = 'CONNECTION',
+}
+
+export type ChangeLogSnapshot = Record<string, unknown>
+
+type CategoryTypeChangeLogAttributes = {
+  id: string
+  actorId: string
+  actorName: string | null
+  action: ChangeLogAction
+  entityType: ChangeLogEntity
+  entityId: string | null
+  before: ChangeLogSnapshot | null
+  after: ChangeLogSnapshot | null
+  affectedAdvertCount: number
+  affectedAdvertIds: string[] | null
+  revertsAuditId: string | null
+  createdAt: Date
+}
+
+export type CategoryTypeChangeLogCreateAttributes = Omit<
+  CategoryTypeChangeLogAttributes,
+  'id' | 'createdAt'
+>
+
+@ParanoidTable({
+  tableName: LegalGazetteModels.CATEGORY_TYPE_CHANGE_LOG,
+  freezeTableName: true,
+  paranoid: false,
+  timestamps: false,
+})
+export class CategoryTypeChangeLogModel extends Model<
+  CategoryTypeChangeLogAttributes,
+  CategoryTypeChangeLogCreateAttributes
+> {
+  @Column({
+    type: DataType.UUID,
+    primaryKey: true,
+    allowNull: false,
+    defaultValue: DataType.UUIDV4,
+  })
+  override id!: string
+
+  @Column({ type: DataType.STRING, allowNull: false, field: 'actor_id' })
+  actorId!: string
+
+  @Column({ type: DataType.STRING, allowNull: true, field: 'actor_name' })
+  actorName!: string | null
+
+  @Column({
+    type: DataType.ENUM(...Object.values(ChangeLogAction)),
+    allowNull: false,
+  })
+  action!: ChangeLogAction
+
+  @Column({
+    type: DataType.ENUM(...Object.values(ChangeLogEntity)),
+    allowNull: false,
+    field: 'entity_type',
+  })
+  entityType!: ChangeLogEntity
+
+  @Column({ type: DataType.UUID, allowNull: true, field: 'entity_id' })
+  entityId!: string | null
+
+  @Column({ type: DataType.JSONB, allowNull: true })
+  before!: ChangeLogSnapshot | null
+
+  @Column({ type: DataType.JSONB, allowNull: true })
+  after!: ChangeLogSnapshot | null
+
+  @Column({
+    type: DataType.INTEGER,
+    allowNull: false,
+    defaultValue: 0,
+    field: 'affected_advert_count',
+  })
+  affectedAdvertCount!: number
+
+  @Column({ type: DataType.JSONB, allowNull: true, field: 'affected_advert_ids' })
+  affectedAdvertIds!: string[] | null
+
+  @Column({ type: DataType.UUID, allowNull: true, field: 'reverts_audit_id' })
+  revertsAuditId!: string | null
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: false,
+    defaultValue: DataType.NOW,
+    field: 'created_at',
+  })
+  override createdAt!: Date
+
+  static fromModel(model: CategoryTypeChangeLogModel): CategoryTypeChangeLogDto {
+    return {
+      id: model.id,
+      actorId: model.actorId,
+      actorName: model.actorName ?? undefined,
+      action: model.action,
+      entityType: model.entityType,
+      entityId: model.entityId ?? undefined,
+      before: model.before ?? undefined,
+      after: model.after ?? undefined,
+      affectedAdvertCount: model.affectedAdvertCount,
+      affectedAdvertIds: model.affectedAdvertIds ?? undefined,
+      revertsAuditId: model.revertsAuditId ?? undefined,
+      createdAt: model.createdAt,
+    }
+  }
+
+  fromModel(): CategoryTypeChangeLogDto {
+    return CategoryTypeChangeLogModel.fromModel(this)
+  }
+}
+
+export class CategoryTypeChangeLogDto {
+  @ApiUUId()
+  id!: string
+
+  @ApiString()
+  actorId!: string
+
+  @ApiOptionalString()
+  actorName?: string
+
+  @ApiEnum(ChangeLogAction, { enumName: 'ChangeLogAction' })
+  action!: ChangeLogAction
+
+  @ApiEnum(ChangeLogEntity, { enumName: 'ChangeLogEntity' })
+  entityType!: ChangeLogEntity
+
+  @ApiOptionalUuid()
+  entityId?: string
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  before?: ChangeLogSnapshot
+
+  @ApiPropertyOptional({ type: 'object', additionalProperties: true })
+  after?: ChangeLogSnapshot
+
+  @ApiNumber()
+  affectedAdvertCount!: number
+
+  @ApiOptionalArray({ type: String })
+  affectedAdvertIds?: string[]
+
+  @ApiOptionalUuid()
+  revertsAuditId?: string
+
+  @ApiDateTime()
+  createdAt!: Date
+}

--- a/apps/legal-gazette-api/src/models/category.model.ts
+++ b/apps/legal-gazette-api/src/models/category.model.ts
@@ -1,4 +1,4 @@
-import { BelongsToMany } from 'sequelize-typescript'
+import { BelongsToMany, Column, DataType } from 'sequelize-typescript'
 
 import { BaseEntityModel, BaseEntityTable } from '@dmr.is/shared-models-base'
 
@@ -20,6 +20,11 @@ export enum CategoryDefaultIdEnum {
 export class CategoryModel extends BaseEntityModel<CategoryDto> {
   @BelongsToMany(() => TypeModel, { through: () => TypeCategoriesModel })
   types!: TypeModel[]
+
+  // Non-selectable (legacy) categories are excluded from the create-flow
+  // dropdowns but remain valid for existing adverts and search facets.
+  @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
+  active!: boolean
 }
 
 export class CategoryDto extends BaseEntityDto {}

--- a/apps/legal-gazette-api/src/models/type.model.ts
+++ b/apps/legal-gazette-api/src/models/type.model.ts
@@ -1,4 +1,4 @@
-import { BelongsToMany } from 'sequelize-typescript'
+import { BelongsToMany, Column, DataType } from 'sequelize-typescript'
 
 import { BaseEntityModel, BaseEntityTable } from '@dmr.is/shared-models-base'
 
@@ -30,6 +30,11 @@ export class TypeModel extends BaseEntityModel<TypeDto> {
   // This is always a array with one element, we need to use BelongsToMany to get the join table
   @BelongsToMany(() => FeeCodeModel, { through: () => AdvertTypeFeeCodeModel })
   feeCode?: FeeCodeModel[]
+
+  // Non-selectable (legacy) types are excluded from the create-flow dropdowns
+  // but remain valid for existing adverts and search facets.
+  @Column({ type: DataType.BOOLEAN, allowNull: false, defaultValue: true })
+  active!: boolean
 
   static fromModelWithCategories(model: TypeModel): TypeWithCategoriesDto {
     return {

--- a/apps/legal-gazette-api/src/modules/base-entity/category/category.controller.ts
+++ b/apps/legal-gazette-api/src/modules/base-entity/category/category.controller.ts
@@ -1,5 +1,3 @@
-import { Op } from 'sequelize'
-
 import {
   Controller,
   Get,
@@ -11,7 +9,6 @@ import { ApiBearerAuth } from '@nestjs/swagger'
 
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
-import { UNASSIGNABLE_CATEGORY_IDS } from '../../../core/constants'
 import { AdminAccess } from '../../../core/decorators/admin.decorator'
 import { LGResponse } from '../../../core/decorators/lg-response.decorator'
 import { AuthorizationGuard } from '../../../core/guards/authorization.guard'
@@ -62,11 +59,7 @@ export class CategoryController extends BaseEntityController<
     @Query() query: GetCategoriesQueryDto,
   ): Promise<GetCategoriesDto> {
     const categories = await super.findAll({
-      where: query.excludeUnassignable
-        ? {
-            id: { [Op.notIn]: UNASSIGNABLE_CATEGORY_IDS },
-          }
-        : undefined,
+      where: query.excludeUnassignable ? { active: true } : undefined,
       include: [
         {
           model: TypeModel,

--- a/apps/legal-gazette-api/src/modules/base-entity/type/type.controller.ts
+++ b/apps/legal-gazette-api/src/modules/base-entity/type/type.controller.ts
@@ -5,10 +5,7 @@ import { ApiBearerAuth } from '@nestjs/swagger'
 
 import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
 
-import {
-  COMMON_ADVERT_TYPES_IDS,
-  UNASSIGNABLE_TYPE_IDS,
-} from '../../../core/constants'
+import { COMMON_ADVERT_TYPES_IDS } from '../../../core/constants'
 import { AdminAccess } from '../../../core/decorators/admin.decorator'
 import { LGResponse } from '../../../core/decorators/lg-response.decorator'
 import { AuthorizationGuard } from '../../../core/guards/authorization.guard'
@@ -63,14 +60,10 @@ export class TypeController extends BaseEntityController<
   @LGResponse({ operationId: 'getTypes', type: GetTypesDto })
   async getTypes(@Query() query?: GetTypesQueryDto): Promise<GetTypesDto> {
     const where: WhereOptions<TypeModel> = {}
-    if (query?.excludeUnassignable && query?.excludeTypes) {
-      const merged = [
-        ...new Set([...UNASSIGNABLE_TYPE_IDS, ...query.excludeTypes]),
-      ]
-      where.id = { [Op.notIn]: merged }
-    } else if (query?.excludeUnassignable) {
-      where.id = { [Op.notIn]: UNASSIGNABLE_TYPE_IDS }
-    } else if (query?.excludeTypes) {
+    if (query?.excludeUnassignable) {
+      where.active = true
+    }
+    if (query?.excludeTypes) {
       where.id = { [Op.notIn]: query.excludeTypes }
     }
 

--- a/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.controller.module.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.controller.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common'
+
+import { CategoryTypeAdminController } from './category-type-admin.controller'
+import { CategoryTypeAdminProviderModule } from './category-type-admin.provider.module'
+
+@Module({
+  imports: [CategoryTypeAdminProviderModule],
+  controllers: [CategoryTypeAdminController],
+})
+export class CategoryTypeAdminControllerModule {}

--- a/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.controller.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.controller.ts
@@ -1,0 +1,210 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common'
+import { ApiBearerAuth } from '@nestjs/swagger'
+
+import { CurrentUser } from '@dmr.is/decorators'
+import { type DMRUser } from '@dmr.is/island-auth-nest/dmrUser'
+import { UUIDValidationPipe } from '@dmr.is/pipelines'
+import { TokenJwtAuthGuard } from '@dmr.is/shared-modules'
+
+import { AdminAccess } from '../../core/decorators/admin.decorator'
+import { LGResponse } from '../../core/decorators/lg-response.decorator'
+import { AuthorizationGuard } from '../../core/guards/authorization.guard'
+import { CategoryDto } from '../../models/category.model'
+import { TypeDto } from '../../models/type.model'
+import {
+  CategoryTypeActor,
+  ChangeLogQuery,
+  ConnectionBody,
+  CreateCategoryBody,
+  CreateTypeBody,
+  GetChangeLogDto,
+  ImpactDto,
+  MoveAdvertsBody,
+  SetActiveBody,
+  UpdateCategoryBody,
+  UpdateTypeBody,
+} from './dto/category-type-admin.dto'
+import { ICategoryTypeAdminService } from './category-type-admin.service.interface'
+
+@Controller({ path: 'category-type', version: '1' })
+@ApiBearerAuth()
+@UseGuards(TokenJwtAuthGuard, AuthorizationGuard)
+@AdminAccess()
+export class CategoryTypeAdminController {
+  constructor(
+    @Inject(ICategoryTypeAdminService)
+    private readonly service: ICategoryTypeAdminService,
+  ) {}
+
+  private actor(user: DMRUser): CategoryTypeActor {
+    return { id: user.nationalId, name: user.name ?? user.fullName ?? null }
+  }
+
+  // --- Categories ---
+
+  @Post('/categories')
+  @LGResponse({ operationId: 'createCategory', type: CategoryDto })
+  createCategory(
+    @Body() body: CreateCategoryBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<CategoryDto> {
+    return this.service.createCategory(body, this.actor(user))
+  }
+
+  @Put('/categories/:id')
+  @LGResponse({ operationId: 'updateCategory', type: CategoryDto })
+  updateCategory(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @Body() body: UpdateCategoryBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<CategoryDto> {
+    return this.service.updateCategory(id, body, this.actor(user))
+  }
+
+  @Put('/categories/:id/active')
+  @LGResponse({ operationId: 'setCategoryActive', type: CategoryDto })
+  setCategoryActive(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @Body() body: SetActiveBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<CategoryDto> {
+    return this.service.setCategoryActive(id, body, this.actor(user))
+  }
+
+  @Get('/categories/:id/impact')
+  @LGResponse({ operationId: 'getCategoryImpact', type: ImpactDto })
+  getCategoryImpact(
+    @Param('id', new UUIDValidationPipe()) id: string,
+  ): Promise<ImpactDto> {
+    return this.service.getCategoryImpact(id)
+  }
+
+  @Delete('/categories/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @LGResponse({ operationId: 'deleteCategory' })
+  deleteCategory(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @CurrentUser() user: DMRUser,
+  ): Promise<void> {
+    return this.service.deleteCategory(id, this.actor(user))
+  }
+
+  // --- Types ---
+
+  @Post('/types')
+  @LGResponse({ operationId: 'createType', type: TypeDto })
+  createType(
+    @Body() body: CreateTypeBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<TypeDto> {
+    return this.service.createType(body, this.actor(user))
+  }
+
+  @Put('/types/:id')
+  @LGResponse({ operationId: 'updateType', type: TypeDto })
+  updateType(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @Body() body: UpdateTypeBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<TypeDto> {
+    return this.service.updateType(id, body, this.actor(user))
+  }
+
+  @Put('/types/:id/active')
+  @LGResponse({ operationId: 'setTypeActive', type: TypeDto })
+  setTypeActive(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @Body() body: SetActiveBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<TypeDto> {
+    return this.service.setTypeActive(id, body, this.actor(user))
+  }
+
+  @Get('/types/:id/impact')
+  @LGResponse({ operationId: 'getTypeImpact', type: ImpactDto })
+  getTypeImpact(
+    @Param('id', new UUIDValidationPipe()) id: string,
+  ): Promise<ImpactDto> {
+    return this.service.getTypeImpact(id)
+  }
+
+  @Delete('/types/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @LGResponse({ operationId: 'deleteType' })
+  deleteType(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @CurrentUser() user: DMRUser,
+  ): Promise<void> {
+    return this.service.deleteType(id, this.actor(user))
+  }
+
+  // --- Connections ---
+
+  @Post('/connections')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @LGResponse({ operationId: 'attachTypeCategory' })
+  attach(
+    @Body() body: ConnectionBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<void> {
+    return this.service.attach(body, this.actor(user))
+  }
+
+  @Post('/connections/detach')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @LGResponse({ operationId: 'detachTypeCategory' })
+  detach(
+    @Body() body: ConnectionBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<void> {
+    return this.service.detach(body, this.actor(user))
+  }
+
+  // --- Bulk moves ---
+
+  @Post('/moves/impact')
+  @LGResponse({ operationId: 'getMoveImpact', type: ImpactDto })
+  getMoveImpact(@Body() body: MoveAdvertsBody): Promise<ImpactDto> {
+    return this.service.getMoveImpact(body)
+  }
+
+  @Post('/moves')
+  @LGResponse({ operationId: 'moveAdverts', type: ImpactDto })
+  moveAdverts(
+    @Body() body: MoveAdvertsBody,
+    @CurrentUser() user: DMRUser,
+  ): Promise<ImpactDto> {
+    return this.service.moveAdverts(body, this.actor(user))
+  }
+
+  // --- Audit + undo ---
+
+  @Get('/change-log')
+  @LGResponse({ operationId: 'getCategoryTypeChangeLog', type: GetChangeLogDto })
+  getChangeLog(@Query() query: ChangeLogQuery): Promise<GetChangeLogDto> {
+    return this.service.getChangeLog(query)
+  }
+
+  @Post('/change-log/:id/revert')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @LGResponse({ operationId: 'revertCategoryTypeChange' })
+  revert(
+    @Param('id', new UUIDValidationPipe()) id: string,
+    @CurrentUser() user: DMRUser,
+  ): Promise<void> {
+    return this.service.revert(id, this.actor(user))
+  }
+}

--- a/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.provider.module.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.provider.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common'
+import { SequelizeModule } from '@nestjs/sequelize'
+
+import { AdvertModel } from '../../models/advert.model'
+import { CategoryModel } from '../../models/category.model'
+import { CategoryTypeChangeLogModel } from '../../models/category-type-change-log.model'
+import { TypeModel } from '../../models/type.model'
+import { TypeCategoriesModel } from '../../models/type-categories.model'
+import { CategoryTypeAdminService } from './category-type-admin.service'
+import { ICategoryTypeAdminService } from './category-type-admin.service.interface'
+
+@Module({
+  imports: [
+    SequelizeModule.forFeature([
+      CategoryModel,
+      TypeModel,
+      TypeCategoriesModel,
+      AdvertModel,
+      CategoryTypeChangeLogModel,
+    ]),
+  ],
+  providers: [
+    {
+      provide: ICategoryTypeAdminService,
+      useClass: CategoryTypeAdminService,
+    },
+  ],
+  exports: [ICategoryTypeAdminService],
+})
+export class CategoryTypeAdminProviderModule {}

--- a/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.service.interface.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.service.interface.ts
@@ -1,0 +1,61 @@
+import { CategoryDto } from '../../models/category.model'
+import { TypeDto } from '../../models/type.model'
+import {
+  CategoryTypeActor,
+  ChangeLogQuery,
+  ConnectionBody,
+  CreateCategoryBody,
+  CreateTypeBody,
+  GetChangeLogDto,
+  ImpactDto,
+  MoveAdvertsBody,
+  SetActiveBody,
+  UpdateCategoryBody,
+  UpdateTypeBody,
+} from './dto/category-type-admin.dto'
+
+export interface ICategoryTypeAdminService {
+  // Categories
+  createCategory(body: CreateCategoryBody, actor: CategoryTypeActor): Promise<CategoryDto>
+  updateCategory(
+    id: string,
+    body: UpdateCategoryBody,
+    actor: CategoryTypeActor,
+  ): Promise<CategoryDto>
+  deleteCategory(id: string, actor: CategoryTypeActor): Promise<void>
+  setCategoryActive(
+    id: string,
+    body: SetActiveBody,
+    actor: CategoryTypeActor,
+  ): Promise<CategoryDto>
+  getCategoryImpact(id: string): Promise<ImpactDto>
+
+  // Types
+  createType(body: CreateTypeBody, actor: CategoryTypeActor): Promise<TypeDto>
+  updateType(
+    id: string,
+    body: UpdateTypeBody,
+    actor: CategoryTypeActor,
+  ): Promise<TypeDto>
+  deleteType(id: string, actor: CategoryTypeActor): Promise<void>
+  setTypeActive(
+    id: string,
+    body: SetActiveBody,
+    actor: CategoryTypeActor,
+  ): Promise<TypeDto>
+  getTypeImpact(id: string): Promise<ImpactDto>
+
+  // Connections (type <-> category)
+  attach(body: ConnectionBody, actor: CategoryTypeActor): Promise<void>
+  detach(body: ConnectionBody, actor: CategoryTypeActor): Promise<void>
+
+  // Bulk advert re-pointing
+  getMoveImpact(body: MoveAdvertsBody): Promise<ImpactDto>
+  moveAdverts(body: MoveAdvertsBody, actor: CategoryTypeActor): Promise<ImpactDto>
+
+  // Audit + undo
+  getChangeLog(query: ChangeLogQuery): Promise<GetChangeLogDto>
+  revert(auditId: string, actor: CategoryTypeActor): Promise<void>
+}
+
+export const ICategoryTypeAdminService = Symbol('ICategoryTypeAdminService')

--- a/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.service.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/category-type-admin.service.ts
@@ -1,0 +1,726 @@
+import { Op, Transaction } from 'sequelize'
+import { Sequelize } from 'sequelize-typescript'
+import slugify from 'slugify'
+
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import { InjectModel } from '@nestjs/sequelize'
+
+import { AdvertModel } from '../../models/advert.model'
+import { CategoryDto, CategoryModel } from '../../models/category.model'
+import {
+  CategoryTypeChangeLogModel,
+  ChangeLogAction,
+  ChangeLogEntity,
+  ChangeLogSnapshot,
+} from '../../models/category-type-change-log.model'
+import { TypeDto, TypeModel } from '../../models/type.model'
+import { TypeCategoriesModel } from '../../models/type-categories.model'
+import {
+  CategoryTypeActor,
+  ChangeLogQuery,
+  ConnectionBody,
+  CreateCategoryBody,
+  CreateTypeBody,
+  GetChangeLogDto,
+  ImpactDto,
+  MoveAdvertsBody,
+  SetActiveBody,
+  UpdateCategoryBody,
+  UpdateTypeBody,
+} from './dto/category-type-admin.dto'
+import { ICategoryTypeAdminService } from './category-type-admin.service.interface'
+
+const SAMPLE_LIMIT = 20
+
+// Per-advert original values captured for exact undo of a move.
+type MovedAdvert = { id: string; typeId: string; categoryId: string }
+
+@Injectable()
+export class CategoryTypeAdminService implements ICategoryTypeAdminService {
+  constructor(
+    @InjectModel(CategoryModel)
+    private readonly categoryModel: typeof CategoryModel,
+    @InjectModel(TypeModel) private readonly typeModel: typeof TypeModel,
+    @InjectModel(TypeCategoriesModel)
+    private readonly typeCategoriesModel: typeof TypeCategoriesModel,
+    @InjectModel(AdvertModel) private readonly advertModel: typeof AdvertModel,
+    @InjectModel(CategoryTypeChangeLogModel)
+    private readonly changeLogModel: typeof CategoryTypeChangeLogModel,
+    private readonly sequelize: Sequelize,
+  ) {}
+
+  private slugify(value: string): string {
+    return slugify(value, { lower: true, strict: true })
+  }
+
+  private async writeChangeLog(
+    transaction: Transaction,
+    params: {
+      actor: CategoryTypeActor
+      action: ChangeLogAction
+      entityType: ChangeLogEntity
+      entityId: string | null
+      before: ChangeLogSnapshot | null
+      after: ChangeLogSnapshot | null
+      affectedAdvertCount?: number
+      affectedAdvertIds?: string[] | null
+      revertsAuditId?: string | null
+    },
+  ): Promise<void> {
+    await this.changeLogModel.create(
+      {
+        actorId: params.actor.id,
+        actorName: params.actor.name,
+        action: params.action,
+        entityType: params.entityType,
+        entityId: params.entityId,
+        before: params.before,
+        after: params.after,
+        affectedAdvertCount: params.affectedAdvertCount ?? 0,
+        affectedAdvertIds: params.affectedAdvertIds ?? null,
+        revertsAuditId: params.revertsAuditId ?? null,
+      },
+      { transaction },
+    )
+  }
+
+  private async advertImpact(
+    where: Record<string, unknown>,
+    transaction?: Transaction,
+  ): Promise<ImpactDto> {
+    const affectedAdvertCount = await this.advertModel.count({
+      where,
+      transaction,
+    })
+    const sample = await this.advertModel.findAll({
+      where,
+      attributes: ['id'],
+      limit: SAMPLE_LIMIT,
+      transaction,
+    })
+    return { affectedAdvertCount, sampleAdvertIds: sample.map((a) => a.id) }
+  }
+
+  private categorySnapshot(model: CategoryModel): ChangeLogSnapshot {
+    return { title: model.title, slug: model.slug, active: model.active }
+  }
+
+  private typeSnapshot(model: TypeModel): ChangeLogSnapshot {
+    return { title: model.title, slug: model.slug, active: model.active }
+  }
+
+  // --- Categories ---------------------------------------------------------
+
+  async createCategory(
+    body: CreateCategoryBody,
+    actor: CategoryTypeActor,
+  ): Promise<CategoryDto> {
+    const slug = body.slug ?? this.slugify(body.title)
+    return this.sequelize.transaction(async (transaction) => {
+      const created = await this.categoryModel.create(
+        { title: body.title, slug },
+        { transaction },
+      )
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.CREATE,
+        entityType: ChangeLogEntity.CATEGORY,
+        entityId: created.id,
+        before: null,
+        after: { title: created.title, slug: created.slug, active: true },
+      })
+      return created.fromModel()
+    })
+  }
+
+  async updateCategory(
+    id: string,
+    body: UpdateCategoryBody,
+    actor: CategoryTypeActor,
+  ): Promise<CategoryDto> {
+    return this.sequelize.transaction(async (transaction) => {
+      const category = await this.categoryModel
+        .unscoped()
+        .findByPk(id, { transaction })
+      if (!category) {
+        throw new NotFoundException(`Category ${id} not found`)
+      }
+      const before = this.categorySnapshot(category)
+      if (body.title !== undefined) category.title = body.title
+      if (body.slug !== undefined) category.slug = body.slug
+      await category.save({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.UPDATE,
+        entityType: ChangeLogEntity.CATEGORY,
+        entityId: category.id,
+        before,
+        after: this.categorySnapshot(category),
+      })
+      return category.fromModel()
+    })
+  }
+
+  async setCategoryActive(
+    id: string,
+    body: SetActiveBody,
+    actor: CategoryTypeActor,
+  ): Promise<CategoryDto> {
+    return this.sequelize.transaction(async (transaction) => {
+      const category = await this.categoryModel
+        .unscoped()
+        .findByPk(id, { transaction })
+      if (!category) {
+        throw new NotFoundException(`Category ${id} not found`)
+      }
+      const before = this.categorySnapshot(category)
+      category.active = body.active
+      await category.save({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.SET_ACTIVE,
+        entityType: ChangeLogEntity.CATEGORY,
+        entityId: category.id,
+        before,
+        after: this.categorySnapshot(category),
+      })
+      return category.fromModel()
+    })
+  }
+
+  async getCategoryImpact(id: string): Promise<ImpactDto> {
+    return this.advertImpact({ categoryId: id })
+  }
+
+  async deleteCategory(id: string, actor: CategoryTypeActor): Promise<void> {
+    await this.sequelize.transaction(async (transaction) => {
+      const category = await this.categoryModel
+        .unscoped()
+        .findByPk(id, { transaction })
+      if (!category) {
+        throw new NotFoundException(`Category ${id} not found`)
+      }
+      const { affectedAdvertCount } = await this.advertImpact(
+        { categoryId: id },
+        transaction,
+      )
+      if (affectedAdvertCount > 0) {
+        throw new BadRequestException(
+          `Cannot delete category: ${affectedAdvertCount} adverts still reference it. Move them first.`,
+        )
+      }
+      const before = this.categorySnapshot(category)
+      await this.typeCategoriesModel.destroy({
+        where: { categoryId: id },
+        transaction,
+      })
+      await category.destroy({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.DELETE,
+        entityType: ChangeLogEntity.CATEGORY,
+        entityId: id,
+        before,
+        after: null,
+      })
+    })
+  }
+
+  // --- Types --------------------------------------------------------------
+
+  async createType(
+    body: CreateTypeBody,
+    actor: CategoryTypeActor,
+  ): Promise<TypeDto> {
+    const slug = body.slug ?? this.slugify(body.title)
+    return this.sequelize.transaction(async (transaction) => {
+      const created = await this.typeModel.create(
+        { title: body.title, slug },
+        { transaction },
+      )
+      for (const categoryId of body.categoryIds ?? []) {
+        await this.createConnection(created.id, categoryId, transaction)
+      }
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.CREATE,
+        entityType: ChangeLogEntity.TYPE,
+        entityId: created.id,
+        before: null,
+        after: {
+          title: created.title,
+          slug: created.slug,
+          active: true,
+          categoryIds: body.categoryIds ?? [],
+        },
+      })
+      return created.fromModel()
+    })
+  }
+
+  async updateType(
+    id: string,
+    body: UpdateTypeBody,
+    actor: CategoryTypeActor,
+  ): Promise<TypeDto> {
+    return this.sequelize.transaction(async (transaction) => {
+      const type = await this.typeModel.unscoped().findByPk(id, { transaction })
+      if (!type) {
+        throw new NotFoundException(`Type ${id} not found`)
+      }
+      const before = this.typeSnapshot(type)
+      if (body.title !== undefined) type.title = body.title
+      if (body.slug !== undefined) type.slug = body.slug
+      await type.save({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.UPDATE,
+        entityType: ChangeLogEntity.TYPE,
+        entityId: type.id,
+        before,
+        after: this.typeSnapshot(type),
+      })
+      return type.fromModel()
+    })
+  }
+
+  async setTypeActive(
+    id: string,
+    body: SetActiveBody,
+    actor: CategoryTypeActor,
+  ): Promise<TypeDto> {
+    return this.sequelize.transaction(async (transaction) => {
+      const type = await this.typeModel.unscoped().findByPk(id, { transaction })
+      if (!type) {
+        throw new NotFoundException(`Type ${id} not found`)
+      }
+      const before = this.typeSnapshot(type)
+      type.active = body.active
+      await type.save({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.SET_ACTIVE,
+        entityType: ChangeLogEntity.TYPE,
+        entityId: type.id,
+        before,
+        after: this.typeSnapshot(type),
+      })
+      return type.fromModel()
+    })
+  }
+
+  async getTypeImpact(id: string): Promise<ImpactDto> {
+    return this.advertImpact({ typeId: id })
+  }
+
+  async deleteType(id: string, actor: CategoryTypeActor): Promise<void> {
+    await this.sequelize.transaction(async (transaction) => {
+      const type = await this.typeModel.unscoped().findByPk(id, { transaction })
+      if (!type) {
+        throw new NotFoundException(`Type ${id} not found`)
+      }
+      const { affectedAdvertCount } = await this.advertImpact(
+        { typeId: id },
+        transaction,
+      )
+      if (affectedAdvertCount > 0) {
+        throw new BadRequestException(
+          `Cannot delete type: ${affectedAdvertCount} adverts still reference it. Move them first.`,
+        )
+      }
+      const before = this.typeSnapshot(type)
+      await this.typeCategoriesModel.destroy({
+        where: { typeId: id },
+        transaction,
+      })
+      await type.destroy({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.DELETE,
+        entityType: ChangeLogEntity.TYPE,
+        entityId: id,
+        before,
+        after: null,
+      })
+    })
+  }
+
+  // --- Connections --------------------------------------------------------
+
+  /** Creates or restores a type<->category join row. Returns true if changed. */
+  private async createConnection(
+    typeId: string,
+    categoryId: string,
+    transaction: Transaction,
+  ): Promise<boolean> {
+    const existing = await this.typeCategoriesModel.findOne({
+      where: { typeId, categoryId },
+      paranoid: false,
+      transaction,
+    })
+    if (existing) {
+      if (existing.deletedAt) {
+        await existing.restore({ transaction })
+        return true
+      }
+      return false
+    }
+    await this.typeCategoriesModel.create(
+      { typeId, categoryId } as never,
+      { transaction },
+    )
+    return true
+  }
+
+  async attach(body: ConnectionBody, actor: CategoryTypeActor): Promise<void> {
+    await this.sequelize.transaction(async (transaction) => {
+      const [type, category] = await Promise.all([
+        this.typeModel.unscoped().findByPk(body.typeId, { transaction }),
+        this.categoryModel.unscoped().findByPk(body.categoryId, { transaction }),
+      ])
+      if (!type) throw new NotFoundException(`Type ${body.typeId} not found`)
+      if (!category) {
+        throw new NotFoundException(`Category ${body.categoryId} not found`)
+      }
+      const changed = await this.createConnection(
+        body.typeId,
+        body.categoryId,
+        transaction,
+      )
+      if (!changed) return
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.ATTACH,
+        entityType: ChangeLogEntity.CONNECTION,
+        entityId: body.typeId,
+        before: null,
+        after: { typeId: body.typeId, categoryId: body.categoryId },
+      })
+    })
+  }
+
+  async detach(body: ConnectionBody, actor: CategoryTypeActor): Promise<void> {
+    await this.sequelize.transaction(async (transaction) => {
+      const existing = await this.typeCategoriesModel.findOne({
+        where: { typeId: body.typeId, categoryId: body.categoryId },
+        transaction,
+      })
+      if (!existing) {
+        throw new NotFoundException('Connection not found')
+      }
+      await existing.destroy({ transaction })
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.DETACH,
+        entityType: ChangeLogEntity.CONNECTION,
+        entityId: body.typeId,
+        before: { typeId: body.typeId, categoryId: body.categoryId },
+        after: null,
+      })
+    })
+  }
+
+  // --- Bulk advert moves --------------------------------------------------
+
+  private moveWhere(body: MoveAdvertsBody): Record<string, unknown> {
+    return {
+      typeId: body.fromTypeId,
+      ...(body.fromCategoryId ? { categoryId: body.fromCategoryId } : {}),
+    }
+  }
+
+  private assertMoveTargets(body: MoveAdvertsBody): void {
+    if (!body.toTypeId && !body.toCategoryId) {
+      throw new BadRequestException(
+        'A move must set a target type and/or category',
+      )
+    }
+  }
+
+  async getMoveImpact(body: MoveAdvertsBody): Promise<ImpactDto> {
+    this.assertMoveTargets(body)
+    return this.advertImpact(this.moveWhere(body))
+  }
+
+  async moveAdverts(
+    body: MoveAdvertsBody,
+    actor: CategoryTypeActor,
+  ): Promise<ImpactDto> {
+    this.assertMoveTargets(body)
+    return this.sequelize.transaction(async (transaction) => {
+      const adverts = await this.advertModel.findAll({
+        where: this.moveWhere(body),
+        attributes: ['id', 'typeId', 'categoryId'],
+        transaction,
+      })
+      const moved: MovedAdvert[] = adverts.map((a) => ({
+        id: a.id,
+        typeId: a.typeId as string,
+        categoryId: a.categoryId,
+      }))
+      const ids = moved.map((m) => m.id)
+
+      if (ids.length > 0) {
+        const values: { typeId?: string; categoryId?: string } = {}
+        if (body.toTypeId) values.typeId = body.toTypeId
+        if (body.toCategoryId) values.categoryId = body.toCategoryId
+        await this.advertModel.update(values, {
+          where: { id: { [Op.in]: ids } },
+          transaction,
+        })
+      }
+
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.MOVE,
+        entityType: ChangeLogEntity.TYPE,
+        entityId: body.fromTypeId,
+        before: {
+          filter: {
+            fromTypeId: body.fromTypeId,
+            fromCategoryId: body.fromCategoryId ?? null,
+          },
+          adverts: moved,
+        },
+        after: {
+          toTypeId: body.toTypeId ?? null,
+          toCategoryId: body.toCategoryId ?? null,
+        },
+        affectedAdvertCount: ids.length,
+        affectedAdvertIds: ids,
+      })
+
+      return {
+        affectedAdvertCount: ids.length,
+        sampleAdvertIds: ids.slice(0, SAMPLE_LIMIT),
+      }
+    })
+  }
+
+  // --- Audit + undo -------------------------------------------------------
+
+  async getChangeLog(query: ChangeLogQuery): Promise<GetChangeLogDto> {
+    const where: Record<string, unknown> = {}
+    if (query.entityType) where.entityType = query.entityType
+    if (query.entityId) where.entityId = query.entityId
+
+    const { rows, count } = await this.changeLogModel.findAndCountAll({
+      where,
+      order: [['createdAt', 'DESC']],
+      limit: query.limit ?? 50,
+      offset: query.offset ?? 0,
+    })
+
+    return {
+      entries: rows.map((r) => r.fromModel()),
+      total: count,
+    }
+  }
+
+  async revert(auditId: string, actor: CategoryTypeActor): Promise<void> {
+    await this.sequelize.transaction(async (transaction) => {
+      const audit = await this.changeLogModel.findByPk(auditId, { transaction })
+      if (!audit) {
+        throw new NotFoundException(`Audit entry ${auditId} not found`)
+      }
+      if (audit.action === ChangeLogAction.REVERT) {
+        throw new BadRequestException('Cannot revert a revert')
+      }
+      const alreadyReverted = await this.changeLogModel.findOne({
+        where: { revertsAuditId: auditId },
+        transaction,
+      })
+      if (alreadyReverted) {
+        throw new BadRequestException('This change has already been reverted')
+      }
+
+      let affectedAdvertCount = 0
+      let affectedAdvertIds: string[] | null = null
+
+      switch (audit.action) {
+        case ChangeLogAction.CREATE:
+          await this.revertCreate(audit, transaction)
+          break
+        case ChangeLogAction.DELETE:
+          await this.revertDelete(audit, transaction)
+          break
+        case ChangeLogAction.UPDATE:
+        case ChangeLogAction.SET_ACTIVE:
+          await this.restoreSnapshot(audit, transaction)
+          break
+        case ChangeLogAction.ATTACH:
+          await this.detachRaw(audit, transaction)
+          break
+        case ChangeLogAction.DETACH:
+          await this.attachRaw(audit, transaction)
+          break
+        case ChangeLogAction.MOVE: {
+          affectedAdvertCount = await this.revertMove(audit, transaction)
+          affectedAdvertIds = audit.affectedAdvertIds ?? null
+          break
+        }
+        default:
+          throw new BadRequestException(
+            `Cannot revert action ${audit.action}`,
+          )
+      }
+
+      await this.writeChangeLog(transaction, {
+        actor,
+        action: ChangeLogAction.REVERT,
+        entityType: audit.entityType,
+        entityId: audit.entityId,
+        before: audit.after,
+        after: audit.before,
+        affectedAdvertCount,
+        affectedAdvertIds,
+        revertsAuditId: audit.id,
+      })
+    })
+  }
+
+  private async revertCreate(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<void> {
+    if (!audit.entityId) return
+    const isCategory = audit.entityType === ChangeLogEntity.CATEGORY
+    const where = isCategory
+      ? { categoryId: audit.entityId }
+      : { typeId: audit.entityId }
+    const { affectedAdvertCount } = await this.advertImpact(where, transaction)
+    if (affectedAdvertCount > 0) {
+      throw new BadRequestException(
+        `Cannot undo creation: ${affectedAdvertCount} adverts now reference it.`,
+      )
+    }
+    await this.typeCategoriesModel.destroy({ where, transaction })
+    if (isCategory) {
+      await this.categoryModel
+        .unscoped()
+        .destroy({ where: { id: audit.entityId }, transaction })
+    } else {
+      await this.typeModel
+        .unscoped()
+        .destroy({ where: { id: audit.entityId }, transaction })
+    }
+  }
+
+  private async revertDelete(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<void> {
+    if (!audit.entityId) return
+    const isCategory = audit.entityType === ChangeLogEntity.CATEGORY
+    if (isCategory) {
+      await this.categoryModel
+        .unscoped()
+        .restore({ where: { id: audit.entityId }, transaction })
+    } else {
+      await this.typeModel
+        .unscoped()
+        .restore({ where: { id: audit.entityId }, transaction })
+    }
+    // Restore any join rows that were soft-deleted alongside it.
+    const where = isCategory
+      ? { categoryId: audit.entityId }
+      : { typeId: audit.entityId }
+    await this.typeCategoriesModel.restore({ where, transaction })
+  }
+
+  private applySnapshot(
+    entity: CategoryModel | TypeModel,
+    before: ChangeLogSnapshot,
+  ): void {
+    if (typeof before.title === 'string') entity.title = before.title
+    if (typeof before.slug === 'string') entity.slug = before.slug
+    if (typeof before.active === 'boolean') entity.active = before.active
+  }
+
+  private async restoreSnapshot(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<void> {
+    if (!audit.entityId || !audit.before) return
+    if (audit.entityType === ChangeLogEntity.CATEGORY) {
+      const entity = await this.categoryModel
+        .unscoped()
+        .findByPk(audit.entityId, { transaction })
+      if (!entity) {
+        throw new NotFoundException(`Category ${audit.entityId} not found`)
+      }
+      this.applySnapshot(entity, audit.before)
+      await entity.save({ transaction })
+    } else {
+      const entity = await this.typeModel
+        .unscoped()
+        .findByPk(audit.entityId, { transaction })
+      if (!entity) {
+        throw new NotFoundException(`Type ${audit.entityId} not found`)
+      }
+      this.applySnapshot(entity, audit.before)
+      await entity.save({ transaction })
+    }
+  }
+
+  private connectionFromSnapshot(
+    snapshot: ChangeLogSnapshot | null,
+  ): { typeId: string; categoryId: string } {
+    const typeId = snapshot?.typeId
+    const categoryId = snapshot?.categoryId
+    if (typeof typeId !== 'string' || typeof categoryId !== 'string') {
+      throw new BadRequestException('Malformed connection audit entry')
+    }
+    return { typeId, categoryId }
+  }
+
+  private async attachRaw(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<void> {
+    const { typeId, categoryId } = this.connectionFromSnapshot(audit.before)
+    await this.createConnection(typeId, categoryId, transaction)
+  }
+
+  private async detachRaw(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<void> {
+    const { typeId, categoryId } = this.connectionFromSnapshot(audit.after)
+    const existing = await this.typeCategoriesModel.findOne({
+      where: { typeId, categoryId },
+      transaction,
+    })
+    if (existing) await existing.destroy({ transaction })
+  }
+
+  private async revertMove(
+    audit: CategoryTypeChangeLogModel,
+    transaction: Transaction,
+  ): Promise<number> {
+    const before = audit.before
+    const adverts = (before?.adverts as MovedAdvert[] | undefined) ?? []
+    if (adverts.length === 0) return 0
+
+    // Group by original (typeId, categoryId) to minimise UPDATE statements.
+    const groups = new Map<string, string[]>()
+    for (const advert of adverts) {
+      const key = `${advert.typeId}|${advert.categoryId}`
+      const bucket = groups.get(key) ?? []
+      bucket.push(advert.id)
+      groups.set(key, bucket)
+    }
+    for (const [key, ids] of groups) {
+      const [typeId, categoryId] = key.split('|')
+      await this.advertModel.update(
+        { typeId, categoryId },
+        { where: { id: { [Op.in]: ids } }, transaction },
+      )
+    }
+    return adverts.length
+  }
+}

--- a/apps/legal-gazette-api/src/modules/category-type-admin/dto/category-type-admin.dto.ts
+++ b/apps/legal-gazette-api/src/modules/category-type-admin/dto/category-type-admin.dto.ts
@@ -1,0 +1,159 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator'
+
+import {
+  ApiBoolean,
+  ApiDtoArray,
+  ApiNumber,
+  ApiOptionalArray,
+  ApiOptionalEnum,
+  ApiOptionalNumber,
+  ApiOptionalString,
+  ApiOptionalUuid,
+  ApiString,
+  ApiUUId,
+} from '@dmr.is/decorators'
+
+import {
+  CategoryTypeChangeLogDto,
+  ChangeLogEntity,
+} from '../../../models/category-type-change-log.model'
+
+/** Who performed the action (resolved from the authenticated admin). */
+export interface CategoryTypeActor {
+  id: string
+  name: string | null
+}
+
+export class CreateCategoryBody {
+  @ApiString()
+  @IsString()
+  title!: string
+
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  slug?: string
+}
+
+export class UpdateCategoryBody {
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  title?: string
+
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  slug?: string
+}
+
+export class CreateTypeBody {
+  @ApiString()
+  @IsString()
+  title!: string
+
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  slug?: string
+
+  @ApiOptionalArray({ type: String })
+  @IsOptional()
+  @IsArray()
+  @IsUUID(undefined, { each: true })
+  categoryIds?: string[]
+}
+
+export class UpdateTypeBody {
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  title?: string
+
+  @ApiOptionalString()
+  @IsOptional()
+  @IsString()
+  slug?: string
+}
+
+export class SetActiveBody {
+  @ApiBoolean()
+  @IsBoolean()
+  active!: boolean
+}
+
+export class ConnectionBody {
+  @ApiUUId()
+  @IsUUID()
+  typeId!: string
+
+  @ApiUUId()
+  @IsUUID()
+  categoryId!: string
+}
+
+/**
+ * Re-points existing adverts. Adverts matching (fromTypeId [, fromCategoryId])
+ * get their type and/or category reassigned to the provided target(s).
+ */
+export class MoveAdvertsBody {
+  @ApiUUId()
+  @IsUUID()
+  fromTypeId!: string
+
+  @ApiOptionalUuid()
+  @IsOptional()
+  @IsUUID()
+  fromCategoryId?: string
+
+  @ApiOptionalUuid()
+  @IsOptional()
+  @IsUUID()
+  toTypeId?: string
+
+  @ApiOptionalUuid()
+  @IsOptional()
+  @IsUUID()
+  toCategoryId?: string
+}
+
+export class ImpactDto {
+  @ApiNumber()
+  affectedAdvertCount!: number
+
+  @ApiOptionalArray({ type: String })
+  sampleAdvertIds?: string[]
+}
+
+export class GetChangeLogDto {
+  @ApiDtoArray(CategoryTypeChangeLogDto)
+  entries!: CategoryTypeChangeLogDto[]
+
+  @ApiNumber()
+  total!: number
+}
+
+export class ChangeLogQuery {
+  @ApiOptionalEnum(ChangeLogEntity, { enumName: 'ChangeLogEntity' })
+  @IsOptional()
+  entityType?: ChangeLogEntity
+
+  @ApiOptionalUuid()
+  @IsOptional()
+  @IsUUID()
+  entityId?: string
+
+  @ApiOptionalNumber()
+  @IsOptional()
+  limit?: number
+
+  @ApiOptionalNumber()
+  @IsOptional()
+  offset?: number
+}

--- a/apps/legal-gazette-api/src/modules/swagger/internal-web.swagger.module.ts
+++ b/apps/legal-gazette-api/src/modules/swagger/internal-web.swagger.module.ts
@@ -15,6 +15,7 @@ import { CourtDistrictControllerModule } from '../base-entity/court-district/cou
 import { StatusControllerModule } from '../base-entity/status/status.controller.module'
 import { TypeControllerModule } from '../base-entity/type/type.controller.module'
 import { CaseControllerModule } from '../case/case.controller.module'
+import { CategoryTypeAdminControllerModule } from '../category-type-admin/category-type-admin.controller.module'
 import { CommentControllerModule } from '../comment/comment.controller.module'
 import { CommunicationChannelControllerModule } from '../communication-channel/communication-channel.module'
 import { FeeCodeModule } from '../fee-code/fee-code.controller.module'
@@ -49,6 +50,7 @@ import { UserControllerModule } from '../users/users.controller.module'
     LGNationalRegistryControllerModule,
     PaymentsControllerModule,
     AdvertPublishControllerModule,
+    CategoryTypeAdminControllerModule,
   ],
 })
 export class InternalWebSwaggerModule {}

--- a/apps/legal-gazette-web/clientConfig.json
+++ b/apps/legal-gazette-web/clientConfig.json
@@ -6295,6 +6295,1079 @@
         "summary": "",
         "tags": ["Legal gazette - internal API"]
       }
+    },
+    "/api/v1/category-type/categories": {
+      "post": {
+        "operationId": "createCategory",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateCategoryBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/categories/{id}": {
+      "put": {
+        "operationId": "updateCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateCategoryBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      },
+      "delete": {
+        "operationId": "deleteCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/categories/{id}/active": {
+      "put": {
+        "operationId": "setCategoryActive",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SetActiveBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CategoryDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/categories/{id}/impact": {
+      "get": {
+        "operationId": "getCategoryImpact",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImpactDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/types": {
+      "post": {
+        "operationId": "createType",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateTypeBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TypeDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/types/{id}": {
+      "put": {
+        "operationId": "updateType",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UpdateTypeBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TypeDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      },
+      "delete": {
+        "operationId": "deleteType",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/types/{id}/active": {
+      "put": {
+        "operationId": "setTypeActive",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SetActiveBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TypeDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/types/{id}/impact": {
+      "get": {
+        "operationId": "getTypeImpact",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImpactDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/connections": {
+      "post": {
+        "operationId": "attachTypeCategory",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ConnectionBody" }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/connections/detach": {
+      "post": {
+        "operationId": "detachTypeCategory",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ConnectionBody" }
+            }
+          }
+        },
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/moves/impact": {
+      "post": {
+        "operationId": "getMoveImpact",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MoveAdvertsBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImpactDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/moves": {
+      "post": {
+        "operationId": "moveAdverts",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MoveAdvertsBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ImpactDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/change-log": {
+      "get": {
+        "operationId": "getCategoryTypeChangeLog",
+        "parameters": [
+          {
+            "name": "entityType",
+            "required": false,
+            "in": "query",
+            "schema": { "$ref": "#/components/schemas/ChangeLogEntity" }
+          },
+          {
+            "name": "entityId",
+            "required": false,
+            "in": "query",
+            "schema": { "format": "uuid", "type": "string" }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "schema": { "type": "number" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GetChangeLogDto" }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
+    },
+    "/api/v1/category-type/change-log/{id}/revert": {
+      "post": {
+        "operationId": "revertCategoryTypeChange",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "204": { "description": "" },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - internal API"]
+      }
     }
   },
   "info": {
@@ -6412,6 +7485,10 @@
             ]
           },
           "message": { "type": "string" },
+          "translatedMessage": {
+            "type": "string",
+            "description": "User-facing, localized message safe to display directly in the client. Absent when the error has no curated translation."
+          },
           "details": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["statusCode", "timestamp"]
@@ -6646,7 +7723,7 @@
           "partnerNationalId": {
             "type": "string",
             "nullable": true,
-            "maxLength": 255
+            "maxLength": 10
           },
           "partnerName": {
             "type": "string",
@@ -7206,7 +8283,7 @@
             "format": "date-time",
             "example": "2026-02-19T10:30:00.000Z"
           },
-          "partnerNationalId": { "type": "string", "maxLength": 255 },
+          "partnerNationalId": { "type": "string", "maxLength": 10 },
           "partnerName": { "type": "string", "maxLength": 255 },
           "partnerDateOfDeath": {
             "type": "string",
@@ -7858,7 +8935,7 @@
           "partnerNationalId": {
             "type": "string",
             "nullable": true,
-            "maxLength": 255
+            "maxLength": 10
           },
           "partnerName": {
             "type": "string",
@@ -8195,6 +9272,129 @@
           "advertIds": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["advertIds"]
+      },
+      "CreateCategoryBody": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": "string" }
+        },
+        "required": ["title"]
+      },
+      "UpdateCategoryBody": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": "string" }
+        }
+      },
+      "SetActiveBody": {
+        "type": "object",
+        "properties": { "active": { "type": "boolean" } },
+        "required": ["active"]
+      },
+      "ImpactDto": {
+        "type": "object",
+        "properties": {
+          "affectedAdvertCount": { "type": "number" },
+          "sampleAdvertIds": { "type": "string" }
+        },
+        "required": ["affectedAdvertCount"]
+      },
+      "CreateTypeBody": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": "string" },
+          "categoryIds": { "type": "string" }
+        },
+        "required": ["title"]
+      },
+      "UpdateTypeBody": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "slug": { "type": "string" }
+        }
+      },
+      "ConnectionBody": {
+        "type": "object",
+        "properties": {
+          "typeId": { "type": "string", "format": "uuid" },
+          "categoryId": { "type": "string", "format": "uuid" }
+        },
+        "required": ["typeId", "categoryId"]
+      },
+      "MoveAdvertsBody": {
+        "type": "object",
+        "properties": {
+          "fromTypeId": { "type": "string", "format": "uuid" },
+          "fromCategoryId": { "type": "string", "format": "uuid" },
+          "toTypeId": { "type": "string", "format": "uuid" },
+          "toCategoryId": { "type": "string", "format": "uuid" }
+        },
+        "required": ["fromTypeId"]
+      },
+      "ChangeLogEntity": {
+        "type": "string",
+        "enum": ["CATEGORY", "TYPE", "CONNECTION"]
+      },
+      "ChangeLogAction": {
+        "type": "string",
+        "enum": [
+          "CREATE",
+          "UPDATE",
+          "DELETE",
+          "ATTACH",
+          "DETACH",
+          "SET_ACTIVE",
+          "MOVE",
+          "REVERT"
+        ]
+      },
+      "CategoryTypeChangeLogDto": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "actorId": { "type": "string" },
+          "actorName": { "type": "string" },
+          "action": {
+            "allOf": [{ "$ref": "#/components/schemas/ChangeLogAction" }]
+          },
+          "entityType": {
+            "allOf": [{ "$ref": "#/components/schemas/ChangeLogEntity" }]
+          },
+          "entityId": { "type": "string", "format": "uuid" },
+          "before": { "type": "object", "additionalProperties": true },
+          "after": { "type": "object", "additionalProperties": true },
+          "affectedAdvertCount": { "type": "number" },
+          "affectedAdvertIds": { "type": "string" },
+          "revertsAuditId": { "type": "string", "format": "uuid" },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-02-19T10:30:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "actorId",
+          "action",
+          "entityType",
+          "affectedAdvertCount",
+          "createdAt"
+        ]
+      },
+      "GetChangeLogDto": {
+        "type": "object",
+        "properties": {
+          "entries": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CategoryTypeChangeLogDto" }
+          },
+          "total": { "type": "number" }
+        },
+        "required": ["entries", "total"]
       },
       "BaseEntityDto": {
         "type": "object",


### PR DESCRIPTION
New admin category and type service logic allowing admins to update the entities. As well as storing in audit log to allow for undo's if something goes wrong. Adding active flag on both entities to allow admins to show/hide.