### PR TITLE
fix(ojoi): Opensearch clamp pagination to prevent exceeding max result window

### DIFF
--- a/apps/official-journal-api/src/util/OpenSearch.ts
+++ b/apps/official-journal-api/src/util/OpenSearch.ts
@@ -146,7 +146,11 @@ export const getOsBody = (
   const q = qp?.search?.trim() ?? ''
 
   const pageSize = Math.min(Math.max(1, qp?.pageSize ?? 20), 100)
-  const page = Math.max(1, Number(qp?.page ?? 1))
+  // OpenSearch rejects from + size > index.max_result_window (default 10000).
+  // Clamp page so deep pagination degrades gracefully instead of throwing.
+  const MAX_RESULT_WINDOW = 10000
+  const maxPage = Math.max(1, Math.floor(MAX_RESULT_WINDOW / pageSize))
+  const page = Math.min(Math.max(1, Number(qp?.page ?? 1)), maxPage)
   const from = (page - 1) * pageSize
   const size = pageSize
 


### PR DESCRIPTION
# What

Clamp the `page` value in `getOsBody` (`apps/official-journal-api/src/util/OpenSearch.ts`) so `from + size` can never exceed OpenSearch's result window (10000).

```ts
  const pageSize = Math.min(Math.max(1, qp?.pageSize ?? 20), 100)
  const MAX_RESULT_WINDOW = 10000
  const maxPage = Math.max(1, Math.floor(MAX_RESULT_WINDOW / pageSize))
  const page = Math.min(Math.max(1, Number(qp?.page ?? 1)), maxPage)
  const from = (page - 1) * pageSize
  const size = pageSize
```


Deep-pagination requests now degrade gracefully to the last valid window instead of throwing.

# Why

Production was throwing a 500 on Official Journal search:

search_phase_execution_exception: [illegal_argument_exception]
Reason: Result window is too large, from + size must be less than or equal to: [10000] but was [10100].

OpenSearch enforces from + size <= index.max_result_window (default 10000). pageSize was clamped to max 100, but page had no upper bound, so pageSize=100, page=101
produced from + size = 10100 — matching the log exactly. User/crawler-triggerable on GET /adverts-lean.