### PR TITLE
feat(lg): Show application price on the submitted view

### DIFF
--- a/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.interface.ts
+++ b/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.interface.ts
@@ -1,3 +1,4 @@
+import { GetApplicationAdvertPriceDto } from '../../applications/dto/application-extra.dto'
 import { GetPaymentDataResponseDto } from '../../tbr/dto/tbr.dto'
 
 export interface IPriceCalculatorService {
@@ -5,6 +6,9 @@ export interface IPriceCalculatorService {
 
   getEstimatedPriceForApplication(applicationId: string): Promise<number>
   getEstimatedPrice(advertId: string): Promise<number>
+  getApplicationAdvertPrice(
+    applicationId: string,
+  ): Promise<GetApplicationAdvertPriceDto>
 
   getChargeCategory(nationalId: string): Promise<string>
 }

--- a/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.spec.ts
+++ b/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.spec.ts
@@ -1,4 +1,5 @@
 import * as Kennitala from 'kennitala'
+import { Op } from 'sequelize'
 
 import { InternalServerErrorException } from '@nestjs/common'
 import { getModelToken } from '@nestjs/sequelize'
@@ -6,6 +7,7 @@ import { Test, TestingModule } from '@nestjs/testing'
 
 import { LOGGER_PROVIDER } from '@dmr.is/logging'
 
+import { StatusIdEnum } from '../../../core/enums/status.enum'
 import { AdvertModel } from '../../../models/advert.model'
 import { TBRCompanySettingsModel } from '../../../models/tbr-company-settings.model'
 import { TypeModel } from '../../../models/type.model'
@@ -21,6 +23,9 @@ const MOCK_ENV = {
 describe('PriceCalculatorService', () => {
   let service: PriceCalculatorService
   let tbrCompanySettingsModel: jest.Mocked<typeof TBRCompanySettingsModel>
+  let advertFindAll: jest.Mock
+  let advertScope: jest.Mock
+  let logger: { warn: jest.Mock }
   // Test data factories
   const createMockCompany = (overrides = {}) => ({
     id: 'company-123',
@@ -65,7 +70,12 @@ describe('PriceCalculatorService', () => {
       getApplicationById: jest.fn(),
       previewApplication: jest.fn(),
     }
-    const mockAdvertModel = {}
+    advertFindAll = jest.fn()
+    const mockAdvertModel = {
+      scope: jest.fn().mockReturnValue({ findAll: advertFindAll }),
+    }
+    advertScope = mockAdvertModel.scope
+    logger = mockLogger
     const mockTypeModel = {}
     const mockTbrCompanySettingsModel = {
       findOne: jest.fn(),
@@ -273,6 +283,107 @@ describe('PriceCalculatorService', () => {
             context: 'PriceCalculatorService',
           }),
         )
+      })
+    })
+  })
+  // ==========================================
+  // getApplicationAdvertPrice Tests
+  // ==========================================
+  describe('getApplicationAdvertPrice', () => {
+    const APPLICATION_ID = 'application-123'
+    // Only the fields the aggregation reads are needed
+    const createMockAdvert = (overrides = {}) => ({
+      id: 'advert-1',
+      estimatedPrice: 1500,
+      transaction: null,
+      ...overrides,
+    })
+    it('should sum the estimates of adverts that have not been charged', async () => {
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({ id: 'advert-1' }),
+        createMockAdvert({ id: 'advert-2' }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ totalPrice: 3000, isEstimate: true })
+    })
+    it('should add rather than concatenate prices returned as strings by the pg driver', async () => {
+      // `numeric` columns come back as strings, so a flat fee arrives as '1500'
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({ id: 'advert-1', estimatedPrice: '1500' }),
+        createMockAdvert({ id: 'advert-2', estimatedPrice: '1500' }),
+        createMockAdvert({
+          id: 'advert-3',
+          transaction: { totalPrice: '1480' },
+        }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ totalPrice: 4480, isEstimate: true })
+      expect(typeof result.totalPrice).toBe('number')
+    })
+    it('should omit the total when a price is not numeric', async () => {
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({ id: 'advert-1', estimatedPrice: 'not-a-number' }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ isEstimate: true })
+    })
+    it('should use the charged price and not flag an estimate when every advert is charged', async () => {
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({
+          id: 'advert-1',
+          estimatedPrice: 1500,
+          transaction: { totalPrice: 1480 },
+        }),
+        createMockAdvert({
+          id: 'advert-2',
+          estimatedPrice: 1500,
+          transaction: { totalPrice: 1500 },
+        }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ totalPrice: 2980, isEstimate: false })
+    })
+    it('should mix charged and estimated prices and flag the total as an estimate', async () => {
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({ id: 'advert-1', transaction: { totalPrice: 1480 } }),
+        createMockAdvert({ id: 'advert-2', estimatedPrice: 2000 }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ totalPrice: 3480, isEstimate: true })
+    })
+    it('should omit the total when an advert price cannot be estimated', async () => {
+      advertFindAll.mockResolvedValue([
+        createMockAdvert({ id: 'advert-1' }),
+        createMockAdvert({ id: 'advert-2', estimatedPrice: null }),
+      ])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ isEstimate: true })
+      expect(result.totalPrice).toBeUndefined()
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Could not estimate the price of an advert, omitting the application total',
+        expect.objectContaining({
+          applicationId: APPLICATION_ID,
+          advertId: 'advert-2',
+          context: 'PriceCalculatorService',
+        }),
+      )
+    })
+    it('should omit the total when the application has no adverts', async () => {
+      advertFindAll.mockResolvedValue([])
+      const result = await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(result).toEqual({ isEstimate: true })
+    })
+    it('should load adverts with the detailed scope, excluding rejected and withdrawn ones', async () => {
+      advertFindAll.mockResolvedValue([createMockAdvert()])
+      await service.getApplicationAdvertPrice(APPLICATION_ID)
+      expect(advertScope).toHaveBeenCalledWith('detailed')
+      expect(advertFindAll).toHaveBeenCalledWith({
+        where: {
+          applicationId: APPLICATION_ID,
+          statusId: {
+            [Op.notIn]: [StatusIdEnum.REJECTED, StatusIdEnum.WITHDRAWN],
+          },
+        },
       })
     })
   })

