### PR TITLE
fix(lg): Require skiptalok advert content and rename label

### DIFF
--- a/apps/legal-gazette-application-web/src/components/adverts/CreateDivisionEnding.tsx
+++ b/apps/legal-gazette-application-web/src/components/adverts/CreateDivisionEnding.tsx
@@ -202,12 +202,32 @@ export const CreateDivisionEnding = ({ applicationId }: Props) => {
             }}
           />
         </FormGroup>
-        <FormGroup title="Efni auglýsingar">
+        <FormGroup
+          title={
+            <>
+              Hvernig var skiptum lokið{' '}
+              <Text fontWeight="regular" color="red600" as="span">
+                *
+              </Text>
+            </>
+          }
+        >
           <FormElement
             width="full"
             type="editor"
             withZIndex={false}
-            onChange={(val) => handleSetState('content', val || undefined)}
+            error={errors?.properties?.content?.errors[0]}
+            onChange={(val) => {
+              handleSetState('content', val || undefined)
+              setErrors((prev) =>
+                prev?.properties
+                  ? {
+                      ...prev,
+                      properties: { ...prev.properties, content: undefined },
+                    }
+                  : prev,
+              )
+            }}
           />
         </FormGroup>
         <FormGroup title="Lýstar kröfur búsins">

--- a/apps/legal-gazette-application-web/src/components/form-group/FormGroup.tsx
+++ b/apps/legal-gazette-application-web/src/components/form-group/FormGroup.tsx
@@ -3,7 +3,7 @@ import { GridRow } from '@dmr.is/ui/components/island-is/GridRow'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
 
 type Props = {
-  title?: string
+  title?: string | React.ReactNode
   subTitle?: string | React.ReactNode
   children?: React.ReactNode
   error?: string

--- a/libs/legal-gazette/schemas/src/lib/inputs/division-meetings.ts
+++ b/libs/legal-gazette/schemas/src/lib/inputs/division-meetings.ts
@@ -22,7 +22,11 @@ export const createDivisionEndingInput = z.object({
   scheduledAt: z.coerce.date({
     error: 'Dagsetning birtingar er nauðsynleg',
   }),
-  content: z.string().optional(),
+  content: z
+    .string('Nauðsynlegt er að fylla út hvernig skiptum var lokið')
+    .refine((content) => content.length > 0, {
+      message: 'Nauðsynlegt er að fylla út hvernig skiptum var lokið',
+    }),
   additionalText: z.string().optional(),
   signature: signatureSchemaRefined,
 })


### PR DESCRIPTION
The advert body field in the "Bæta við skiptalokum" form was optional and its validation error was never surfaced, so a skiptalok advert could be sent to publication with no body text.

- Make `content` required and non-empty in `createDivisionEndingInput`, which also tightens the `addDivisionEnding` tRPC input.
- Rename the field label from "Efni auglýsingar" to "Hvernig var skiptum lokið" and mark it required with the red asterisk used elsewhere in the form.
- Wire the validation error into the editor and clear it on change, matching the pattern the other fields in the form already use.
- Widen `FormGroup.title` to accept a ReactNode so the asterisk can be rendered inline with the title.

Skiptafundur (`CreateDivisionMeeting`) is intentionally left unchanged.