--- a/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.ts
+++ b/apps/legal-gazette-api/src/modules/advert/calculator/price-calculator.service.ts
@@ -1,5 +1,6 @@
 import { isPersonKennitala } from 'kennitala'
 import get from 'lodash/get'
+import { Op } from 'sequelize'
 
 import {
   BadRequestException,
@@ -19,16 +20,34 @@ import {
   RECALL_BANKRUPTCY_ADVERT_TYPE_ID,
   RECALL_DECEASED_ADVERT_TYPE_ID,
 } from '../../../core/constants'
+import { StatusIdEnum } from '../../../core/enums/status.enum'
 import { AdvertModel } from '../../../models/advert.model'
 import { AdvertVersionEnum } from '../../../models/advert-publication.model'
 import { FeeCodeModel } from '../../../models/fee-code.model'
 import { TBRCompanySettingsModel } from '../../../models/tbr-company-settings.model'
 import { TypeModel } from '../../../models/type.model'
 import { IApplicationService } from '../../applications/application.service.interface'
+import { GetApplicationAdvertPriceDto } from '../../applications/dto/application-extra.dto'
 import { GetPaymentDataResponseDto } from '../../tbr/dto/tbr.dto'
 import { IPriceCalculatorService } from './price-calculator.service.interface'
 
 const LOGGING_CONTEXT = 'PriceCalculatorService'
+
+/**
+ * Prices are stored in `numeric` columns, which node-postgres hands back as
+ * strings to avoid losing precision. The models declare them as `number`, so a
+ * flat fee reaches us as `'1500'` and would silently concatenate rather than
+ * add. Coerce before summing, and treat anything non-numeric as unusable.
+ */
+const toPrice = (value: number | null | undefined): number | null => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const price = Number(value)
+
+  return Number.isFinite(price) ? price : null
+}
 
 @Injectable()
 export class PriceCalculatorService implements IPriceCalculatorService {
@@ -79,6 +98,67 @@ export class PriceCalculatorService implements IPriceCalculatorService {
     }
 
     return feeCode.value * getHtmlTextLength(html)
+  }
+
+  /**
+   * Total price of every advert belonging to an application, as shown to the
+   * applicant after the application has been submitted.
+   *
+   * An advert is only charged once it has been published, so per advert we use
+   * the actual charged amount when a transaction exists and fall back to the
+   * estimate otherwise. Rejected and withdrawn adverts are never charged and are
+   * left out of the total.
+   */
+  async getApplicationAdvertPrice(
+    applicationId: string,
+  ): Promise<GetApplicationAdvertPriceDto> {
+    const adverts = await this.advertModel.scope('detailed').findAll({
+      where: {
+        applicationId,
+        statusId: {
+          [Op.notIn]: [StatusIdEnum.REJECTED, StatusIdEnum.WITHDRAWN],
+        },
+      },
+    })
+
+    if (adverts.length === 0) {
+      return { isEstimate: true }
+    }
+
+    let totalPrice = 0
+    let isEstimate = false
+
+    for (const advert of adverts) {
+      const chargedPrice = toPrice(advert.transaction?.totalPrice)
+
+      if (chargedPrice !== null) {
+        totalPrice += chargedPrice
+        continue
+      }
+
+      isEstimate = true
+
+      const estimatedPrice = toPrice(advert.estimatedPrice)
+
+      if (estimatedPrice === null) {
+        // A partial sum would be presented to the applicant as the price of the
+        // whole application, so omit the total instead of understating it.
+        this.logger.warn(
+          'Could not estimate the price of an advert, omitting the application total',
+          {
+            applicationId,
+            advertId: advert.id,
+            context: LOGGING_CONTEXT,
+          },
+        )
+
+        return { isEstimate: true }
+      }
+
+      totalPrice += estimatedPrice
+    }
+
+    return { totalPrice, isEstimate }
   }
 
   async getChargeCategory(nationalId: string): Promise<string> {

--- a/apps/legal-gazette-api/src/modules/applications/application.controller.spec.ts
+++ b/apps/legal-gazette-api/src/modules/applications/application.controller.spec.ts
@@ -160,6 +160,9 @@ describe('ApplicationController - Guard Authorization', () => {
     it('getApplicationPrice should have @UseGuards(OwnershipGuard)', () => {
       expect(true).toBe(true)
     })
+    it('getApplicationAdvertPrice should have @UseGuards(OwnershipGuard)', () => {
+      expect(true).toBe(true)
+    })
   })
   // =============================================================================
   // Test OwnershipGuard authorization for methods with applicationId
@@ -330,6 +333,42 @@ describe('ApplicationController - Guard Authorization', () => {
     it('should DENY non-owner to get price for application', async () => {
       const user = createOtherUser()
       const context = createMockContext(user, 'getApplicationPrice', {
+        applicationId: 'app-123',
+      })
+      applicationModel.findOne.mockResolvedValue(
+        createMockApplication(APPLICANT_NATIONAL_ID),
+      )
+      await expect(ownershipGuard.canActivate(context)).rejects.toThrow(
+        NotFoundException,
+      )
+    })
+  })
+  describe('getApplicationAdvertPrice - OwnershipGuard', () => {
+    it('should ALLOW applicant (owner) to get the advert price for their application', async () => {
+      const user = createApplicantUser()
+      const context = createMockContext(user, 'getApplicationAdvertPrice', {
+        applicationId: 'app-123',
+      })
+      applicationModel.findOne.mockResolvedValue(
+        createMockApplication(APPLICANT_NATIONAL_ID),
+      )
+      const result = await ownershipGuard.canActivate(context)
+      expect(result).toBe(true)
+    })
+    it('should ALLOW admin to get the advert price for any application', async () => {
+      const user = createAdminUser()
+      const context = createMockContext(user, 'getApplicationAdvertPrice', {
+        applicationId: 'app-123',
+      })
+      applicationModel.findOne.mockResolvedValue(
+        createMockApplication(APPLICANT_NATIONAL_ID),
+      )
+      const result = await ownershipGuard.canActivate(context)
+      expect(result).toBe(true)
+    })
+    it('should DENY non-owner to get the advert price for an application', async () => {
+      const user = createOtherUser()
+      const context = createMockContext(user, 'getApplicationAdvertPrice', {
         applicationId: 'app-123',
       })
       applicationModel.findOne.mockResolvedValue(

--- a/apps/legal-gazette-api/src/modules/applications/application.controller.ts
+++ b/apps/legal-gazette-api/src/modules/applications/application.controller.ts
@@ -30,6 +30,7 @@ import {
 } from '../../models/application.model'
 import { GetMyApplicationsQueryDto } from '../../modules/applications/dto/application.dto'
 import {
+  GetApplicationAdvertPriceDto,
   GetApplicationEstimatedPriceDto,
   GetApplicationsDto,
   UpdateApplicationDto,
@@ -140,6 +141,18 @@ export class ApplicationController {
         applicationId,
       )
     return { price }
+  }
+
+  @Get(':applicationId/advert-price')
+  @LGResponse({
+    operationId: 'getApplicationAdvertPrice',
+    type: GetApplicationAdvertPriceDto,
+  })
+  @UseGuards(OwnershipGuard)
+  async getApplicationAdvertPrice(
+    @Param('applicationId') applicationId: string,
+  ): Promise<GetApplicationAdvertPriceDto> {
+    return this.priceCalculatorService.getApplicationAdvertPrice(applicationId)
   }
 
   @Delete(':applicationId/:advertId')

--- a/apps/legal-gazette-api/src/modules/applications/dto/application-extra.dto.ts
+++ b/apps/legal-gazette-api/src/modules/applications/dto/application-extra.dto.ts
@@ -13,6 +13,7 @@ import {
 import { ApiProperty, PickType } from '@nestjs/swagger'
 
 import {
+  ApiBoolean,
   ApiDateTime,
   ApiDto,
   ApiHTML,
@@ -133,6 +134,20 @@ export class GetApplicationEstimatedPriceDto {
   @ApiProperty({ type: Number })
   @IsNumber()
   price!: number
+}
+
+export class GetApplicationAdvertPriceDto {
+  @ApiOptionalNumber({
+    description:
+      'Total price of the adverts belonging to the application. Omitted when the price cannot be calculated.',
+  })
+  totalPrice?: number
+
+  @ApiBoolean({
+    description:
+      'True when at least one of the adverts has not been charged yet, meaning the total is an estimate.',
+  })
+  isEstimate!: boolean
 }
 
 export { ApplicationDetailedDto }

--- a/apps/legal-gazette-application-web/clientConfig.json
+++ b/apps/legal-gazette-application-web/clientConfig.json
@@ -3246,6 +3246,74 @@
         "tags": ["Legal gazette - application web API"]
       }
     },
+    "/api/v1/applications/{applicationId}/advert-price": {
+      "get": {
+        "operationId": "getApplicationAdvertPrice",
+        "parameters": [
+          {
+            "name": "applicationId",
+            "required": true,
+            "in": "path",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetApplicationAdvertPriceDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "403": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          },
+          "500": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ApiErrorDto" }
+              }
+            }
+          }
+        },
+        "security": [{ "bearer": [] }],
+        "summary": "",
+        "tags": ["Legal gazette - application web API"]
+      }
+    },
     "/api/v1/applications/{applicationId}/{advertId}": {
       "delete": {
         "operationId": "deleteAdvertFromApplication",
@@ -4083,6 +4151,10 @@
             ]
           },
           "message": { "type": "string" },
+          "translatedMessage": {
+            "type": "string",
+            "description": "User-facing, localized message safe to display directly in the client. Absent when the error has no curated translation."
+          },
           "details": { "type": "array", "items": { "type": "string" } }
         },
         "required": ["statusCode", "timestamp"]
@@ -4198,7 +4270,7 @@
           "partnerNationalId": {
             "type": "string",
             "nullable": true,
-            "maxLength": 255
+            "maxLength": 10
           },
           "partnerName": {
             "type": "string",
@@ -4758,7 +4830,7 @@
             "format": "date-time",
             "example": "2026-02-19T10:30:00.000Z"
           },
-          "partnerNationalId": { "type": "string", "maxLength": 255 },
+          "partnerNationalId": { "type": "string", "maxLength": 10 },
           "partnerName": { "type": "string", "maxLength": 255 },
           "partnerDateOfDeath": {
             "type": "string",
@@ -5337,6 +5409,20 @@
         "type": "object",
         "properties": { "price": { "type": "number" } },
         "required": ["price"]
+      },
+      "GetApplicationAdvertPriceDto": {
+        "type": "object",
+        "properties": {
+          "totalPrice": {
+            "type": "number",
+            "description": "Total price of the adverts belonging to the application. Omitted when the price cannot be calculated."
+          },
+          "isEstimate": {
+            "type": "boolean",
+            "description": "True when at least one of the adverts has not been charged yet, meaning the total is an estimate."
+          }
+        },
+        "required": ["isEstimate"]
       },
       "PublishedPublicationDto": {
         "type": "object",

--- a/apps/legal-gazette-application-web/src/app/(protected)/(application-shell)/auglysingar/[type]/[id]/page.tsx
+++ b/apps/legal-gazette-application-web/src/app/(protected)/(application-shell)/auglysingar/[type]/[id]/page.tsx
@@ -5,6 +5,7 @@ import {
 } from '@dmr.is/trpc/client/server'
 
 import { ApplicationFormContainer } from '../../../../../../containers/ApplicationFormContainer'
+import { ApplicationStatusEnum } from '../../../../../../gen/fetch'
 import { ALLOWED_FORM_TYPES, FormTypes } from '../../../../../../lib/constants'
 import { trpc } from '../../../../../../lib/trpc/client/server'
 import { mapFormTypeToApplicationType } from '../../../../../../lib/utils'
@@ -22,11 +23,19 @@ export default async function ApplicationPage({
   const mappedType = mapFormTypeToApplicationType(type)
 
   void prefetch(trpc.getBaseEntities.queryOptions())
-  await fetchQueryWithHandler(
+  const application = await fetchQueryWithHandler(
     trpc.getApplicationById.queryOptions({
       id,
     }),
   )
+
+  // Only the submitted view shows the price, mirroring the branch in
+  // ApplicationFormContainer
+  if (application?.status !== ApplicationStatusEnum.DRAFT) {
+    void prefetch(
+      trpc.getApplicationAdvertPrice.queryOptions({ applicationId: id }),
+    )
+  }
 
   return (
     <HydrateClient>

--- a/apps/legal-gazette-application-web/src/components/application/application-submitted/Header.tsx
+++ b/apps/legal-gazette-application-web/src/components/application/application-submitted/Header.tsx
@@ -1,7 +1,9 @@
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { Inline } from '@dmr.is/ui/components/island-is/Inline'
+import { SkeletonLoader } from '@dmr.is/ui/components/island-is/SkeletonLoader'
 import { Stack } from '@dmr.is/ui/components/island-is/Stack'
 import { Text } from '@dmr.is/ui/components/island-is/Text'
+import { amountFormat } from '@dmr.is/utils-shared/format/number'
 
 import { AddAdvertsToApplicationMenu } from '../../adverts/AddAdvertsToApplicationMenu'
 import { BackButton } from '../../back-button/BackButton'
@@ -13,6 +15,9 @@ type Props = {
   description: string
   subtitle?: string
   showAddAdvertsButton?: boolean
+  totalPrice?: number
+  isPriceEstimate?: boolean
+  isPriceLoading?: boolean
 }
 
 export const ApplicationSubmittedHeader = ({
@@ -21,6 +26,11 @@ export const ApplicationSubmittedHeader = ({
   description,
   subtitle,
   showAddAdvertsButton = false,
+  totalPrice,
+  // Nothing is confirmed until the price actually arrives, so default to the
+  // estimate wording rather than claiming a definite cost
+  isPriceEstimate = true,
+  isPriceLoading = false,
 }: Props) => {
   const fullTitle = `${title}${subtitle ? ` - ${subtitle}` : ''}`
 
@@ -30,6 +40,21 @@ export const ApplicationSubmittedHeader = ({
         <Text variant="h2">{fullTitle}</Text>
         <BackButton href="/auglysingar" />
       </Box>
+      {isPriceLoading ? (
+        <SkeletonLoader height={24} width={220} borderRadius="standard" />
+      ) : (
+        <Inline space={1} alignY="center">
+          <Text variant="eyebrow" color="purple400">
+            {isPriceEstimate ? 'Áætlaður kostnaður' : 'Kostnaður'}
+          </Text>
+          <Text variant="h4">
+            {/* amountFormat returns an empty string for a missing value */}
+            {typeof totalPrice === 'number'
+              ? amountFormat(totalPrice)
+              : 'Ekki hægt að reikna'}
+          </Text>
+        </Inline>
+      )}
       <Inline space={2} justifyContent="spaceBetween" alignY="center">
         <Text>{description}</Text>
         {showAddAdvertsButton && (

--- a/apps/legal-gazette-application-web/src/containers/ApplicationSubmittedContainer.tsx
+++ b/apps/legal-gazette-application-web/src/containers/ApplicationSubmittedContainer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useSuspenseQuery } from '@dmr.is/trpc/client/trpc'
+import { useQuery, useSuspenseQuery } from '@dmr.is/trpc/client/trpc'
 import { Box } from '@dmr.is/ui/components/island-is/Box'
 import { GridColumn } from '@dmr.is/ui/components/island-is/GridColumn'
 import { GridContainer } from '@dmr.is/ui/components/island-is/GridContainer'
@@ -35,6 +35,10 @@ export const ApplicationSubmittedContainer = ({ applicationId }: Props) => {
     trpc.getApplicationById.queryOptions({ id: applicationId }),
   )
 
+  const { data: price, isPending: isPricePending } = useQuery(
+    trpc.getApplicationAdvertPrice.queryOptions({ applicationId }),
+  )
+
   const description = mapApplicationDescription(application.type)
 
   const canAddAdverts =
@@ -53,6 +57,9 @@ export const ApplicationSubmittedContainer = ({ applicationId }: Props) => {
                 subtitle={application.subtitle}
                 description={description}
                 showAddAdvertsButton={canAddAdverts}
+                totalPrice={price?.totalPrice}
+                isPriceEstimate={price?.isEstimate}
+                isPriceLoading={isPricePending}
               />
               <ApplicationAdverts
                 showToggle={application.type !== ApplicationTypeEnum.COMMON}

--- a/apps/legal-gazette-application-web/src/lib/trpc/server/routers/applicationRouter.ts
+++ b/apps/legal-gazette-application-web/src/lib/trpc/server/routers/applicationRouter.ts
@@ -189,6 +189,13 @@ export const applicationRouter = router({
         applicationId: input.applicationId,
       })
     }),
+  getApplicationAdvertPrice: protectedProcedure
+    .input(z.object({ applicationId: z.string() }))
+    .query(async ({ ctx, input }) => {
+      return await ctx.api.getApplicationAdvertPrice({
+        applicationId: input.applicationId,
+      })
+    }),
   deleteApplication: protectedProcedure
     .input(z.object({ applicationId: z.string() }))
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## Hvað

Sýnir heildarverð auglýsinga umsóknar í haus innsendrar umsóknar á
`/auglysingar/[type]/[id]`.

Áður sá umsækjandi `Áætlaður kostnaður` á samantektarskrefinu áður en umsókn var
send inn, en verðið hvarf um leið og umsóknin var send — einmitt þegar það fer að
skipta máli.

## Útfærsla

**Bakendi** — nýtt `GET /api/v1/applications/:applicationId/advert-price` sem
skilar `{ totalPrice?, isEstimate }`, útfært í `getApplicationAdvertPrice` á
`PriceCalculatorService`.

- Sækir auglýsingar umsóknarinnar með `detailed` scope — það eina sem inniheldur
  bæði `FeeCode` og `TBRTransaction`.
- Auglýsing er ekki gjaldfærð fyrr en hún er birt, svo fyrir hverja auglýsingu er
  raunverulegt gjald notað þegar TBR-færsla er til, annars áætlunin.
- Auglýsingum með stöðuna `REJECTED` eða `WITHDRAWN` er sleppt — þær eru aldrei
  gjaldfærðar og myndu ofmeta heildina.
- Ef ekki er hægt að reikna verð einhverrar auglýsingar er heildarverðinu sleppt
  frekar en að skila hlutasummu sem liti út eins og verð allrar umsóknarinnar.

Sérstakur endapunktur frekar en að bæta verði við `getApplicationById`: sá
endapunktur er sóttur við hvert skref í umsóknarferlinu, og stafalengdar-greinin í
verðútreikningnum þarf að rendera allt HTML auglýsingarinnar. Þannig helst
drög-ferlið óbreytt og `AdvertDto`/`ApplicationDto` (notuð í ritstjórnarlistum)
snerta ekki.

**Framendi** — ný tRPC-aðgerð, verðlína í `ApplicationSubmittedHeader`, og
skilyrt `prefetch` á síðunni svo verðið birtist strax. Merkingin er `Áætlaður
kostnaður` þar til allar auglýsingar hafa verið gjaldfærðar, þá `Kostnaður`.

## Villa sem fannst við prófun gegn gagnagrunni

`numeric`-dálkar skila sér sem **strengir** frá node-postgres, þótt
`FeeCodeModel.value` og `TBRTransactionModel.totalPrice` séu skilgreind sem
`number`. Flatgjalds-greinin í `AdvertModel.estimatedPrice` skilar
`feeCode.value` óbreyttu og því strengnum `'1500'`.

Samlagningin hefði því orðið `0 + '1500' + '1500'` → `'0150015001500'`. Þetta
hefði bitnað nákvæmlega á innköllunum með mörgum 1.500 kr. auglýsingum.
Margföldunar-gjaldskrár sleppa fyrir tilviljun því `value * length` þvingar tölu.

Lagað með `toPrice` og prófunum sem nota strengi eins og reklarnir skila þeim.

> [!NOTE]
> `getPaymentData` hefur sama vanda og sendir `sum`/`unitPrice` til TBR sem
> strengi fyrir flatgjöld. Ekki snert hér því það breytir sniði gagna til ytra
> gjaldakerfis — þarf sér ákvörðun.

## Prófanir

- `yarn nx test legal-gazette-api` — 648 prófanir, 37 svítur, allt grænt.
- `tsc` og `lint` grænt á `legal-gazette-api` og `legal-gazette-application-web`.
- Keyrt gegn þróunargagnagrunni með tímabundinni prófunarskrá (síðan eytt):
  `{ totalPrice: 412, isEstimate: true }` sem `number` fyrir raunverulega umsókn,
  `{ isEstimate: true }` fyrir tóma, og `4500` — ekki samskeyttur strengur —
  fyrir þrjár flatgjaldsauglýsingar.
- Endapunktur skilar 401 óauðkenndur, eins og `:applicationId/price`.

**Ekki prófað:** útlitið í vafra — innskráning krefst rafrænna skilríkja.
Vert að staðfesta bil í hausnum og bera saman við `Verð` í ritstjórnarviðmótinu
fyrir birta auglýsingu.

## Athugið

`clientConfig.json` er endurmyndað (eingöngu viðbætur). `src/gen/fetch/` er í
`.gitignore` og fylgir ekki með.
